### PR TITLE
Use correct assertThat static import, consolidate assertj declarative recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -1,0 +1,25 @@
+#
+# Copyright 2020 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.AssertJUseAssertThatFromAssertionsPackage
+recipeList:
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: "org.assertj.core.api.AssertionsForClassTypes assertThat(..)"
+      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: "org.assertj.core.api.AssertionsForInterfaceTypes assertThat(..)"
+      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"

--- a/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
+++ b/src/main/resources/META-INF/rewrite/junit5-assertions-to-assertj.yml
@@ -28,9 +28,3 @@ recipeList:
   - org.openrewrite.java.testing.junitassertj.JUnitFailToAssertJFail
   - org.openrewrite.java.UseStaticImport:
       methodPattern: "org.assertj.core.api.Assertions *(..)"
-  - org.openrewrite.java.ChangeMethodTargetToStatic
-      methodPattern: "org.assertj.core.api.AssertionsForClassTypes.assertThat *(..)"
-      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions.assertThat"
-  - org.openrewrite.java.ChangeMethodTargetToStatic
-    methodPattern: "org.assertj.core.api.AssertionsForInterfaceTypes.assertThat *(..)"
-    fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions.assertThat"


### PR DESCRIPTION
part of https://github.com/openrewrite/rewrite/issues/296

- Moves the `assertThat` recipes to `assertj.yml`, explicitly names them

I put these in their own recipe, `AssertJUseAssertThatFromAssertionsPackage`, because the recipes are conceptually different. I felt it's better to do smaller, goal-oriented recipes which can be opt-in. Changes welcome if that's what people think would otherwise be better.