### PR TITLE
Add LifecycleNonPrivate for JUnit 5.9.0 (#241)

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/LifecycleNonPrivate.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/LifecycleNonPrivate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.MethodDeclaration;
+import org.openrewrite.java.tree.J.Modifier.Type;
+import org.openrewrite.java.tree.JavaSourceFile;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+public class LifecycleNonPrivate extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Make lifecycle methods non private";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Make JUnit 5's `@AfterAll`, `@AfterEach`, `@BeforeAll` and `@BeforeEach` non private.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitJavaSourceFile(JavaSourceFile cu, ExecutionContext executionContext) {
+                doAfterVisit(new UsesType<>("org.junit.jupiter.api.AfterAll"));
+                doAfterVisit(new UsesType<>("org.junit.jupiter.api.AfterEach"));
+                doAfterVisit(new UsesType<>("org.junit.jupiter.api.BeforeAll"));
+                doAfterVisit(new UsesType<>("org.junit.jupiter.api.BeforeEach"));
+                return cu;
+            }
+        };
+    }
+
+    @Override
+    protected LifecycleNonPrivateVisitor getVisitor() {
+        return new LifecycleNonPrivateVisitor();
+    }
+
+    private static class LifecycleNonPrivateVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J visitMethodDeclaration(MethodDeclaration method, ExecutionContext p) {
+            J.MethodDeclaration md = (MethodDeclaration) super.visitMethodDeclaration(method, p);
+            if (md.getModifiers().stream().anyMatch(mod -> mod.getType() == Type.Private)) {
+                return md
+                        .withModifiers(md.getModifiers().stream()
+                        .filter(mod -> mod.getType() != Type.Private)
+                        .collect(Collectors.toList()));
+            }
+            return md;
+        }
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/TempDirNonFinal.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TempDirNonFinal.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.Modifier.Type;
+
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+public class TempDirNonFinal extends Recipe {
+
+    private static final AnnotationMatcher TEMPDIR_ANNOTATION_MATCHER = new AnnotationMatcher(
+            "@org.junit.jupiter.api.io.TempDir");
+
+    @Override
+    public String getDisplayName() {
+        return "Make `@TempDir` fields non final";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Make JUnit 5's `org.junit.jupiter.api.io.TempDir` fields non final.";
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>("org.junit.jupiter.api.io.TempDir");
+    }
+
+    @Override
+    protected TempDirVisitor getVisitor() {
+        return new TempDirVisitor();
+    }
+
+    private static class TempDirVisitor extends JavaVisitor<ExecutionContext> {
+        @Override
+        public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+            J.VariableDeclarations mv = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable,
+                    executionContext);
+            if (mv.getLeadingAnnotations().stream().anyMatch(TEMPDIR_ANNOTATION_MATCHER::matches)
+                    && mv.getModifiers().stream().anyMatch(mod -> mod.getType() == Type.Final)) {
+                return mv.withModifiers(mv.getModifiers().stream()
+                        .filter(mod -> mod.getType() != Type.Final)
+                        .collect(Collectors.toList()));
+            }
+            return mv;
+        }
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+}

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -70,6 +70,7 @@ recipeList:
   - org.openrewrite.java.testing.junit5.CategoryToTag
   - org.openrewrite.java.testing.junit5.CleanupJUnitImports
   - org.openrewrite.java.testing.junit5.TemporaryFolderToTempDir
+  - org.openrewrite.java.testing.junit5.TempDirNonFinal
   - org.openrewrite.java.testing.junit5.TestRuleToTestInfo
   - org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations
   - org.openrewrite.java.testing.junit5.UpdateTestAnnotation

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -73,6 +73,7 @@ recipeList:
   - org.openrewrite.java.testing.junit5.TempDirNonFinal
   - org.openrewrite.java.testing.junit5.TestRuleToTestInfo
   - org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations
+  - org.openrewrite.java.testing.junit5.LifecycleNonPrivate
   - org.openrewrite.java.testing.junit5.UpdateTestAnnotation
   - org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized
   - org.openrewrite.java.testing.junit5.JUnitParamsRunnerToParameterized

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
@@ -39,6 +39,8 @@ class LifecycleNonPrivateTest : JavaRecipeTest {
                 @BeforeEach
                 private void beforeEach() {
                 }
+                private void unaffected() {
+                }
             }
         """,
         after = """
@@ -48,19 +50,53 @@ class LifecycleNonPrivateTest : JavaRecipeTest {
                 @BeforeEach
                 void beforeEach() {
                 }
+                private void unaffected() {
+                }
             }
         """
     )
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun beforeEachUnchanged() = assertUnchanged(
+    fun afterAllPrivate() = assertChanged(
+        before = """
+            import org.junit.jupiter.api.AfterAll;
+            
+            class A {
+                @AfterAll
+                private static void afterAll() {
+                }
+                private void unaffected() {
+                }
+            }
+        """,
+        after = """
+            import org.junit.jupiter.api.AfterAll;
+            
+            class A {
+                @AfterAll
+                static void afterAll() {
+                }
+                private void unaffected() {
+                }
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun beforeEachAfterAllUnchanged() = assertUnchanged(
         before = """
             import org.junit.jupiter.api.BeforeEach;
             
             class A {
                 @BeforeEach
                 void beforeEach() {
+                }
+                @AfterAll
+                static void afterAll() {
+                }
+                private void unaffected() {
                 }
             }
         """

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class LifecycleNonPrivateTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .classpath("junit")
+        .build()
+
+    override val recipe: Recipe
+        get() = LifecycleNonPrivate()
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun beforeEachPrivate() = assertChanged(
+        before = """
+            import org.junit.jupiter.api.BeforeEach;
+            
+            class A {
+                @BeforeEach
+                private void beforeEach() {
+                }
+            }
+        """,
+        after = """
+            import org.junit.jupiter.api.BeforeEach;
+            
+            class A {
+                @BeforeEach
+                void beforeEach() {
+                }
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun beforeEachUnchanged() = assertUnchanged(
+        before = """
+            import org.junit.jupiter.api.BeforeEach;
+            
+            class A {
+                @BeforeEach
+                void beforeEach() {
+                }
+            }
+        """
+    )
+}

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/LifecycleNonPrivateTest.kt
@@ -87,6 +87,7 @@ class LifecycleNonPrivateTest : JavaRecipeTest {
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
     fun beforeEachAfterAllUnchanged() = assertUnchanged(
         before = """
+            import org.junit.jupiter.api.AfterAll;
             import org.junit.jupiter.api.BeforeEach;
             
             class A {

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5
+
+import org.junit.jupiter.api.Test
+import org.openrewrite.Issue
+import org.openrewrite.Recipe
+import org.openrewrite.java.JavaParser
+import org.openrewrite.java.JavaRecipeTest
+
+class TempDirNonFinalTest : JavaRecipeTest {
+    override val parser: JavaParser = JavaParser.fromJavaVersion()
+        .classpath("junit")
+        .build()
+
+    override val recipe: Recipe
+        get() = TempDirNonFinal()
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun tempDirStaticFinalFile() = assertChanged(
+        before = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.io.File;
+            
+            class A {
+                @TempDir
+                static final File tempDir;
+            }
+        """,
+        after = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.io.File;
+            
+            class A {
+                @TempDir
+                static File tempDir;
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun tempDirStaticFinalPath() = assertChanged(
+        before = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.nio.file.Path;
+            
+            class A {
+                @TempDir
+                static final Path tempDir;
+            }
+        """,
+        after = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.nio.file.Path;
+            
+            class A {
+                @TempDir
+                static Path tempDir;
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun tempDirFileParameter() = assertUnchanged(
+        before = """
+            import org.junit.jupiter.api.Test
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.nio.file.Path;
+            
+            class A {
+                @Test
+                void fileTest(@TempDir File tempDir) {
+                }
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun tempDirStaticFile() = assertUnchanged(
+        before = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.io.File;
+            
+            class A {
+                @TempDir
+                static File tempDir;
+            }
+        """
+    )
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    fun tempDirStaticPath() = assertUnchanged(
+        before = """
+            import org.junit.jupiter.api.io.TempDir;
+            
+            import java.nio.file.Path;
+            
+            class A {
+                @TempDir
+                static Path tempDir;
+            }
+        """
+    )
+}


### PR DESCRIPTION
Could I get some guidance on how to get the desired whitespace to work?
All attempts I did with Space so far made things worse. :)

```java
org.opentest4j.AssertionFailedError: 
expected: 
  "import org.junit.jupiter.api.BeforeEach;
  
  class A {
      @BeforeEach
      void beforeEach() {
      }
  }"
 but was: 
  "import org.junit.jupiter.api.BeforeEach;
  
  class A {
      @BeforeEach void beforeEach() {
      }
  }"
```