### PR TITLE
Do not strip prefix when remainder results in methods such as toString()

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveTestPrefix.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveTestPrefix.java
@@ -39,7 +39,9 @@ public class RemoveTestPrefix extends Recipe {
             "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum",
             "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final",
             "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float",
-            "native", "super", "while", "null");
+            "native", "super", "while",
+            // Non keywords that still result in an error
+            "null", "clone", "equals", "finalize", "hashCode", "notify", "notifyAll", "toString", "wait");
 
     @Override
     public String getDisplayName() {

--- a/src/test/kotlin/org/openrewrite/java/testing/cleanup/RemoveTestPrefixTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/cleanup/RemoveTestPrefixTest.kt
@@ -174,4 +174,17 @@ class RemoveTestPrefixTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun ignoreToString() = assertUnchanged(
+            before = """
+            import org.junit.jupiter.api.Test;
+
+            class ATest {
+                @Test
+                void testToString() {
+                }
+            }
+        """
+    )
 }


### PR DESCRIPTION
Came across this when migrating a large repository; potential source of errors to avoid.