### PR TITLE
fix: Avoid reserved keywords when stripping prefix from test methods

### DIFF
--- a/src/test/kotlin/org/openrewrite/java/testing/cleanup/RemoveTestPrefixTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/cleanup/RemoveTestPrefixTest.kt
@@ -127,6 +127,45 @@ class RemoveTestPrefixTest : JavaRecipeTest {
     )
 
     @Test
+    fun ignoreKeyword() = assertUnchanged(
+            before = """
+            import org.junit.jupiter.api.Test;
+
+            class ATest {
+                @Test
+                void testSwitch() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreNull() = assertUnchanged(
+            before = """
+            import org.junit.jupiter.api.Test;
+
+            class ATest {
+                @Test
+                void testNull() {
+                }
+            }
+        """
+    )
+
+    @Test
+    fun ignoreUnderscore() = assertUnchanged(
+            before = """
+            import org.junit.jupiter.api.Test;
+
+            class ATest {
+                @Test
+                void test_() {
+                }
+            }
+        """
+    )
+
+    @Test
     fun ignoreNotAnnotatedMethods() = assertUnchanged(
             before = """
             class ATest {


### PR DESCRIPTION
Fixes #234. Not clear to me if meta annotations are immediately supported. Some insight or guidance there appreciated!