### PR TITLE
Added EnclosedToNested recipe for JUnit4 to JUnit5 migration

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.format.AutoFormat;
+import org.openrewrite.java.format.AutoFormatVisitor;
+import org.openrewrite.java.search.FindAnnotations;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+
+import static org.openrewrite.Parser.Input.fromString;
+
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class EnclosedToNested extends Recipe {
+    private static final String ENCLOSED = "org.junit.experimental.runners.Enclosed";
+    private static final String RUN_WITH = "org.junit.runner.RunWith";
+    private static final String NESTED = "org.junit.jupiter.api.Nested";
+    private static final String TEST_JUNIT4 = "org.junit.Test";
+    private static final String TEST_JUNIT_JUPITER = "org.junit.jupiter.api.Test";
+
+    @Override
+    public String getDisplayName() {
+        return "JUnit 4 `@RunWith(Enclosed.class)` to JUnit Jupiter `@Nested`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes the `Enclosed` specification from a class, and adds `Nested` to its inner classes";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>(ENCLOSED);
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(5);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @SuppressWarnings("ConstantConditions")
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                final Set<J.Annotation> runWithEnclosedAnnotationSet = FindAnnotations.find(cd.withBody(null),
+                        String.format("@%s(%s.class)", RUN_WITH, ENCLOSED));
+                for (J.Annotation runWithEnclosed : runWithEnclosedAnnotationSet) {
+                    cd.getLeadingAnnotations().remove(runWithEnclosed);
+                    cd = cd.withBody((J.Block) new AddNestedAnnotationVisitor().visit(cd.getBody(), ctx, getCursor()));
+
+                    maybeRemoveImport(ENCLOSED);
+                    maybeRemoveImport(RUN_WITH);
+                    maybeAddImport(NESTED);
+                }
+                return cd;
+            }
+        };
+    }
+
+    public static class AddNestedAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+            if (hasTestMethods(cd)) {
+                cd = cd.withTemplate(getNestedJavaTemplate(), cd.getCoordinates().addAnnotation(Comparator.comparing(
+                        J.Annotation::getSimpleName)));
+                cd.getModifiers().removeIf(modifier -> modifier.getType().equals(J.Modifier.Type.Static));
+            }
+            return cd;
+        }
+
+        @NotNull
+        private JavaTemplate getNestedJavaTemplate() {
+            return JavaTemplate.builder(this::getCursor, "@Nested")
+                    .javaParser(() -> JavaParser.fromJavaVersion().dependsOn(Collections.singletonList(
+                            fromString("package org.junit.jupiter.api;\npublic @interface Nested {}"))).build())
+                    .imports(NESTED).build();
+        }
+
+        private boolean hasTestMethods(final J.ClassDeclaration cd) {
+            return !FindAnnotations.find(cd, "@" + TEST_JUNIT4).isEmpty()
+                    || !FindAnnotations.find(cd, "@" + TEST_JUNIT_JUPITER).isEmpty();
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -80,6 +80,7 @@ recipeList:
   - org.openrewrite.java.testing.junit5.ExpectedExceptionToAssertThrows
   - org.openrewrite.java.testing.junit5.UpdateMockWebServer
   - org.openrewrite.java.testing.junit5.VertxUnitToVertxJunit5
+  - org.openrewrite.java.testing.junit5.EnclosedToNested
   - org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed
   - org.openrewrite.maven.RemoveDependency:
       groupId: junit

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.kt
@@ -1,0 +1,163 @@
+package org.openrewrite.java.testing.junit5
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.java.JavaParser
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
+
+class EnclosedToNestedTest : RewriteTest {
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(EnclosedToNested())
+            .parser(JavaParser.fromJavaVersion().classpath("junit").logCompilationWarningsAndErrors(true).build())
+    }
+
+    @Test
+    fun `one inner class`() = rewriteRun(java(
+        """
+        import org.junit.Test;
+        import org.junit.experimental.runners.Enclosed;
+        import org.junit.runner.RunWith;
+        
+        @RunWith(Enclosed.class)
+        public class RootTest {
+            public static class InnerTest {
+                @Test
+                public void test() {}
+            }
+        }
+    """.trimIndent(), """
+        import org.junit.Test;
+        import org.junit.jupiter.api.Nested;
+        
+        
+        
+        public class RootTest {
+            @Nested
+            public class InnerTest {
+                @Test
+                public void test() {}
+            }
+        }
+    """.trimIndent()
+    ))
+
+    @Test
+    fun `multiple inner classes`() = rewriteRun(java(
+        """
+        import org.junit.Test;
+        import org.junit.experimental.runners.Enclosed;
+        import org.junit.runner.RunWith;
+        
+        @RunWith(Enclosed.class)
+        public class RootTest {
+            public static class InnerTest {
+                @Test
+                public void test() {}
+            }
+            
+            public static class Inner2Test {
+                @Test
+                public void test() {}
+        
+                public static class InnermostTest {
+                    @Test
+                    public void test() {}
+                }
+            }
+        }
+    """.trimIndent(), """
+        import org.junit.Test;
+        import org.junit.jupiter.api.Nested;
+        
+        
+        
+        public class RootTest {
+            @Nested
+            public class InnerTest {
+                @Test
+                public void test() {}
+            }
+        
+            @Nested
+            public class Inner2Test {
+                @Test
+                public void test() {}
+        
+                @Nested
+                public class InnermostTest {
+                    @Test
+                    public void test() {}
+                }
+            }
+        }
+    """.trimIndent()
+    ))
+
+    @Test
+    fun `recognizes test annotation with arguments`() = rewriteRun(java(
+        """
+        import org.junit.Test;
+        import org.junit.experimental.runners.Enclosed;
+        import org.junit.runner.RunWith;
+        
+        @RunWith(Enclosed.class)
+        public class RootTest {
+            public static class InnerTest {
+                @Test(timeout = 10)
+                public void test() {}
+            }
+        }
+    """.trimIndent(), """
+        import org.junit.Test;
+        import org.junit.jupiter.api.Nested;
+        
+        
+        
+        public class RootTest {
+            @Nested
+            public class InnerTest {
+                @Test(timeout = 10)
+                public void test() {}
+            }
+        }
+    """.trimIndent()
+    ))
+
+    @Test
+    fun `does not annotate non-test inner class`() = rewriteRun(java(
+        """
+        import org.junit.Test;
+        import org.junit.experimental.runners.Enclosed;
+        import org.junit.runner.RunWith;
+        
+        @RunWith(Enclosed.class)
+        public class RootTest {
+            public static class InnerTest {
+                @Test
+                public void test() {}
+            }
+            
+            public static class Foo {
+                public void bar() {}
+            }
+        }
+    """.trimIndent(), """
+        import org.junit.Test;
+        import org.junit.jupiter.api.Nested;
+        
+        
+        
+        public class RootTest {
+            @Nested
+            public class InnerTest {
+                @Test
+                public void test() {}
+            }
+            
+            public static class Foo {
+                public void bar() {}
+            }
+        }
+    """.trimIndent()
+    ))
+}


### PR DESCRIPTION
Couple caveats:
* The test case expectations have some extraneous whitespace, tied to this issue here: https://github.com/openrewrite/rewrite/issues/1912
* I expect the full test suite will throw some "Unable to construct Java11Parser" exceptions, same as #232, but on my local those are the *only* test failures