### PR TITLE
JUnit 5 assertNull / assertNotNull conversions to assertJ

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNotNullToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNotNullToAssertThat.java
@@ -41,15 +41,15 @@ import static org.openrewrite.java.tree.MethodTypeBuilder.newMethodType;
 @AutoConfigure
 public class AssertNotNullToAssertThat extends JavaIsoRefactorVisitor {
 
-    private static final String JUNIT_QUALIFIED_ASSERTIONS_CLASS = "org.junit.jupiter.api.Assertions";
+    private static final String JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME = "org.junit.jupiter.api.Assertions";
     private static final String ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME = "org.assertj.core.api.Assertions";
     private static final String ASSERTJ_ASSERT_THAT_METHOD_NAME = "assertThat";
 
     /**
-     * This matcher uses a pointcut expression to find the matching junit methods that will be migrated by this visitor.
+     * This matcher finds the junit methods that will be migrated by this visitor.
      */
-    private static final MethodMatcher JUNIT_ASSERT_TRUE_MATCHER = new MethodMatcher(
-            JUNIT_QUALIFIED_ASSERTIONS_CLASS + " assertNotNull(..)"
+    private static final MethodMatcher JUNIT_ASSERT_NOT_NULL_MATCHER = new MethodMatcher(
+            JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME + " assertNotNull(..)"
     );
 
     private static final JavaType.Method assertThatMethodType = newMethodType()
@@ -61,15 +61,9 @@ public class AssertNotNullToAssertThat extends JavaIsoRefactorVisitor {
             .build();
 
     @Override
-    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu) {
-        maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS);
-        return super.visitCompilationUnit(cu);
-    }
-
-    @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method) {
         J.MethodInvocation original = super.visitMethodInvocation(method);
-        if (!JUNIT_ASSERT_TRUE_MATCHER.matches(method)) {
+        if (!JUNIT_ASSERT_NOT_NULL_MATCHER.matches(method)) {
             return original;
         }
 
@@ -130,6 +124,9 @@ public class AssertNotNullToAssertThat extends JavaIsoRefactorVisitor {
                 null,
                 format("\n")
         );
+
+        // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
+        maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME);
 
         // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat"
         maybeAddImport(ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME, ASSERTJ_ASSERT_THAT_METHOD_NAME);

--- a/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThat.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junitassertj;
+
+import org.openrewrite.AutoConfigure;
+import org.openrewrite.java.*;
+import org.openrewrite.java.tree.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.openrewrite.Formatting.EMPTY;
+import static org.openrewrite.Formatting.format;
+import static org.openrewrite.Tree.randomId;
+import static org.openrewrite.java.tree.MethodTypeBuilder.newMethodType;
+
+/**
+ * This is a refactoring visitor that will convert JUnit-style assertNull() to assertJ's assertThat().isNull().
+ *
+ * This visitor only supports the migration of the following JUnit 5 assertTrue() methods:
+ *
+ * <PRE>
+ *     assertNull(Object actual) -> assertThat(condition).isNull()
+ *     assertNull(Object actual, String message) -> assertThat(condition).as(message).isNull();
+ *     assertNull(Object actual, Supplier<String> messageSupplier) -> assertThat(condition).withFailMessage(messageSupplier).isNull();
+ * </PRE>
+ */
+@AutoConfigure
+public class AssertNullToAssertThat extends JavaIsoRefactorVisitor {
+
+    private static final String JUNIT_QUALIFIED_ASSERTIONS_CLASS = "org.junit.jupiter.api.Assertions";
+    private static final String ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME = "org.assertj.core.api.Assertions";
+    private static final String ASSERTJ_ASSERT_THAT_METHOD_NAME = "assertThat";
+
+    /**
+     * This matcher uses a pointcut expression to find the matching junit methods that will be migrated by this visitor
+     */
+    private static final MethodMatcher JUNIT_ASSERT_TRUE_MATCHER = new MethodMatcher(
+            JUNIT_QUALIFIED_ASSERTIONS_CLASS + " assertNull(..)"
+    );
+
+    private static final JavaType.Method assertThatMethodType = newMethodType()
+            .declaringClass(ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME)
+            .flags(Flag.Public, Flag.Static)
+            .returnType("org.assertj.core.api.AbstractBooleanAssert")
+            .name(ASSERTJ_ASSERT_THAT_METHOD_NAME)
+            .parameter(JavaType.Primitive.Boolean, "arg1")
+            .build();
+
+    @Override
+    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu) {
+        maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS);
+        return super.visitCompilationUnit(cu);
+    }
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method) {
+        J.MethodInvocation original = super.visitMethodInvocation(method);
+        if (!JUNIT_ASSERT_TRUE_MATCHER.matches(method)) {
+            return original;
+        }
+
+        List<Expression> originalArgs = original.getArgs().getArgs();
+        Expression objToCheck = originalArgs.get(0);
+        Expression message = originalArgs.size() == 2 ? originalArgs.get(1):null;
+
+        // This creates the `assertThat(<EXPRESSION>)` method invocation. Without the type information for this invocation,
+        // the AddImport visitor won't add a static import for "assertThat" (assuming it doesn't already exist)
+        // because it won't be able to find a reference to the type.
+        J.MethodInvocation assertSelect = new J.MethodInvocation(
+                randomId(),
+                null,
+                null,
+                J.Ident.build(randomId(), ASSERTJ_ASSERT_THAT_METHOD_NAME, JavaType.Primitive.Void, EMPTY),
+                new J.MethodInvocation.Arguments(
+                        randomId(),
+                        Collections.singletonList(objToCheck),
+                        EMPTY
+                ),
+                assertThatMethodType,
+                EMPTY
+        );
+
+        // If the assertTrue is the two-argument variant, we need to maintain the message via a chained method
+        // call to "as"/"withFailMessage". The message may be a String or Supplier<String>.
+        if (message != null) {
+            // In assertJ the "as" method has a more informative error message, but doesn't accept String suppliers
+            // so we're using "as" if the message is a string and "withFailMessage" if it is a supplier.
+            String messageAs = TypeUtils.isString(message.getType())? "as" : "withFailMessage";
+
+            assertSelect = new J.MethodInvocation(
+                    randomId(),
+                    assertSelect, // assertThat is the select for this method.
+                    null,
+                    J.Ident.build(randomId(), messageAs, null, EMPTY),
+                    new J.MethodInvocation.Arguments(
+                            randomId(),
+                            Collections.singletonList(message.withPrefix("")),
+                            EMPTY
+                    ),
+                    null,
+                    EMPTY
+            );
+        }
+
+        // This will always return the "isNull()" method using assertSelect as the select.
+        J.MethodInvocation replacement = new J.MethodInvocation(
+                randomId(),
+                assertSelect,
+                null,
+                J.Ident.build(randomId(), "isNull", JavaType.Primitive.Boolean, EMPTY),
+                new J.MethodInvocation.Arguments(
+                        randomId(),
+                        Collections.emptyList(),
+                        EMPTY
+                ),
+                null,
+                format("\n")
+        );
+
+        // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat"
+        maybeAddImport(ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME, ASSERTJ_ASSERT_THAT_METHOD_NAME);
+
+        // Format the replacement method invocation in the context of where it is called.
+        andThen(new AutoFormat(replacement));
+        return replacement;
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThat.java
@@ -41,15 +41,15 @@ import static org.openrewrite.java.tree.MethodTypeBuilder.newMethodType;
 @AutoConfigure
 public class AssertNullToAssertThat extends JavaIsoRefactorVisitor {
 
-    private static final String JUNIT_QUALIFIED_ASSERTIONS_CLASS = "org.junit.jupiter.api.Assertions";
+    private static final String JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME = "org.junit.jupiter.api.Assertions";
     private static final String ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME = "org.assertj.core.api.Assertions";
     private static final String ASSERTJ_ASSERT_THAT_METHOD_NAME = "assertThat";
 
     /**
-     * This matcher uses a pointcut expression to find the matching junit methods that will be migrated by this visitor.
+     * This matcher finds the junit methods that will be migrated by this visitor.
      */
-    private static final MethodMatcher JUNIT_ASSERT_TRUE_MATCHER = new MethodMatcher(
-            JUNIT_QUALIFIED_ASSERTIONS_CLASS + " assertNull(..)"
+    private static final MethodMatcher JUNIT_ASSERT_NULL_MATCHER = new MethodMatcher(
+            JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME + " assertNull(..)"
     );
 
     private static final JavaType.Method assertThatMethodType = newMethodType()
@@ -61,15 +61,9 @@ public class AssertNullToAssertThat extends JavaIsoRefactorVisitor {
             .build();
 
     @Override
-    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu) {
-        maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS);
-        return super.visitCompilationUnit(cu);
-    }
-
-    @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method) {
         J.MethodInvocation original = super.visitMethodInvocation(method);
-        if (!JUNIT_ASSERT_TRUE_MATCHER.matches(method)) {
+        if (!JUNIT_ASSERT_NULL_MATCHER.matches(method)) {
             return original;
         }
 
@@ -130,6 +124,8 @@ public class AssertNullToAssertThat extends JavaIsoRefactorVisitor {
                 null,
                 format("\n")
         );
+        // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
+        maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME);
 
         // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat".
         maybeAddImport(ASSERTJ_QUALIFIED_ASSERTIONS_CLASS_NAME, ASSERTJ_ASSERT_THAT_METHOD_NAME);

--- a/src/test/kotlin/org/openrewrite/java/testing/junitassertj/AssertNotNullToAssertThatTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junitassertj/AssertNotNullToAssertThatTest.kt
@@ -22,28 +22,28 @@ import org.openrewrite.RefactorVisitorTestForParser
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.tree.J
 
-class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUnit> {
+class AssertNotNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUnit> {
     override val parser: Parser<J.CompilationUnit> = JavaParser.fromJavaVersion()
         .classpath("junit", "assertj-core", "apiguardian-api")
         .build()
 
-    override val visitors: Iterable<RefactorVisitor<*>> = listOf(AssertNullToAssertThat())
+    override val visitors: Iterable<RefactorVisitor<*>> = listOf(AssertNotNullToAssertThat())
 
     @Test
     fun singleStaticMethodNoMessage() = assertRefactored(
         before = """
                 import org.junit.Test;
 
-                import static org.junit.jupiter.api.Assertions.assertNull;
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
 
                 public class A {
  
                     @Test
                     public void test() {
-                        assertNull(notification());
+                        assertNotNull(notification());
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """,
@@ -56,10 +56,10 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
 
                     @Test
                     public void test() {
-                        assertThat(notification()).isNull();
+                        assertThat(notification()).isNotNull();
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """
@@ -70,16 +70,16 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
         before = """
                 import org.junit.Test;
 
-                import static org.junit.jupiter.api.Assertions.assertNull;
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
 
                 public class A {
  
                     @Test
                     public void test() {
-                        assertNull(notification(), "Should be null");
+                        assertNotNull(notification(), "Should not be null");
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """,
@@ -92,10 +92,10 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
 
                     @Test
                     public void test() {
-                        assertThat(notification()).as("Should be null").isNull();
+                        assertThat(notification()).as("Should not be null").isNotNull();
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """
@@ -106,16 +106,16 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
         before = """
                 import org.junit.Test;
 
-                import static org.junit.jupiter.api.Assertions.assertNull;
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
 
                 public class A {
  
                     @Test
                     public void test() {
-                        assertNull(notification(), () -> "Should be null");
+                        assertNotNull(notification(), () -> "Should not be null");
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """,
@@ -128,10 +128,10 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
 
                     @Test
                     public void test() {
-                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                        assertThat(notification()).withFailMessage(() -> "Should not be null").isNotNull();
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """
@@ -146,12 +146,12 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
                 
                     @Test
                     public void test() {
-                        org.junit.jupiter.api.Assertions.assertNull(notification());
-                        org.junit.jupiter.api.Assertions.assertNull(notification(), "Should be null");
-                        org.junit.jupiter.api.Assertions.assertNull(notification(), () -> "Should be null");
+                        org.junit.jupiter.api.Assertions.assertNotNull(notification());
+                        org.junit.jupiter.api.Assertions.assertNotNull(notification(), "Should not be null");
+                        org.junit.jupiter.api.Assertions.assertNotNull(notification(), () -> "Should not be null");
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """,
@@ -164,12 +164,12 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
                 
                     @Test
                     public void test() {
-                        assertThat(notification()).isNull();
-                        assertThat(notification()).as("Should be null").isNull();
-                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                        assertThat(notification()).isNotNull();
+                        assertThat(notification()).as("Should not be null").isNotNull();
+                        assertThat(notification()).withFailMessage(() -> "Should not be null").isNotNull();
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """
@@ -181,18 +181,18 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
                 import org.junit.Test;
                 
                 import static org.assertj.core.api.Assertions.*;
-                import static org.junit.jupiter.api.Assertions.assertNull;
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
                 
                 public class A {
                 
                     @Test
                     public void test() {
-                        assertNull(notification());
-                        org.junit.jupiter.api.Assertions.assertNull(notification(), "Should be null");
-                        assertNull(notification(), () -> "Should be null");
+                        assertNotNull(notification());
+                        org.junit.jupiter.api.Assertions.assertNotNull(notification(), "Should not be null");
+                        assertNotNull(notification(), () -> "Should not be null");
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """,
@@ -205,12 +205,12 @@ class AssertNullToAssertThatTest : RefactorVisitorTestForParser<J.CompilationUni
                 
                     @Test
                     public void test() {
-                        assertThat(notification()).isNull();
-                        assertThat(notification()).as("Should be null").isNull();
-                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                        assertThat(notification()).isNotNull();
+                        assertThat(notification()).as("Should not be null").isNotNull();
+                        assertThat(notification()).withFailMessage(() -> "Should not be null").isNotNull();
                     }
                     private String notification() {
-                        return null;
+                        return "";
                     }
                 }
             """

--- a/src/test/kotlin/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThatTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junitassertj/AssertNullToAssertThatTest.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junitassertj
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Parser
+import org.openrewrite.RefactorVisitor
+import org.openrewrite.RefactorVisitorTestForParser
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.tree.J
+
+class AssertNullToAssertThatTest: RefactorVisitorTestForParser<J.CompilationUnit> {
+    override val parser: Parser<J.CompilationUnit> = JavaParser.fromJavaVersion()
+        .classpath("junit", "assertj-core", "apiguardian-api")
+        .build()
+
+    override val visitors: Iterable<RefactorVisitor<*>> = listOf(AssertNullToAssertThat())
+
+    @Test
+    fun singleStaticMethodNoMessage() = assertRefactored(
+        before = """
+                import org.junit.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertNull;
+
+                public class A {
+ 
+                    @Test
+                    public void test() {
+                        assertNull(notification());
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """,
+        after = """
+                import org.junit.Test;
+
+                import static org.assertj.core.api.Assertions.assertThat;
+
+                public class A {
+
+                    @Test
+                    public void test() {
+                        assertThat(notification()).isNull();
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun singleStaticMethodWithMessageString() = assertRefactored(
+        before = """
+                import org.junit.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertNull;
+
+                public class A {
+ 
+                    @Test
+                    public void test() {
+                        assertNull(notification(), "Should be null");
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """,
+        after = """
+                import org.junit.Test;
+
+                import static org.assertj.core.api.Assertions.assertThat;
+
+                public class A {
+
+                    @Test
+                    public void test() {
+                        assertThat(notification()).as("Should be null").isNull();
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun singleStaticMethodWithMessageSupplier() = assertRefactored(
+        before = """
+                import org.junit.Test;
+
+                import static org.junit.jupiter.api.Assertions.assertNull;
+
+                public class A {
+ 
+                    @Test
+                    public void test() {
+                        assertNull(notification(), () -> "Should be null");
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """,
+        after = """
+                import org.junit.Test;
+
+                import static org.assertj.core.api.Assertions.assertThat;
+
+                public class A {
+
+                    @Test
+                    public void test() {
+                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun inlineReference() = assertRefactored(
+        before = """
+                import org.junit.Test;
+ 
+                public class A {
+                
+                    @Test
+                    public void test() {
+                        org.junit.jupiter.api.Assertions.assertNull(notification());
+                        org.junit.jupiter.api.Assertions.assertNull(notification(), "Should be null");
+                        org.junit.jupiter.api.Assertions.assertNull(notification(), () -> "Should be null");
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """,
+        after = """
+                import org.junit.Test;
+                
+                import static org.assertj.core.api.Assertions.assertThat;
+                
+                public class A {
+                
+                    @Test
+                    public void test() {
+                        assertThat(notification()).isNull();
+                        assertThat(notification()).as("Should be null").isNull();
+                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """
+    )
+
+    @Test
+    fun mixedReferences() = assertRefactored(
+        before = """
+                import org.junit.Test;
+                
+                import static org.assertj.core.api.Assertions.*;
+                import static org.junit.jupiter.api.Assertions.assertNull;
+                
+                public class A {
+                
+                    @Test
+                    public void test() {
+                        assertNull(notification());
+                        org.junit.jupiter.api.Assertions.assertNull(notification(), "Should be null");
+                        assertNull(notification(), () -> "Should be null");
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """,
+        after = """
+                import org.junit.Test;
+                
+                import static org.assertj.core.api.Assertions.*;
+                
+                public class A {
+                
+                    @Test
+                    public void test() {
+                        assertThat(notification()).isNull();
+                        assertThat(notification()).as("Should be null").isNull();
+                        assertThat(notification()).withFailMessage(() -> "Should be null").isNull();
+                    }
+                    private String notification() {
+                        return null;
+                    }
+                }
+            """
+    )
+}


### PR DESCRIPTION
Implemented visitors to convert the following null assertions from JUnit 5 to assertJ.

`assertNull()` => `assertThat().isNull()`
`assertNotNull()` => `assertThat().isNotNull()`