### PR TITLE
RewriteTest for TempDir and cleanup unused imports & deprecations

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEquals.java
@@ -23,7 +23,6 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
-import java.util.List;
 import java.util.function.Supplier;
 
 public class AssertTrueComparisonToAssertEquals extends Recipe {
@@ -83,11 +82,6 @@ public class AssertTrueComparisonToAssertEquals extends Recipe {
 
                 }
                 return super.visitMethodInvocation(method, ctx);
-            }
-
-            private J.MethodInvocation getMethodInvocation(Expression expr){
-                List<J> s = expr.getSideEffects();
-                return  ((J.MethodInvocation) s.get(0));
             }
 
             private boolean isEqualBinary(J.MethodInvocation method) {

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNegationToAssertFalse.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNegationToAssertFalse.java
@@ -17,13 +17,9 @@ package org.openrewrite.java.testing.cleanup;
 
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
-import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 
-import java.util.List;
 import java.util.function.Supplier;
 
 public class AssertTrueNegationToAssertFalse extends Recipe {

--- a/src/main/java/org/openrewrite/java/testing/junit5/CategoryToTag.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CategoryToTag.java
@@ -60,7 +60,7 @@ public class CategoryToTag extends Recipe {
     }
 
     public static class CategoryToTagVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final JavaType.Class tagType = JavaType.Class.build("org.junit.jupiter.api.Tag");
+        private static final JavaType.Class tagType = JavaType.ShallowClass.build("org.junit.jupiter.api.Tag");
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
@@ -24,12 +24,9 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.format.AutoFormat;
-import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -72,7 +72,7 @@ public class MigrateJUnitTestCase extends Recipe {
             @Override
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext executionContext) {
                 for (J.ClassDeclaration clazz : cu.getClasses()) {
-                    if (TypeUtils.isAssignableTo(JavaType.Class.build("junit.framework.TestCase"), clazz.getType())) {
+                    if (TypeUtils.isAssignableTo(JavaType.ShallowClass.build("junit.framework.TestCase"), clazz.getType())) {
                         return cu.withMarkers(cu.getMarkers().searchResult());
                     }
                 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/RunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RunnerToExtension.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.testing.junit5;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.ExecutionContext;
@@ -35,7 +34,6 @@ import org.openrewrite.java.tree.JavaType;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Supplier;
 
 import static org.openrewrite.Parser.Input.fromString;
 
@@ -91,7 +89,7 @@ public class RunnerToExtension extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
-            private final JavaType.Class extensionType = JavaType.Class.build(extension);
+            private final JavaType.Class extensionType = JavaType.ShallowClass.build(extension);
             @Nullable
             private JavaTemplate extendsWithTemplate;
             private JavaTemplate getExtendsWithTemplate() {

--- a/src/main/java/org/openrewrite/java/testing/junit5/TempDirNonFinal.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TempDirNonFinal.java
@@ -55,10 +55,9 @@ public class TempDirNonFinal extends Recipe {
     private static class TempDirVisitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
-            J.VariableDeclarations varDecls = super.visitVariableDeclarations(multiVariable,
-                    executionContext);
+            J.VariableDeclarations varDecls = super.visitVariableDeclarations(multiVariable, executionContext);
             if (varDecls.getLeadingAnnotations().stream().anyMatch(TEMPDIR_ANNOTATION_MATCHER::matches)
-                    && varDecls.getModifiers().stream().anyMatch(mod -> mod.getType() == Type.Final)) {
+                    && varDecls.hasModifier(Type.Final)) {
                 return maybeAutoFormat(varDecls, varDecls.withModifiers(ListUtils
                         .map(varDecls.getModifiers(), modifier -> modifier.getType() == Type.Final ? null : modifier)),
                         executionContext, getCursor().getParentOrThrow());

--- a/src/test/kotlin/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.kt
@@ -17,22 +17,23 @@ package org.openrewrite.java.testing.junit5
 
 import org.junit.jupiter.api.Test
 import org.openrewrite.Issue
-import org.openrewrite.Recipe
+import org.openrewrite.java.Assertions.java
 import org.openrewrite.java.JavaParser
-import org.openrewrite.java.JavaRecipeTest
+import org.openrewrite.test.RecipeSpec
+import org.openrewrite.test.RewriteTest
 
-class TempDirNonFinalTest : JavaRecipeTest {
-    override val parser: JavaParser = JavaParser.fromJavaVersion()
-        .classpath("junit")
-        .build()
-
-    override val recipe: Recipe
-        get() = TempDirNonFinal()
+class TempDirNonFinalTest : RewriteTest {
+    override fun defaults(spec: RecipeSpec) {
+        spec.recipe(TempDirNonFinal())
+        spec.parser(JavaParser.fromJavaVersion()
+            .classpath("junit")
+            .build())
+    }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun tempDirStaticFinalFile() = assertChanged(
-        before = """
+    fun tempDirStaticFinalFile() = rewriteRun(
+        java("""
             import org.junit.jupiter.api.io.TempDir;
             
             import java.io.File;
@@ -42,7 +43,7 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 static final File tempDir;
             }
         """,
-        after = """
+        """
             import org.junit.jupiter.api.io.TempDir;
             
             import java.io.File;
@@ -51,13 +52,13 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 @TempDir
                 static File tempDir;
             }
-        """
+        """)
     )
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun tempDirStaticFinalPath() = assertChanged(
-        before = """
+    fun tempDirStaticFinalPath() = rewriteRun(
+        java("""
             import org.junit.jupiter.api.io.TempDir;
             
             import java.nio.file.Path;
@@ -67,7 +68,7 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 static final Path tempDir;
             }
         """,
-        after = """
+        """
             import org.junit.jupiter.api.io.TempDir;
             
             import java.nio.file.Path;
@@ -76,14 +77,14 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 @TempDir
                 static Path tempDir;
             }
-        """
+        """)
     )
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun tempDirFileParameter() = assertUnchanged(
-        before = """
-            import org.junit.jupiter.api.Test
+    fun tempDirFileParameter() = rewriteRun(
+        java("""
+            import org.junit.jupiter.api.Test;
             import org.junit.jupiter.api.io.TempDir;
             
             import java.nio.file.Path;
@@ -93,13 +94,13 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 void fileTest(@TempDir File tempDir) {
                 }
             }
-        """
+        """)
     )
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun tempDirStaticFile() = assertUnchanged(
-        before = """
+    fun tempDirStaticFile() = rewriteRun(
+        java("""
             import org.junit.jupiter.api.io.TempDir;
             
             import java.io.File;
@@ -108,13 +109,13 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 @TempDir
                 static File tempDir;
             }
-        """
+        """)
     )
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
-    fun tempDirStaticPath() = assertUnchanged(
-        before = """
+    fun tempDirStaticPath() = rewriteRun(
+        java("""
             import org.junit.jupiter.api.io.TempDir;
             
             import java.nio.file.Path;
@@ -123,6 +124,6 @@ class TempDirNonFinalTest : JavaRecipeTest {
                 @TempDir
                 static Path tempDir;
             }
-        """
+        """)
     )
 }


### PR DESCRIPTION
Based on feedback received in https://github.com/openrewrite/rewrite-testing-frameworks/pull/252#issuecomment-1221326960
> JavaRecipeTest is being replaced with [RewriteTest](https://docs.openrewrite.org/tutorials/recipe-testing#rewritetest-interface)