### PR TITLE
Reduce visibility of JUnit5 methods

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotations.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotations.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.AutoConfigure;
+import org.openrewrite.java.*;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This refactor visitor will replace JUnit 4's "Before", "BeforeClass", "After", and "AfterClass" annotations with their
+ * JUnit 5 equivalents. Additionally, this visitor will reduce the visibility of methods marked with those annotations
+ * to "package" to comply with JUnit 5 best practices.
+ *
+ * <PRE>
+ *  org.junit.Before --> org.junit.jupiter.api.BeforeEach
+ *  org.junit.After --> org.junit.jupiter.api.AfterEach
+ *  org.junit.BeforeClass --> org.junit.jupiter.api.BeforeAll
+ *  org.junit.AfterClass --> org.junit.jupiter.api.AfterAll
+ * </PRE>
+ */
+@AutoConfigure
+public class UpdateBeforeAfterAnnotations extends JavaIsoRefactorVisitor {
+
+    @Override
+    public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu) {
+        //This visitor handles changing the method visibility for any method annotated with one of the four before/after
+        //annotations. It registers visitors that will sweep behind it making the type changes.
+        ChangeType changeType = new ChangeType();
+        changeType.setType("org.junit.Before");
+        changeType.setTargetType("org.junit.jupiter.api.BeforeEach");
+        andThen(changeType);
+
+        changeType = new ChangeType();
+        changeType.setType("org.junit.After");
+        changeType.setTargetType("org.junit.jupiter.api.AfterEach");
+        andThen(changeType);
+
+        changeType = new ChangeType();
+        changeType.setType("org.junit.BeforeClass");
+        changeType.setTargetType("org.junit.jupiter.api.BeforeAll");
+        andThen(changeType);
+
+        changeType = new ChangeType();
+        changeType.setType("org.junit.AfterClass");
+        changeType.setTargetType("org.junit.jupiter.api.AfterAll");
+        andThen(changeType);
+
+        return super.visitCompilationUnit(cu);
+    }
+
+    @Override
+    public J.MethodDecl visitMethod(J.MethodDecl method) {
+        J.MethodDecl m = super.visitMethod(method);
+
+        boolean changed = false;
+        List<J.Annotation> annotations = new ArrayList<>(m.getAnnotations());
+        for (J.Annotation a : annotations) {
+
+            if (TypeUtils.isOfClassType(a.getType(), "org.junit.Before") ||
+                    TypeUtils.isOfClassType(a.getType(), "org.junit.After") ||
+                    TypeUtils.isOfClassType(a.getType(), "org.junit.BeforeClass") ||
+                    TypeUtils.isOfClassType(a.getType(), "org.junit.AfterClass")) {
+
+                //If we found the annotation, we change the visibility of the method to package. Also need to format
+                //the method declaration because the previous visibility likely had formatting that is removed.
+                m = m.withModifiers(J.Modifier.withVisibility(m.getModifiers(), "package"));
+                andThen(new AutoFormat(m));
+                break;
+            }
+        }
+        return m;
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -59,8 +59,13 @@ public class UpdateTestAnnotation extends JavaIsoRefactorVisitor {
         boolean changed = false;
         List<J.Annotation> annotations = new ArrayList<>(m.getAnnotations());
         for (int i = 0, annotationsSize = annotations.size(); i < annotationsSize; i++) {
+
             J.Annotation a = annotations.get(i);
             if (TypeUtils.isOfClassType(a.getType(), "org.junit.Test")) {
+                //If we found the annotation, we change the visibility of the method to package. Because the
+                m = m.withModifiers(J.Modifier.withVisibility(m.getModifiers(), "package"));
+                andThen(new AutoFormat(m));
+
                 annotations.set(i, a.withArgs(null));
                 if(a.getArgs() == null) {
                     continue;
@@ -85,7 +90,7 @@ public class UpdateTestAnnotation extends JavaIsoRefactorVisitor {
                             andThen(addAssertThrows);
                             andThen(new AutoFormat(assertThrows));
 
-                            m = method.withBody(m.getBody().withStatements(singletonList(assertThrows)));
+                            m = m.withBody(m.getBody().withStatements(singletonList(assertThrows)));
                         } else if (assignParamName.equals("timeout")) {
                             AddAnnotation.Scoped aa = new AddAnnotation.Scoped(m, "org.junit.jupiter.api.Timeout", e.withFormatting(EMPTY));
                             andThen(aa);
@@ -100,7 +105,6 @@ public class UpdateTestAnnotation extends JavaIsoRefactorVisitor {
         if (changed) {
             m = m.withAnnotations(annotations);
         }
-
         return m;
     }
 }

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -15,20 +15,8 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/visitor
-name: org.openrewrite.java.testing.junit5.ReplaceAnnotations
+name: org.openrewrite.java.testing.junit5.ReplaceIngoreAnnotations
 visitors:
-  - org.openrewrite.java.ChangeType:
-      type: org.junit.Before
-      targetType: org.junit.jupiter.api.BeforeEach
-  - org.openrewrite.java.ChangeType:
-      type: org.junit.After
-      targetType: org.junit.jupiter.api.AfterEach
-  - org.openrewrite.java.ChangeType:
-      type: org.junit.BeforeClass
-      targetType: org.junit.jupiter.api.BeforeAll
-  - org.openrewrite.java.ChangeType:
-      type: org.junit.AfterClass
-      targetType: org.junit.jupiter.api.AfterAll
   - org.openrewrite.java.ChangeType:
       type: org.junit.Ignore
       targetType: org.junit.jupiter.api.Disabled

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -15,7 +15,7 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/visitor
-name: org.openrewrite.java.testing.junit5.ReplaceIngoreAnnotations
+name: org.openrewrite.java.testing.junit5.ReplaceIgnoreAnnotations
 visitors:
   - org.openrewrite.java.ChangeType:
       type: org.junit.Ignore

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.kt
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.java.testing.junit5
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.openrewrite.RefactorVisitorTestForParser
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.tree.J

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.kt
@@ -41,7 +41,9 @@ class JUnit5MigrationTest : RefactorVisitorTestForParser<J.CompilationUnit> {
                 import org.junit.jupiter.api.BeforeEach;
 
                 public class Example {
-                    @BeforeEach public void initialize() {}
+
+                    @BeforeEach
+                    void initialize() {}
                 }
             """
     )
@@ -59,7 +61,9 @@ class JUnit5MigrationTest : RefactorVisitorTestForParser<J.CompilationUnit> {
                 import org.junit.jupiter.api.AfterEach;
 
                 public class Example {
-                    @AfterEach public void initialize() {}
+
+                    @AfterEach
+                    void initialize() {}
                 }
             """
     )
@@ -70,14 +74,17 @@ class JUnit5MigrationTest : RefactorVisitorTestForParser<J.CompilationUnit> {
                 import org.junit.BeforeClass;
 
                 public class Example {
-                    @BeforeClass public void initialize() {}
+                    @BeforeClass
+                    void initialize() {}
                 }
             """,
             after = """
                 import org.junit.jupiter.api.BeforeAll;
 
                 public class Example {
-                    @BeforeAll public void initialize() {}
+
+                    @BeforeAll
+                    void initialize() {}
                 }
             """
     )
@@ -95,7 +102,9 @@ class JUnit5MigrationTest : RefactorVisitorTestForParser<J.CompilationUnit> {
                 import org.junit.jupiter.api.AfterAll;
 
                 public class Example {
-                    @AfterAll public void initialize() {}
+
+                    @AfterAll
+                    void initialize() {}
                 }
             """
     )

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/SpringRunnerToSpringExtensionTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/SpringRunnerToSpringExtensionTest.kt
@@ -15,7 +15,7 @@
  */
 package org.openrewrite.java.testing.junit5
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.openrewrite.RefactorVisitorTestForParser
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.tree.J

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.kt
@@ -50,7 +50,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 public class A {
                 
                     @Test
-                    public void test() {
+                    void test() {
                         assertThrows(IllegalArgumentException.class, () -> {
                             throw new IllegalArgumentException("boom");
                         });
@@ -80,7 +80,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 public class A {
                 
                     @Test
-                    public void test() {
+                    void test() {
                         assertThrows(IndexOutOfBoundsException.class, () -> {
                             int arr = new int[]{}[0];
                         });
@@ -111,7 +111,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 public class A {
                 
                     @Test
-                    public void test() {
+                    void test() {
                         assertThrows(IllegalArgumentException.class, () -> {
                             String foo = "foo";
                             throw new IllegalArgumentException("boom");
@@ -138,7 +138,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 public class A {
                 
                     @Test
-                    public void test() { }
+                    void test() { }
                 }
             """
     )
@@ -162,7 +162,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 
                     @Test
                     @Timeout(500)
-                    public void test() { }
+                    void test() { }
                 }
             """
     )
@@ -190,7 +190,7 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
                 
                     @Test
                     @Timeout(500)
-                    public void test() {
+                    void test() {
                         assertThrows(IllegalArgumentException.class, () -> {
                             throw new IllegalArgumentException("boom");
                         });
@@ -200,21 +200,56 @@ class UpdateTestAnnotationTest: RefactorVisitorTestForParser<J.CompilationUnit> 
     )
 
     @Test
-    fun foo() {
-        val cu = parser.parse("""
-            import static org.junit.jupiter.api.Assertions.assertThrows;
-            import org.junit.jupiter.api.*;
-            
-            class A {
-                @Test
-                public void foo2() {
-                    assertThrows(IndexOutOfBoundsException.class, () -> {
-                        int arr = new int[]{}[0];
-                    });
-                }
-            }
-        """).first()
+    fun protectedToPackageVisibility() = assertRefactored(
+        //An existing test method with protected visibility would not be executed by JUnit 4. This refactor will actual
+        //fix this use case when moving to JUnit 5.
 
-        cu
-    }
+        before = """
+                import org.junit.Test;
+
+                public class A {
+                
+                    @Test
+                    protected void test() {
+                    }
+                }
+            """.trimIndent(),
+        after = """
+                import org.junit.jupiter.api.Test;
+
+                public class A {
+
+                    @Test
+                    void test() {
+                    }
+                }
+            """.trimIndent()
+    )
+
+    @Test
+    fun privateToPackageVisibility() = assertRefactored(
+        //An existing test method with private visibility would not be executed by JUnit 4. This refactor will actual
+        //fix this use case when moving to JUnit 5.
+        before = """
+                import org.junit.Test;
+                
+                public class A {
+                
+                    @Test
+                    private void test() {
+                    }
+                }
+            """.trimIndent(),
+        after = """
+                import org.junit.jupiter.api.Test;
+                
+                public class A {
+                
+                    @Test
+                    void test() {
+                    }
+                }
+            """.trimIndent()
+    )
+
 }


### PR DESCRIPTION
This PR introduces logic to reduce the visibility of methods marked with JUnit annotations to "package" to comply with JUnit 5 best practices. Fixes #23  