### PR TITLE
Separate assertj assertions using static imports from the junit5 assertions migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj-assertions-use-static-import.yml
+++ b/src/main/resources/META-INF/rewrite/assertj-assertions-use-static-import.yml
@@ -1,0 +1,21 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.AssertJAssertionsUseStaticImport
+recipeList:
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: "org.assertj.core.api.Assertions *(..)"

--- a/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
+++ b/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
@@ -26,5 +26,3 @@ recipeList:
   - org.openrewrite.java.testing.junitassertj.AssertSameToAssertThat
   - org.openrewrite.java.testing.junitassertj.AssertTrueToAssertThat
   - org.openrewrite.java.testing.junitassertj.JUnitFailToAssertJFail
-  - org.openrewrite.java.UseStaticImport:
-      methodPattern: "org.assertj.core.api.Assertions *(..)"


### PR DESCRIPTION
see: https://github.com/openrewrite/rewrite-testing-frameworks/pull/38
see: https://github.com/openrewrite/rewrite-testing-frameworks/issues/31

Separates assertj assertions static imports from the junit5 assertions to assertj migration.

This provides two benefits:
1.) **It's less surprising**, since it gives users a choice on whether to use static imports with assertJ from JUnit 5 -> assertJ migration as a choice to make, and;
2.) **It's more efficient** by making it easier to consume "AssertJ Use Static Imports" as a separate recipe without having to waste time going through the other Junit migration recipes if that isn't desired (and vice versa).

Easy peezy PR, feel free to either merge or close whenever.