### PR TITLE
JUnit5 Assertions to Assert J assertions pre-packaged declarative recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
+++ b/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
@@ -1,0 +1,30 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.JUnit5AssertionsToAssertJMigration
+recipeList:
+  - org.openrewrite.java.testing.junitassertj.AssertArrayEqualsToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertEqualsToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertFalseToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertNotEqualsToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertNotNullToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertNullToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertSameToAssertThat
+  - org.openrewrite.java.testing.junitassertj.AssertTrueToAssertThat
+  - org.openrewrite.java.testing.junitassertj.JUnitFailToAssertJFail
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: "org.assertj.core.api.Assertions *(..)"


### PR DESCRIPTION
In order to enable direct, easy consumption of the JUnit Assertions to AssertJ recipes from the `junitassertj` package, pre-package the recipes in a declarative yaml.

The recipe is titled `JUnit5AssertionsToAssertJMigration` (fully qualified, `org.openrewrite.java.testing.JUnit5AssertionsToAssertJMigration`)