### PR TITLE
Only replace assertTrue(x.equals(...)) if equals has a single argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build/
 .gradle/
 out/
 .idea/
+.classpath
+.project
+.settings/
+bin/

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
@@ -102,7 +102,8 @@ public class AssertTrueEqualsToAssertEquals extends Recipe {
 
                J.MethodInvocation methodInvocation = getMethodInvocation(expr);
 
-               return "equals".equals(methodInvocation.getName().getSimpleName());
+               return "equals".equals(methodInvocation.getName().getSimpleName())
+                      && methodInvocation.getArguments().size() == 1;
 
             }
         };

--- a/src/test/kotlin/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.kt
@@ -85,7 +85,6 @@ class AssertTrueEqualsToAssertEqualsTest : JavaRecipeTest {
         """)
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/238")
-
     @Test
     fun retainArraysEquals() = assertUnchanged(
         before = """

--- a/src/test/kotlin/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.kt
@@ -21,7 +21,7 @@ import org.openrewrite.Recipe
 import org.openrewrite.java.JavaParser
 import org.openrewrite.java.JavaRecipeTest
 
-class AssertTrueEqualToAssertEqualsTest : JavaRecipeTest {
+class AssertTrueEqualsToAssertEqualsTest : JavaRecipeTest {
     override val parser: JavaParser = JavaParser.fromJavaVersion()
         .logCompilationWarningsAndErrors(true)
         .classpath("junit-jupiter-api")
@@ -55,8 +55,7 @@ class AssertTrueEqualToAssertEqualsTest : JavaRecipeTest {
                     assertEquals(a, b);
                 }
             }
-        """,
-    )
+        """)
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/206")
     @Suppress("ConstantConditions", "SimplifiableAssertion")
@@ -83,6 +82,22 @@ class AssertTrueEqualToAssertEqualsTest : JavaRecipeTest {
                     Assertions.assertEquals(a, b);
                 }
             }
-        """,
-    )
+        """)
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/238")
+
+    @Test
+    fun retainArraysEquals() = assertUnchanged(
+        before = """
+            import java.util.Arrays;
+            import org.junit.jupiter.api.Assertions;
+            
+            public class Test {
+                void test() {
+                    int[] a = {1, 2, 3};
+                    int[] b = {1, 2, 3};
+                    Assertions.assertTrue(Arrays.equals(a, b));
+                }
+            }
+        """)
 }


### PR DESCRIPTION
Fixes #238 