### PR TITLE
Use FindTypes to check for junit4 Test for UpdateTestAnnotation performance [#392]

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.ChangeType;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.tree.*;
 
 import java.util.ArrayList;
@@ -51,7 +52,9 @@ public class UpdateTestAnnotation extends Recipe {
 
         @Override
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            doAfterVisit(new ChangeType("org.junit.Test", "org.junit.jupiter.api.Test"));
+            if (!FindTypes.find(cu, "org.junit.Test").isEmpty()) {
+                doAfterVisit(new ChangeType("org.junit.Test", "org.junit.jupiter.api.Test"));
+            }
             return super.visitCompilationUnit(cu, ctx);
         }
 


### PR DESCRIPTION
I won't write issues this verbose for other enhancements, but considering the impact this has, I've included additional commentary.

Leaving this PR small as it's impact is significant on it's own (as in, there's room for other enhancements elsewhere). This appears to improve performance  ~300%+ (which isn't scientific, but, hey, it's buzzwordy)

---

I believe this is still semantically correct, and if it's 100% correct I question whether there's value in moving this logic into ChangeType itself as a check since it appears to be quite quick by comparison. But--

Having `FindTypes.find(cu, "org.junit.Test")` check for any types improves execution performance, specifically when tested in against codesets which don't have `org.junit.Test` in it, meaning it's adding drag in situations where the recipe ultimately won't need to be executing. In other words, if we were to think about this in terms of "check" ("_should_ this recipe apply?") and "apply" as separate phases, the "check" phase's performance can be improved.

before introducing a `FindType` check on the compilation unit alone:

```
UpdateTestAnnotationBenchmark.updateTestAnnotationOriginal:updateTestAnnotationOriginal·p0.95    sample               0.021             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotationOriginal:updateTestAnnotationOriginal·p0.99    sample               0.023             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotationOriginal:updateTestAnnotationOriginal·p0.999   sample               0.029             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotationOriginal:updateTestAnnotationOriginal·p0.9999  sample               0.034             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotationOriginal:updateTestAnnotationOriginal·p1.00    sample               0.034             s/op
```

after:

```
UpdateTestAnnotationBenchmark.updateTestAnnotation:updateTestAnnotation·p0.95                    sample               0.007             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotation:updateTestAnnotation·p0.99                    sample               0.008             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotation:updateTestAnnotation·p0.999                   sample               0.010             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotation:updateTestAnnotation·p0.9999                  sample               0.015             s/op
UpdateTestAnnotationBenchmark.updateTestAnnotation:updateTestAnnotation·p1.00                    sample               0.015             s/op
```