### PR TITLE
JUnit 4 to 5 TestCase migration recipe.

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class MigrateJUnitTestCase extends Recipe {
+
+    private static final String JUNIT_TEST_CASE_FQN = "junit.framework.TestCase";
+
+    private static final ThreadLocal<JavaParser> JAVA_PARSER_THREAD_LOCAL = ThreadLocal.withInitial(() ->
+            JavaParser.fromJavaVersion()
+                    .dependsOn(Collections.singletonList(Parser.Input.fromString(
+                            "package org.junit.jupiter.api;\n" +
+                                    "public @interface Test {}\n" +
+                                    "public @interface AfterEach {}\n" +
+                                    "public @interface BeforeEach {}")))
+                    .build());
+
+    @Override
+    public String getDisplayName() {
+        return "TestCase to Jupiter tests";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert JUnit TestCase to JUnit 5 Jupiter tests";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new TestCaseVisitor();
+    }
+
+    private static class TestCaseVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private static final JavaType.Class JUNIT_ASSERT_TYPE = JavaType.Class.build("org.junit.Assert");
+        private static final AnnotationMatcher OVERRIDE_ANNOTATION_MATCHER = new AnnotationMatcher("@java.lang.Override");
+        private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
+        private static final AnnotationMatcher BEFORE_EACH_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.BeforeEach");
+        private static final AnnotationMatcher AFTER_EACH_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.AfterEach");
+        private static final AnnotationMatcher JUNIT_BEFORE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.Before");
+        private static final AnnotationMatcher JUNIT_AFTER_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.After");
+        private static final AnnotationMatcher JUNIT_TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.Test");
+
+        private static final String TEST_CASE_MESSAGE_KEY = "junit-test-case";
+        private static final String OBJECT_FQN = "java.lang.Object";
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+            // Because TestCase extends Assert and assertions may be referenced from TestCase even if the class is not a TestCase
+            // it is necessary to add a cursor message stating that the class extends TestCase so the TestCase.Assert assertions can be processed
+            if (isSupertypeTestCase(classDecl.getType())) {
+                getCursor().putMessage(TEST_CASE_MESSAGE_KEY, Boolean.TRUE);
+            }
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
+            if (cd.getExtends() != null && cd.getExtends().getType() != null) {
+                JavaType.FullyQualified fullQualifiedExtension = TypeUtils.asFullyQualified(cd.getExtends().getType());
+                if (fullQualifiedExtension != null && JUNIT_TEST_CASE_FQN.equals(fullQualifiedExtension.getFullyQualifiedName())) {
+                    cd = cd.withExtends(null);
+                }
+            }
+            maybeRemoveImport(JUNIT_TEST_CASE_FQN);
+            return cd;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+            String name = mi.getSimpleName();
+            // setUp and tearDown will be invoked via Before and After annotations, setName is not convertible
+            if (("setUp".equals(name) || "tearDown".equals(name) || "setName".equals(name))
+                    && Boolean.TRUE.equals(getCursor().getNearestMessage(TEST_CASE_MESSAGE_KEY))) {
+                return null;
+            }
+            // Change TestCase.Assert types to JUnit 5 Assertions
+            else if (mi.getType() != null && mi.getType().getDeclaringType() != null
+                    && JUNIT_TEST_CASE_FQN.equals(mi.getType().getDeclaringType().getFullyQualifiedName())) {
+                mi = mi.withType(mi.getType().withDeclaringType(JUNIT_ASSERT_TYPE));
+                doAfterVisit(new AssertToAssertions.AssertToAssertionsVisitor());
+                maybeAddImport("org.junit.jupiter.api.Assertions", mi.getSimpleName());
+            }
+            return mi;
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+            J.MethodDeclaration md = super.visitMethodDeclaration(method, executionContext);
+            if (Boolean.TRUE.equals(getCursor().getNearestMessage(TEST_CASE_MESSAGE_KEY))) {
+                if (md.getSimpleName().startsWith("test")
+                        && !hasAnnotation(md.getLeadingAnnotations(), TEST_ANNOTATION_MATCHER, JUNIT_TEST_ANNOTATION_MATCHER)) {
+                    md = md.withTemplate(template("@Test")
+                                    .javaParser(JAVA_PARSER_THREAD_LOCAL.get())
+                                    .imports("org.junit.jupiter.api.Test").build(),
+                            md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+                    maybeAddImport("org.junit.jupiter.api.Test");
+                } else if (md.getSimpleName().equals("setUp")
+                        && !hasAnnotation(md.getLeadingAnnotations(), BEFORE_EACH_ANNOTATION_MATCHER, JUNIT_BEFORE_ANNOTATION_MATCHER)) {
+                    md = md.withTemplate(template("@BeforeEach")
+                                    .javaParser(JAVA_PARSER_THREAD_LOCAL.get())
+                                    .imports("org.junit.jupiter.api.BeforeEach").build(),
+                            md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+                    md = maybeAddPublicModifier(md);
+                    md = maybeRemoveOverrideAnnotation(md);
+                    maybeAddImport("org.junit.jupiter.api.BeforeEach");
+                } else if (md.getSimpleName().equals("tearDown")
+                        && !hasAnnotation(md.getLeadingAnnotations(), AFTER_EACH_ANNOTATION_MATCHER, JUNIT_AFTER_ANNOTATION_MATCHER)) {
+                    md = md.withTemplate(template("@AfterEach").javaParser(JAVA_PARSER_THREAD_LOCAL.get())
+                                    .imports("org.junit.jupiter.api.AfterEach").build(),
+                            md.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
+                    md = maybeAddPublicModifier(md);
+                    md = maybeRemoveOverrideAnnotation(md);
+                    maybeAddImport("org.junit.jupiter.api.AfterEach");
+                }
+            }
+            return md;
+        }
+
+        private boolean hasAnnotation(List<J.Annotation> annotationList, AnnotationMatcher... annotationMatchers) {
+            if (annotationList.isEmpty()) {
+                return false;
+            }
+            for (AnnotationMatcher annotationMatcher : annotationMatchers) {
+                if (annotationList.stream().filter(annotationMatcher::matches).findAny().isPresent()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private J.MethodDeclaration maybeAddPublicModifier(J.MethodDeclaration md) {
+            List<J.Modifier> modifiers = ListUtils.map(md.getModifiers(), modifier -> {
+                if (modifier.getType() == J.Modifier.Type.Protected) {
+                    return modifier.withType(J.Modifier.Type.Public);
+                } else {
+                    return modifier;
+                }
+            });
+            return md.withModifiers(modifiers);
+        }
+
+        private J.MethodDeclaration maybeRemoveOverrideAnnotation(J.MethodDeclaration md) {
+            return md.withLeadingAnnotations(ListUtils.map(md.getLeadingAnnotations(), annotation -> {
+                if (OVERRIDE_ANNOTATION_MATCHER.matches(annotation)) {
+                    return null;
+                }
+                return annotation;
+            }));
+        }
+
+        private boolean isSupertypeTestCase(@Nullable JavaType.Class javaTypeClass) {
+            if (javaTypeClass == null || javaTypeClass.getSupertype() == null || OBJECT_FQN.equals(javaTypeClass.getFullyQualifiedName())) {
+                return false;
+            }
+            JavaType.FullyQualified fqType = TypeUtils.asFullyQualified(javaTypeClass);
+            if (fqType != null && JUNIT_TEST_CASE_FQN.equals(fqType.getFullyQualifiedName())) {
+                return true;
+            }
+            return isSupertypeTestCase(javaTypeClass.getSupertype());
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -89,7 +89,7 @@ public class MigrateJUnitTestCase extends Recipe {
     }
 
     private static class TestCaseVisitor extends JavaIsoVisitor<ExecutionContext> {
-
+        private static final JavaType.Class JUNIT_ASSERT_TYPE = JavaType.Class.build("org.junit.Assert");
         private static final AnnotationMatcher OVERRIDE_ANNOTATION_MATCHER = new AnnotationMatcher("@java.lang.Override");
 
         @Override
@@ -115,6 +115,12 @@ public class MigrateJUnitTestCase extends Recipe {
             // setUp and tearDown will be invoked via Before and After annotations, setName is not convertible
             if ("setUp".equals(name) || "tearDown".equals(name) || "setName".equals(name)) {
                 return null;
+            }
+            // FIXME changing method type should not be necessary, yet the `convertTestCase` test fails due to missing imports
+            else if (mi.getType() != null && mi.getType().getDeclaringType() != null
+                    && JUNIT_TEST_CASE_FQN.equals(mi.getType().getDeclaringType().getFullyQualifiedName())) {
+                mi = mi.withType(mi.getType().withDeclaringType(JUNIT_ASSERT_TYPE));
+                maybeAddImport("org.junit.Assert", mi.getSimpleName());
             }
             return mi;
         }

--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -79,6 +79,7 @@ public class MigrateJUnitTestCase extends Recipe {
                 if (cu.getClasses().stream().findAny().isPresent()) {
                     doAfterVisit(new TestCaseVisitor());
                 }
+                doAfterVisit(new ChangeType("junit.framework.TestCase", "org.junit.Assert"));
                 doAfterVisit(new AssertToAssertions.AssertToAssertionsVisitor());
                 doAfterVisit(new UseStaticImport("org.junit.jupiter.api.Assertions assert*(..)"));
                 doAfterVisit(new UseStaticImport("org.junit.jupiter.api.Assertions fail*(..)"));
@@ -104,7 +105,6 @@ public class MigrateJUnitTestCase extends Recipe {
                 }
             }
             maybeRemoveImport(JUNIT_TEST_CASE_FQN);
-            doAfterVisit(new ChangeType("junit.framework.TestCase", "org.junit.Assert"));
             return cd;
         }
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -89,7 +89,6 @@ public class MigrateJUnitTestCase extends Recipe {
     }
 
     private static class TestCaseVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final JavaType.Class JUNIT_ASSERT_TYPE = JavaType.Class.build("org.junit.Assert");
         private static final AnnotationMatcher OVERRIDE_ANNOTATION_MATCHER = new AnnotationMatcher("@java.lang.Override");
 
         @Override
@@ -115,12 +114,6 @@ public class MigrateJUnitTestCase extends Recipe {
             // setUp and tearDown will be invoked via Before and After annotations, setName is not convertible
             if ("setUp".equals(name) || "tearDown".equals(name) || "setName".equals(name)) {
                 return null;
-            }
-            // FIXME changing method type should not be necessary, yet the `convertTestCase` test fails due to missing imports
-            else if (mi.getType() != null && mi.getType().getDeclaringType() != null
-                    && JUNIT_TEST_CASE_FQN.equals(mi.getType().getDeclaringType().getFullyQualifiedName())) {
-                mi = mi.withType(mi.getType().withDeclaringType(JUNIT_ASSERT_TYPE));
-                maybeAddImport("org.junit.Assert", mi.getSimpleName());
             }
             return mi;
         }

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -83,7 +83,6 @@ public class UpdateTestAnnotation extends Recipe {
     private static class UpdateTestAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
         private static final AnnotationMatcher JUNIT_4_TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.Test");
         private static final String JUNIT_4_TEST_ANNOTATION_ARGUMENTS = "junit4TestAnnotationArguments";
-        private static final JavaType.Class JUNIT_JUPITER_TEST = JavaType.Class.build("org.junit.jupiter.api.Test");
 
         @Override
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -126,6 +126,7 @@ tags:
   - junit
   - mockito
 recipeList:
+  - org.openrewrite.java.testing.mockito.Mockito1to3Migration
   - org.openrewrite.java.testing.junit5.RunnerToExtension:
       runners:
         - org.mockito.runners.MockitoJUnitRunner

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -63,6 +63,7 @@ recipeList:
   - org.openrewrite.java.testing.junit5.UseHamcrestAssertThat
   - org.openrewrite.java.testing.junit5.UseMockitoExtension
   - org.openrewrite.java.testing.junit5.UseTestMethodOrder
+  - org.openrewrite.java.testing.junit5.MigrateJUnitTestCase
   - org.openrewrite.java.testing.junit5.AssertToAssertions
   - org.openrewrite.java.testing.junit5.CategoryToTag
   - org.openrewrite.java.testing.junit5.CleanupJUnitImports

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/MigrateJunitTestCaseTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/MigrateJunitTestCaseTest.kt
@@ -172,6 +172,7 @@ class MigrateJunitTestCaseTest : JavaRecipeTest {
     fun notTestCaseHasTestCaseAssertion() = assertChanged(
         before = """
             import org.junit.Test;
+            
             import static junit.framework.TestCase.assertTrue;
             
             class AaTest {
@@ -186,6 +187,7 @@ class MigrateJunitTestCaseTest : JavaRecipeTest {
         """,
         after = """
             import org.junit.Test;
+            
             import static org.junit.jupiter.api.Assertions.assertTrue;
             
             class AaTest {

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/MigrateJunitTestCaseTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/MigrateJunitTestCaseTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class MigrateJunitTestCaseTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .classpath("junit")
+        .build()
+
+    override val recipe: Recipe
+        get() = MigrateJUnitTestCase()
+
+    @Test
+    fun convertTestCase() = assertChanged(
+        before = """
+            import junit.framework.TestCase;
+            
+            public class MathTest extends TestCase {
+                protected long value1;
+                protected long value2;
+            
+                @Override
+                protected void setUp() {
+                    super.setUp();
+                    value1 = 2;
+                    value2 = 3;
+                }
+            
+                public void testAdd() {
+                    setName("primitive test");
+                    long result = value1 + value2;
+                    assertEquals(5, result);
+                    fail("some Failure message");
+                }
+            
+                @Override
+                protected void tearDown() {
+                    super.tearDown();
+                    value1 = 0;
+                    value2 = 0;
+                }
+            }
+        """,
+        after = """
+            import org.junit.jupiter.api.AfterEach;
+            import org.junit.jupiter.api.BeforeEach;
+            import org.junit.jupiter.api.Test;
+            
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+            import static org.junit.jupiter.api.Assertions.fail;
+
+            public class MathTest {
+                protected long value1;
+                protected long value2;
+            
+                @BeforeEach
+                public void setUp() {
+                    value1 = 2;
+                    value2 = 3;
+                }
+            
+                @Test
+                public void testAdd() {
+                    long result = value1 + value2;
+                    assertEquals(5, result);
+                    fail("some Failure message");
+                }
+            
+                @AfterEach
+                public void tearDown() {
+                    value1 = 0;
+                    value2 = 0;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun convertExtendedTestCase() = assertChanged(
+        dependsOn = arrayOf(
+            """
+                package com.abc;
+                import junit.framework.TestCase;
+                public abstract class CTest extends TestCase {
+                    @Override
+                    public void setUp() {}
+                    
+                    @Override
+                    public void tearDown() {}
+                }
+            """
+        ),
+        before = """
+            package com.abc;
+            import com.abc.CTest;
+            import static org.junit.Assert.assertEquals;
+            public class MathTest extends CTest {
+                protected long value1;
+                protected long value2;
+            
+                @Override
+                protected void setUp() {
+                    value1 = 2;
+                    value2 = 3;
+                }
+            
+                public void testAdd() {
+                    long result = value1 + value2;
+                    assertEquals(5, result);
+                }
+            
+                @Override
+                protected void tearDown() {
+                    value1 = 0;
+                    value2 = 0;
+                }
+            }
+        """,
+        after = """
+            package com.abc;
+            import com.abc.CTest;
+            import org.junit.jupiter.api.AfterEach;
+            import org.junit.jupiter.api.BeforeEach;
+            import org.junit.jupiter.api.Test;
+            
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class MathTest extends CTest {
+                protected long value1;
+                protected long value2;
+            
+                @BeforeEach
+                public void setUp() {
+                    value1 = 2;
+                    value2 = 3;
+                }
+            
+                @Test
+                public void testAdd() {
+                    long result = value1 + value2;
+                    assertEquals(5, result);
+                }
+            
+                @AfterEach
+                public void tearDown() {
+                    value1 = 0;
+                    value2 = 0;
+                }
+            }
+        """
+    )
+
+    @Test
+    fun notTestCaseHasTestCaseAssertion() = assertChanged(
+        before = """
+            import org.junit.Test;
+            import static junit.framework.TestCase.assertTrue;
+            
+            class AaTest {
+                @Test
+                public void someTest() {
+                    assertTrue("assert message", isSameStuff("stuff"));
+                }
+                private boolean isSameStuff(String stuff) {
+                    return "stuff".equals(stuff);
+                }
+            }
+        """,
+        after = """
+            import org.junit.Test;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
+            
+            class AaTest {
+                @Test
+                public void someTest() {
+                    assertTrue(isSameStuff("stuff"), "assert message");
+                }
+                private boolean isSameStuff(String stuff) {
+                    return "stuff".equals(stuff);
+                }
+            }
+        """
+    )
+
+    @Test
+    fun notTestCase() = assertUnchanged(
+        before = """
+            import org.junit.Test;
+            class AaTest {
+                @Test(expected = NumberFormatException.class)
+                public void testSomeNumberStuff() {
+                    Double n = Double.valueOf("a");
+                }
+            }
+        """
+    )
+}

--- a/src/test/kotlin/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.kt
@@ -358,13 +358,13 @@ class JunitMockitoUpgradeIntegrationTest : JavaRecipeTest {
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-api</artifactId>
-                        <version>5.7.1</version>
+                        <version>5.7.2</version>
                         <scope>test</scope>
                     </dependency>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>
                         <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.7.1</version>
+                        <version>5.7.2</version>
                         <scope>test</scope>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
JUnit 4 to 5 migration recipe for junit.framework.TestCase.  Fixes #78 