### PR TITLE
Fix expected exception expect exception message string

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -170,17 +170,19 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 }
             }
 
+            String exceptionDeclParam = ((isExpectArgAMatcher || isExpectMessageArgAMatcher || isExpectedCauseArgAMatcher)
+                    || expectMessageMethodInvocation != null) ?
+                    "Throwable exception =" : "";
+
             Object expectedExceptionParam = (expectMethodInvocation == null || isExpectArgAMatcher) ?
                     "Exception.class" : expectMethodInvocation.getArguments().get(0);
-
-            String exceptionDeclParam = ((isExpectArgAMatcher || isExpectMessageArgAMatcher || isExpectedCauseArgAMatcher) || expectMessageMethodInvocation != null) ? "Throwable exception =" : "";
 
             String templateString = expectedExceptionParam instanceof String ? "#{} assertThrows(#{}, () -> #{});" : "#{} assertThrows(#{any()}, () -> #{});";
 
             m = m.withTemplate(
                     template(templateString)
                             .javaParser(ASSERTIONS_PARSER::get)
-                            .staticImports("org.junit.jupiter.api.Assertions.assertThrows", "org.junit.jupiter.api.Assertions.assertTrue")
+                            .staticImports("org.junit.jupiter.api.Assertions.assertThrows")
                             .build(),
                     m.getCoordinates().replaceBody(),
                     exceptionDeclParam,
@@ -190,11 +192,11 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
 
             maybeAddImport("org.junit.jupiter.api.Assertions", "assertThrows");
 
-            if (expectMessageMethodInvocation != null && !isExpectMessageArgAMatcher) {
+            if (expectMessageMethodInvocation != null && !isExpectMessageArgAMatcher && m.getBody() != null) {
                 m = m.withTemplate(
                         template("assertTrue(exception.getMessage().contains(#{any(java.lang.String)});")
                                 .javaParser(ASSERTIONS_PARSER::get)
-                                .staticImports("org.junit.jupiter.api.Assertions.assertThrows", "org.junit.jupiter.api.Assertions.assertTrue")
+                                .staticImports("org.junit.jupiter.api.Assertions.assertTrue")
                                 .build(),
                         m.getBody().getCoordinates().lastStatement(),
                         expectMessageMethodInvocation.getArguments().get(0)

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -173,9 +173,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             Object expectedExceptionParam = (expectMethodInvocation == null || isExpectArgAMatcher) ?
                     "Exception.class" : expectMethodInvocation.getArguments().get(0);
 
-            String exceptionDeclParam = (isExpectArgAMatcher || isExpectMessageArgAMatcher || isExpectedCauseArgAMatcher) ?
-                    "Exception exception =" : "Throwable exception =";
-
+            String exceptionDeclParam = ((isExpectArgAMatcher || isExpectMessageArgAMatcher || isExpectedCauseArgAMatcher) || expectMessageMethodInvocation != null) ? "Throwable exception =" : "";
 
             String templateString = expectedExceptionParam instanceof String ? "#{} assertThrows(#{}, () -> #{});" : "#{} assertThrows(#{any()}, () -> #{});";
 

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.kt
@@ -111,7 +111,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class SimpleExpectedExceptionTest {
             
                 public void throwsExceptionWithSpecificType() {
-                    Throwable exception = assertThrows(NullPointerException.class, () -> {
+                    assertThrows(NullPointerException.class, () -> {
                         throw new NullPointerException();
                     });
                 }
@@ -150,7 +150,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class SimpleExpectedExceptionTest {
             
                 public void throwsExceptionWithSpecificType() {
-                    Exception exception = assertThrows(Exception.class, () -> {
+                    Throwable exception = assertThrows(Exception.class, () -> {
                         throw new NullPointerException();
                     });
                     assertThat(exception, isA(NullPointerException.class));
@@ -230,7 +230,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class ExampleTests {
             
                 public void expectMessageWithMatcher() {
-                    Exception exception = assertThrows(Exception.class, () -> {
+                    Throwable exception = assertThrows(Exception.class, () -> {
                         throw new NullPointerException("rewrite expectMessage with hamcrest matcher.");
                     });
                     assertThat(exception.getMessage(), containsString("rewrite expectMessage"));
@@ -270,7 +270,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class ExampleTests {
             
                 public void expectCause() {
-                    Exception exception = assertThrows(Exception.class, () -> {
+                    Throwable exception = assertThrows(Exception.class, () -> {
                         throw new NullPointerException("rewrite expectMessage with hamcrest matcher.");
                     });
                     assertThat(exception.getCause(), nullValue());
@@ -312,7 +312,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class ExampleTests {
             
                 public void expectExceptionUseCases() {
-                    Exception exception = assertThrows(Exception.class, () -> {
+                    Throwable exception = assertThrows(Exception.class, () -> {
                         throw new NullPointerException("rewrite expectMessage with hamcrest matcher.");
                     });
                     assertThat(exception, isA(NullPointerException.class));

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.kt
@@ -111,7 +111,7 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             public class SimpleExpectedExceptionTest {
             
                 public void throwsExceptionWithSpecificType() {
-                    assertThrows(NullPointerException.class, () -> {
+                    Throwable exception = assertThrows(NullPointerException.class, () -> {
                         throw new NullPointerException();
                     });
                 }
@@ -184,14 +184,16 @@ class ExpectedExceptionToAssertThrowsTest : JavaRecipeTest {
             package org.openrewrite.java.testing.junit5;
             
             import static org.junit.jupiter.api.Assertions.assertThrows;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
             
             public class SimpleExpectedExceptionTest {
             
                 public void statementsBeforeExpected() {
-                    assertThrows(IndexOutOfBoundsException.class, () -> {
+                    Throwable exception = assertThrows(IndexOutOfBoundsException.class, () -> {
                         int[] a = new int[]{1};
                         int b = a[1];
-                    }, "Index 1 out of bounds for length 1");
+                    });
+                    assertTrue(exception.getMessage().contains("Index 1 out of bounds for length 1"));
                 }
             }
         """


### PR DESCRIPTION
ExpectedExceptionToAssertThrows asserts the expected message string. Fixes #153

@skingsland, thanks again for identifying this issue.  The solution is slightly different from your suggestion because the `AssertToAssertions` does not assume AssertJ is on the classpath.

```java
public void statementsBeforeExpected() {
    Throwable exception = assertThrows(IndexOutOfBoundsException.class, () -> {
        int[] a = new int[]{1};
        int b = a[1];
    });
    assertTrue(exception.getMessage().contains("Index 1 out of bounds for length 1"));
}
```