### PR TITLE
Recipe for upgrading okhttp3 3.x MockWebServer Rule to JUnit 5 compatible 4.x MockWebServer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,6 +118,7 @@ dependencies {
     testRuntimeOnly("org.mockito:mockito-all:$mockito1Version")
     testRuntimeOnly("org.hamcrest:hamcrest:latest.release")
     testRuntimeOnly("pl.pragmatists:JUnitParams:1.+")
+    testRuntimeOnly("com.squareup.okhttp3:mockwebserver:3.+")
 
     "beforeImplementation"("junit:junit:latest.release")
     "beforeImplementation"("org.mockito:mockito-core:$mockito1Version")

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
@@ -1,0 +1,144 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.search.FindTypes;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.RecipeSearchResult;
+import org.openrewrite.maven.UpgradeDependencyVersion;
+
+import java.util.Collections;
+import java.util.UUID;
+
+/**
+ * Recipe for converting JUnit4 okhttp3 MockWebServer Rules with their JUnit5 equivalent.
+ * Note this recipe upgrades okhttp3 to version 4.x there are a few backwards incompatible changes: https://square.github.io/okhttp/upgrading_to_okhttp_4/#backwards-incompatible-changes
+ * - If MockWebServer Rule exists remove the Rule annotation and update okhttp3 to version 4.x
+ * - If AfterEach method exists insert a close statement for the MockWebServer and throws for IOException
+ * - If AfterEach does not exist then insert new afterEachTest method closing MockWebServer
+ */
+public class UpdateMockWebServer extends Recipe {
+    private static final AnnotationMatcher RULE_MATCHER = new AnnotationMatcher("@org.junit.Rule");
+    private static final AnnotationMatcher AFTER_EACH_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.AfterEach");
+
+    private static final ThreadLocal<JavaParser> OKHTTP3_PARSER = ThreadLocal.withInitial(() ->
+            JavaParser.fromJavaVersion().dependsOn(Collections.singletonList(
+                    Parser.Input.fromString("package okhttp3.mockwebserver;" +
+                            "public final class MockWebServer extends java.io.Closeable {}"
+                    )
+            )).build());
+
+    @Override
+    public String getDisplayName() {
+        return "okhttp3 3.x MockWebserver @Rule To 4.x MockWebServer";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace usages of okhttp3 3.x @Rule MockWebServer with 4.x MockWebServer.";
+    }
+
+    @Override
+    protected @Nullable TreeVisitor<?, ExecutionContext> getApplicableTest() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
+                J.CompilationUnit c = super.visitCompilationUnit(cu, executionContext);
+                if (!FindTypes.find(cu, "org.junit.Rule").isEmpty()
+                        && !FindTypes.find(cu, "okhttp3.mockwebserver.MockWebServer").isEmpty()) {
+                    c = c.withMarker(new RecipeSearchResult(UpdateMockWebServer.this));
+                }
+                return c;
+            }
+        };
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private final static String MOCK_WEBSERVER_RULE = "mock-web-server-rule";
+            private final static String AFTER_EACH_METHOD = "after-each-method";
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+                String mockWebServerVarableName = getCursor().pollMessage(MOCK_WEBSERVER_RULE);
+                final J.MethodDeclaration afterEachMethod = getCursor().pollMessage(AFTER_EACH_METHOD);
+                if (mockWebServerVarableName != null) {
+                    if (afterEachMethod != null) {
+                        cd = maybeAutoFormat(cd, cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
+                            if (statement == afterEachMethod) {
+                                statement = statement.withTemplate(template(mockWebServerVarableName + ".close();")
+                                        .javaParser(OKHTTP3_PARSER.get()).build(), ((J.MethodDeclaration) statement).getBody()
+                                        .getCoordinates().lastStatement());
+
+                                if (((J.MethodDeclaration) statement).getThrows() == null || ((J.MethodDeclaration) statement).getThrows().stream()
+                                        .noneMatch(n -> TypeUtils.isOfClassType(n.getType(), "java.io.IOException"))) {
+                                    J.Identifier ioExceptionIdent = J.Identifier.build(UUID.randomUUID(),
+                                            Space.format(" "),
+                                            Markers.EMPTY,
+                                            "IOException",
+                                            JavaType.Class.build("java.io.IOException"));
+                                    statement = ((J.MethodDeclaration) statement).withThrows(ListUtils.concat(((J.MethodDeclaration) statement).getThrows(), ioExceptionIdent));
+                                    maybeAddImport("java.io.IOException");
+                                }
+
+                            }
+                            return statement;
+                        }))), executionContext);
+                    } else {
+                        String closeMethod = "@AfterEach void afterEachTest() throws IOException {" + mockWebServerVarableName + ".close();}";
+                        cd = maybeAutoFormat(cd, cd.withBody(cd.getBody().withTemplate(template(closeMethod)
+                                .imports("org.junit.jupiter.api.AfterEach", "okhttp3.mockwebserver", "java.io.IOException")
+                                .javaParser(OKHTTP3_PARSER.get()).build(), cd.getBody().getCoordinates().lastStatement())), executionContext);
+                        maybeAddImport("org.junit.jupiter.api.AfterEach");
+                        maybeAddImport("java.io.IOException");
+                    }
+                    maybeRemoveImport("org.junit.Rule");
+                    doAfterVisit(new UpgradeDependencyVersion("com.squareup.okhttp3", "mockwebserver", "4.X", null));
+                }
+                return cd;
+            }
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+                J.VariableDeclarations variableDeclarations = super.visitVariableDeclarations(multiVariable, executionContext);
+                JavaType.Class fieldType = variableDeclarations.getTypeAsClass();
+                if (TypeUtils.isOfClassType(fieldType, "okhttp3.mockwebserver.MockWebServer")) {
+                    variableDeclarations = variableDeclarations.withLeadingAnnotations(ListUtils.map(variableDeclarations.getLeadingAnnotations(), annotation -> {
+                        if (RULE_MATCHER.matches(annotation)) {
+                            return null;
+                        }
+                        return annotation;
+                    }));
+                }
+                if (multiVariable != variableDeclarations) {
+                    getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, MOCK_WEBSERVER_RULE, variableDeclarations.getVariables().get(0).getSimpleName());
+                }
+                return variableDeclarations;
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                J.MethodDeclaration md = super.visitMethodDeclaration(method, executionContext);
+                if (md.getLeadingAnnotations().stream().anyMatch(AFTER_EACH_MATCHER::matches)) {
+                    getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, AFTER_EACH_METHOD, md);
+                }
+                return md;
+            }
+        };
+
+
+    }
+}

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/UpdateMockWebServerTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/UpdateMockWebServerTest.kt
@@ -1,0 +1,79 @@
+package org.openrewrite.java.testing.junit5
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class UpdateMockWebServerTest : JavaRecipeTest {
+
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .classpath("junit", "mockwebserver")
+        .build()
+    override val recipe: Recipe
+        get() = UpdateMockWebServer()
+
+    @Test
+    fun mockWebServerRuleUpdated() = assertChanged(
+        before = """
+            import okhttp3.mockwebserver.MockWebServer;
+            import org.junit.Rule;
+            class A {
+                @Rule
+                public MockWebServer server = new MockWebServer();
+            }
+        """,
+        after = """
+            import okhttp3.mockwebserver.MockWebServer;
+            import org.junit.jupiter.api.AfterEach;
+        
+            import java.io.IOException;
+        
+            class A {
+            
+                public MockWebServer server = new MockWebServer();
+            
+                @AfterEach
+                void afterEachTest() throws IOException {
+                    server.close();
+                }
+            }
+        """
+    )
+
+    @Test
+    fun mockWebServerRuleUpdatedExistingAfterEachStatement() = assertChanged(
+        before = """
+            import okhttp3.mockwebserver.MockWebServer;
+            import org.junit.Rule;
+            import org.junit.jupiter.api.AfterEach;
+            
+            class A {
+                @Rule
+                public MockWebServer server = new MockWebServer();
+                
+                @AfterEach
+                void afterEachTest() {
+                    String s = "s";
+                }
+            }
+        """,
+        after = """
+            import okhttp3.mockwebserver.MockWebServer;
+            import org.junit.jupiter.api.AfterEach;
+            
+            import java.io.IOException;
+        
+            class A {
+            
+                public MockWebServer server = new MockWebServer();
+            
+                @AfterEach
+                void afterEachTest() throws IOException {
+                    String s = "s";
+                    server.close();
+                }
+            }
+        """
+    )
+}


### PR DESCRIPTION
Recipe for upgrading okhttp3 3.x MockWebServer Rule to JUnit 5 compatible 4.x MockWebServer - fixes #71 
    
If a MockWebServer Rule exists
- upgrade okhttp3 to 4.x
- remove the @Rule annotation
- close the server after each test via an '@AfterEach' annotated method.
 
Note on upgrading to [okhttp 4.x](https://square.github.io/okhttp/upgrading_to_okhttp_4/)
> OkHttp 4.x upgrades our implementation language from Java to Kotlin and keeps everything else the same. We’ve chosen Kotlin because it gives us powerful new capabilities while integrating closely with Java.
We spent a lot of time and energy on retaining strict compatibility with OkHttp 3.x. We’re even keeping the package name the same: okhttp3!

there are a few [backwards-incompatible-changes](https://square.github.io/okhttp/upgrading_to_okhttp_4/#backwards-incompatible-changes)