### PR TITLE
additional benchmarking on recipes for direct comparison

### DIFF
--- a/src/jmh/java/org/openrewrite/benchmarks/java/JavaCompilationUnitState.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/JavaCompilationUnitState.java
@@ -33,7 +33,7 @@ public class JavaCompilationUnitState {
 
     @Setup(Level.Trial)
     public void setup() throws URISyntaxException {
-        Path rewriteRoot = Paths.get(UpdateTestAnnotationBenchmark.class.getResource("./")
+        Path rewriteRoot = Paths.get(JavaCompilationUnitState.class.getResource("./")
                 .toURI()).resolve("../../../../../../../").normalize();
 
         List<Path> inputs = Arrays.asList(
@@ -48,9 +48,9 @@ public class JavaCompilationUnitState {
                 rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotations.java"),
                 rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java"),
                 rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/junit5/UseTestMethodOrder.java"),
-                rewriteRoot.resolve("src/before/java/org/openrewrite/java/testing/junit5/ExampleJunitTestClass.java")
-                // rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertArrayEqualsToAssertThat.java"),
-                // rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java")
+                rewriteRoot.resolve("src/before/java/org/openrewrite/java/testing/junit5/ExampleJunitTestClass.java"),
+                rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertArrayEqualsToAssertThat.java"),
+                rewriteRoot.resolve("src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java")
         );
 
         sourceFiles = JavaParser.fromJavaVersion()

--- a/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertArrayEqualsToAssertThatBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertArrayEqualsToAssertThatBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.assertj;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class JUnitAssertArrayEqualsToAssertThatBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(JUnitAssertArrayEqualsToAssertThatBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void jUnitAssertArrayEqualsToAssertThat(JavaCompilationUnitState state) {
+        new JUnitAssertArrayEqualsToAssertThat().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertNotNullToAssertThatBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertNotNullToAssertThatBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.assertj;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class JUnitAssertNotNullToAssertThatBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(JUnitAssertNotNullToAssertThatBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void jUnitAssertNotNullToAssertThat(JavaCompilationUnitState state) {
+        new JUnitAssertNotNullToAssertThat().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertTrueToAssertThatBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/assertj/JUnitAssertTrueToAssertThatBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.assertj;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class JUnitAssertTrueToAssertThatBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(JUnitAssertTrueToAssertThatBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void jUnitAssertTrueToAssertThat(JavaCompilationUnitState state) {
+        new JUnitAssertTrueToAssertThat().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/AssertToAssertionsBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/AssertToAssertionsBenchmark.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.openrewrite.benchmarks.java;
+package org.openrewrite.benchmarks.java.junit5;
 
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.profile.GCProfiler;
@@ -21,7 +21,8 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.openrewrite.java.testing.junit5.UpdateTestAnnotation;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.AssertToAssertions;
 
 import java.util.concurrent.TimeUnit;
 
@@ -31,19 +32,19 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Threads(4)
-public class UpdateTestAnnotationBenchmark {
+public class AssertToAssertionsBenchmark {
 
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
-                .include(UpdateTestAnnotationBenchmark.class.getSimpleName())
+                .include(AssertToAssertionsBenchmark.class.getSimpleName())
                 .addProfiler(GCProfiler.class)
                 .build();
         new Runner(opt).run();
     }
 
     @Benchmark
-    public void updateTestAnnotation(JavaCompilationUnitState state) {
-        new UpdateTestAnnotation().run(state.getSourceFiles());
+    public void assertToAssertions(JavaCompilationUnitState state) {
+        new AssertToAssertions().run(state.getSourceFiles());
     }
 
 }

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/ExpectedExceptionToAssertThrowsBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/ExpectedExceptionToAssertThrowsBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.junit5;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.ExpectedExceptionToAssertThrows;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class ExpectedExceptionToAssertThrowsBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(ExpectedExceptionToAssertThrowsBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void expectedExceptionToAssertThrows(JavaCompilationUnitState state) {
+        new ExpectedExceptionToAssertThrows().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/TemporaryFolderToTempDirBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/TemporaryFolderToTempDirBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.junit5;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.TemporaryFolderToTempDir;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class TemporaryFolderToTempDirBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(TemporaryFolderToTempDirBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void temporaryFolderToTempDir(JavaCompilationUnitState state) {
+        new TemporaryFolderToTempDir().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UpdateBeforeAfterAnnotationsBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UpdateBeforeAfterAnnotationsBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.junit5;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class UpdateBeforeAfterAnnotationsBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(UpdateBeforeAfterAnnotationsBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void updateBeforeAfterAnnotations(JavaCompilationUnitState state) {
+        new UpdateBeforeAfterAnnotations().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UpdateTestAnnotationBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UpdateTestAnnotationBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.junit5;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.UpdateTestAnnotation;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class UpdateTestAnnotationBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(UpdateTestAnnotationBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void updateTestAnnotation(JavaCompilationUnitState state) {
+        new UpdateTestAnnotation().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UseTestMethodOrderBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/junit5/UseTestMethodOrderBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.junit5;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.junit5.UseTestMethodOrder;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class UseTestMethodOrderBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(UseTestMethodOrderBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void useTestMethodOrder(JavaCompilationUnitState state) {
+        new UseTestMethodOrder().run(state.getSourceFiles());
+    }
+
+}

--- a/src/jmh/java/org/openrewrite/benchmarks/java/mockito/CleanupMockitoImportsBenchmark.java
+++ b/src/jmh/java/org/openrewrite/benchmarks/java/mockito/CleanupMockitoImportsBenchmark.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java.mockito;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openrewrite.benchmarks.java.JavaCompilationUnitState;
+import org.openrewrite.java.testing.mockito.CleanupMockitoImports;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(4)
+public class CleanupMockitoImportsBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(CleanupMockitoImportsBenchmark.class.getSimpleName())
+                .addProfiler(GCProfiler.class)
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void cleanupMockitoImports(JavaCompilationUnitState state) {
+        new CleanupMockitoImports().run(state.getSourceFiles());
+    }
+
+}


### PR DESCRIPTION
Includes more benchmarking baselines for relative comparison. Pulled recipes based on grafana. Change however seen fit..

---

scratchpad notes for jmh parameter configuration in build.gradle.kts as per https://github.com/melix/jmh-gradle-plugin/blob/master/samples/simple-java/kotlin-dsl/build.gradle.kts just storing off notes
```
import me.champeau.jmh.JmhParameters

id("me.champeau.jmh") version "0.6.3"

configure<JmhParameters> {
    fork.set(1) // @Fork(1)
    iterations.set(2) // @Measurement(iterations = 2)
    warmupIterations.set(2) // @Warmup(iterations = 2)
//    benchmarkMode = listOf("SampleTime") // @BenchmarkMode(Mode.SampleTime)
//    timeUnit = "s" // @OutputTimeUnit(TimeUnit.SECONDS)
//    threads = 4 // @Threads(4)
//    duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
}
```