### PR TITLE
Improved JUnit AssertToAssertions behavior with missing type info

### DIFF
--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.kt
@@ -346,4 +346,27 @@ class AssertToAssertionsTest : JavaRecipeTest {
             }
         """
     )
+
+    @Test
+    fun preservesWildcardImport() = assertChanged(
+        before = """
+            import static org.junit.Assert.*;
+            
+            class A {
+                void test() {
+                    assertNotNull(UnknownType.unknownMethod());
+                }
+            }
+        """,
+        after = """
+            import static org.junit.jupiter.api.Assertions.*;
+        
+            class A {
+                void test() {
+                    assertNotNull(UnknownType.unknownMethod());
+                }
+            }
+        """,
+        typeValidation =  { methodInvocations = false; identifiers = false; }
+    )
 }

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.kt
@@ -369,4 +369,30 @@ class AssertToAssertionsTest : JavaRecipeTest {
         """,
         typeValidation =  { methodInvocations = false; identifiers = false; }
     )
+
+    // The retained org.junit.Assert import is not ideal,
+    // but if this recipe is invoked within JUnit4to5Migration, then it gets removed by CleanupJUnitImports
+    @Test
+    fun migratesAssertStatementsWithMissingTypeInfo() = assertChanged(
+        before = """
+            import static org.junit.Assert.assertNotNull;
+            
+            class A {
+                void test() {
+                    assertNotNull(UnknownType.unknownMethod());
+                }
+            }
+        """,
+        after = """
+            import static org.junit.Assert.assertNotNull;
+            import static org.junit.jupiter.api.Assertions.assertNotNull;
+        
+            class A {
+                void test() {
+                    assertNotNull(UnknownType.unknownMethod());
+                }
+            }
+        """,
+        typeValidation =  { methodInvocations = false; identifiers = false; }
+    )
 }


### PR DESCRIPTION
Depends on https://github.com/openrewrite/rewrite/pull/2160

Apps which use Lombok are especially vulnerable to issues with the JUnit4 to 5 Migration recipe, as they commonly use Lombok-generated getters within `assert` statements, which breaks type information for the whole line and causes those `assert` invocations to "hide" from the recipe.

This PR improves the migration's resiliency in those cases by allowing matching on unknown types.