### PR TITLE
Convert cucumber regexes to cucumber expressions where possible #264

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cucumber/CucumberJava8HookDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/CucumberJava8HookDefinitionToCucumberJava.java
@@ -31,6 +31,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType.Primitive;
+import org.openrewrite.marker.SearchResult;
 
 public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
 
@@ -87,8 +88,7 @@ public class CucumberJava8HookDefinitionToCucumberJava extends Recipe {
             // Replacement annotations can only handle literals or constants
             if (methodInvocation.getArguments().stream()
                     .anyMatch(arg -> !(arg instanceof J.Literal) && !(arg instanceof J.Lambda))) {
-                return methodInvocation
-                        .withMarkers(methodInvocation.getMarkers().searchResult("TODO Migrate manually"));
+                return SearchResult.found(methodInvocation,"TODO Migrate manually");
             }
 
             // Extract arguments passed to method

--- a/src/main/java/org/openrewrite/java/testing/cucumber/CucumberJava8StepDefinitionToCucumberJava.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/CucumberJava8StepDefinitionToCucumberJava.java
@@ -30,6 +30,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.SearchResult;
 
 public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
 
@@ -80,8 +81,7 @@ public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
             // Annotations require a String literal
             Expression stringExpression = arguments.get(0);
             if (!(stringExpression instanceof J.Literal)) {
-                return methodInvocation
-                        .withMarkers(methodInvocation.getMarkers().searchResult("TODO Migrate manually"));
+                return SearchResult.found(methodInvocation, "TODO Migrate manually");
             }
             J.Literal literal = (J.Literal) stringExpression;
 
@@ -90,8 +90,7 @@ public class CucumberJava8StepDefinitionToCucumberJava extends Recipe {
             if (!(possibleStepDefinitionBody instanceof J.Lambda)
                     || !TypeUtils.isAssignableTo(IO_CUCUMBER_JAVA8_STEP_DEFINITION_BODY,
                             possibleStepDefinitionBody.getType())) {
-                return methodInvocation
-                        .withMarkers(methodInvocation.getMarkers().searchResult("TODO Migrate manually"));
+                return SearchResult.found(methodInvocation, "TODO Migrate manually");
             }
             J.Lambda lambda = (J.Lambda) possibleStepDefinitionBody;
 

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.cucumber;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+public class RegexToCucumberExpression extends Recipe {
+
+    private static final String IO_CUCUMBER_JAVA_STEP_DEFINITION = "io.cucumber.java.*";
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
+        return new UsesType<>(IO_CUCUMBER_JAVA_STEP_DEFINITION);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Replace Cucumber-Java step definition regexes with Cucumber expressions.";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Strip regex prefix and suffix from step annotation expressions arguments where possible.";
+    }
+
+    @Override
+    public @Nullable Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new CucumberStepDefinitionBodyVisitor();
+    }
+
+    static final class CucumberStepDefinitionBodyVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation a, ExecutionContext p) {
+            J.Annotation annotation = super.visitAnnotation(a, p);
+            List<Expression> arguments = annotation.getArguments();
+            Optional<String> possibleExpression = Stream.of(arguments)
+                    .filter(Objects::nonNull)
+                    .filter(list -> list.size() == 1)
+                    .flatMap(Collection::stream)
+                    .filter(J.Literal.class::isInstance)
+                    .map(e -> (J.Literal) e)
+                    .map(l -> (String) l.getValue())
+                    // https://github.com/cucumber/cucumber-expressions/blob/main/java/heuristics.adoc
+                    .filter(s -> (s.startsWith("^") || s.endsWith("$"))
+                            || (s.startsWith("/") && s.endsWith("/")))
+                    .findFirst();
+            if (!possibleExpression.isPresent()) {
+                return annotation;
+            }
+
+            // Strip leading/trailing regex anchors
+            String replacement = possibleExpression.get();
+            if (replacement.startsWith("^") || replacement.startsWith("/")) {
+                replacement = replacement.substring(1);
+            }
+            if (replacement.endsWith("$") || replacement.endsWith("/")) {
+                replacement = replacement.substring(0, replacement.length() - 1);
+            }
+
+            // Attempt to replace elements of the regular expression
+            if (!replacement.contains("(")) {
+                final String finalReplacement = replacement;
+                return maybeAutoFormat(
+                        annotation,
+                        annotation
+                                .withArguments(ListUtils.map(annotation.getArguments(),
+                                        arg -> ((J.Literal) arg).withValue(finalReplacement))),
+                        p);
+            }
+
+            return annotation;
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -31,9 +31,11 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 public class RegexToCucumberExpression extends Recipe {
 
+    private static final String IO_CUCUMBER_JAVA = "io.cucumber.java";
     private static final String IO_CUCUMBER_JAVA_STEP_DEFINITION = "io.cucumber.java.*.*";
 
     @Override
@@ -76,6 +78,13 @@ public class RegexToCucumberExpression extends Recipe {
                 J.MethodDeclaration methodDeclaration,
                 J.Annotation annotation,
                 ExecutionContext p) {
+
+            // Skip if not a cucumber annotation
+            if (!((JavaType.Class) annotation.getAnnotationType().getType()).getPackageName()
+                    .startsWith(IO_CUCUMBER_JAVA)) {
+                return annotation;
+            }
+
             List<Expression> arguments = annotation.getArguments();
             Optional<String> possibleExpression = Stream.of(arguments)
                     .filter(Objects::nonNull)

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -34,7 +34,7 @@ import org.openrewrite.java.tree.J;
 
 public class RegexToCucumberExpression extends Recipe {
 
-    private static final String IO_CUCUMBER_JAVA_STEP_DEFINITION = "io.cucumber.java.*";
+    private static final String IO_CUCUMBER_JAVA_STEP_DEFINITION = "io.cucumber.java.*.*";
 
     @Override
     protected TreeVisitor<?, ExecutionContext> getSingleSourceApplicableTest() {
@@ -93,12 +93,12 @@ public class RegexToCucumberExpression extends Recipe {
 
             // Attempt to replace elements of the regular expression
             if (!replacement.contains("(")) {
-                final String finalReplacement = replacement;
+                final String finalReplacement = String.format("\"%s\"", replacement);
                 return maybeAutoFormat(
                         annotation,
-                        annotation
-                                .withArguments(ListUtils.map(annotation.getArguments(),
-                                        arg -> ((J.Literal) arg).withValue(finalReplacement))),
+                        annotation.withArguments(ListUtils.map(annotation.getArguments(), arg -> ((J.Literal) arg)
+                                .withValue(finalReplacement)
+                                .withValueSource(finalReplacement))),
                         p);
             }
 

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -101,15 +101,16 @@ public class RegexToCucumberExpression extends Recipe {
                 replacement = replacement.substring(0, replacement.length() - 1);
             }
 
-            // Attempt to replace elements of the regular expression
-            if (!replacement.contains("(")) {
-                final String finalReplacement = String.format("\"%s\"", replacement);
-                return annotation.withArguments(ListUtils.map(annotation.getArguments(), arg -> ((J.Literal) arg)
-                        .withValue(finalReplacement)
-                        .withValueSource(finalReplacement)));
+            // Back off when special characters are encountered in regex
+            if (Stream.of("(", ")", "{", "}", "[", "]", "?", "*", "+").anyMatch(replacement::contains)) {
+                return annotation;
             }
 
-            return annotation;
+            // Replace regular expression with cucumber expression
+            final String finalReplacement = String.format("\"%s\"", replacement);
+            return annotation.withArguments(ListUtils.map(annotation.getArguments(), arg -> ((J.Literal) arg)
+                    .withValue(finalReplacement)
+                    .withValueSource(finalReplacement)));
         }
     }
 

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -94,11 +94,14 @@ public class RegexToCucumberExpression extends Recipe {
 
             // Strip leading/trailing regex anchors
             String replacement = possibleExpression.get();
-            if (replacement.startsWith("^") || replacement.startsWith("/")) {
+            if (replacement.startsWith("^")) {
                 replacement = replacement.substring(1);
             }
-            if (replacement.endsWith("$") || replacement.endsWith("/")) {
+            if (replacement.endsWith("$")) {
                 replacement = replacement.substring(0, replacement.length() - 1);
+            }
+            if (replacement.startsWith("/") && replacement.endsWith("/")) {
+                replacement = replacement.substring(1, replacement.length() -1);
             }
 
             // Back off when special characters are encountered in regex

--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -111,7 +111,7 @@ public class RegexToCucumberExpression extends Recipe {
                 return initialExpression.substring(1, initialExpression.length() - 1);
             }
 
-            // The presence of anchors assumes a Regular Expression, even if only one of the anchors are present 
+            // The presence of anchors assumes a Regular Expression, even if only one of the anchors are present
             String replacement = initialExpression;
             if (replacement.startsWith("^")) {
                 replacement = replacement.substring(1);
@@ -119,6 +119,12 @@ public class RegexToCucumberExpression extends Recipe {
             if (replacement.endsWith("$")) {
                 replacement = replacement.substring(0, replacement.length() - 1);
             }
+
+            // Prevent conversion of `^/hello world/$` to `/hello world/`
+            if (leadingAndTrailingSlash(replacement)) {
+                return initialExpression;
+            }
+
             return replacement;
         }
 

--- a/src/main/java/org/openrewrite/java/testing/cucumber/package-info.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/package-info.java
@@ -1,0 +1,5 @@
+@NonNullApi
+
+package org.openrewrite.java.testing.cucumber;
+
+import org.openrewrite.internal.lang.NonNullApi;

--- a/src/main/resources/META-INF/rewrite/cucumber.yml
+++ b/src/main/resources/META-INF/rewrite/cucumber.yml
@@ -22,6 +22,19 @@ tags:
   - testing
   - cucumber
 recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: info.cukes
+      oldArtifactId: cucumber-java
+      newGroupId: io.cucumber
+      newArtifactId: cucumber-java
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: info.cukes
+      oldArtifactId: cucumber-java8
+      newGroupId: io.cucumber
+      newArtifactId: cucumber-java8
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: cucumber.api
+      newPackageName: io.cucumber
   - org.openrewrite.java.testing.cucumber.CucumberJava8HookDefinitionToCucumberJava
   - org.openrewrite.java.testing.cucumber.CucumberJava8StepDefinitionToCucumberJava
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:

--- a/src/main/resources/META-INF/rewrite/cucumber.yml
+++ b/src/main/resources/META-INF/rewrite/cucumber.yml
@@ -15,9 +15,35 @@
 #
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.testing.cucumber.CucumberJava8ToJava
-displayName: Cucumber-Java8 migration to Cucumber-Java
-description: Migrates Cucumber-Java8 step definitions and LambdaGlue hooks to Cucumber-Java annotated methods.
+name: org.openrewrite.java.testing.cucumber.UpgradeCucumber7x
+displayName: Upgrade to Cucumber-JVM 7.x
+description: Upgrade to Cucumber-JVM 7.x from any previous version.
+tags:
+  - testing
+  - cucumber
+recipeList:
+  - org.openrewrite.java.testing.cucumber.UpgradeCucumber5x
+  - org.openrewrite.java.testing.cucumber.CucumberJava8ToJava
+  - org.openrewrite.java.testing.cucumber.DropSummaryPrinter
+  - org.openrewrite.java.testing.cucumber.RegexToCucumberExpression
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.cucumber.UpgradeCucumber5x
+displayName: Upgrade to Cucumber-JVM 5.x
+description: Upgrade to Cucumber-JVM 5.x from any previous version.
+tags:
+  - testing
+  - cucumber
+recipeList:
+  - org.openrewrite.java.testing.cucumber.UpgradeCucumber2x
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: cucumber.api
+      newPackageName: io.cucumber
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.cucumber.UpgradeCucumber2x
+displayName: Upgrade to Cucumber-JVM 2.x
+description: Upgrade to Cucumber-JVM 2.x from any previous version.
 tags:
   - testing
   - cucumber
@@ -32,9 +58,15 @@ recipeList:
       oldArtifactId: cucumber-java8
       newGroupId: io.cucumber
       newArtifactId: cucumber-java8
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: cucumber.api
-      newPackageName: io.cucumber
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.cucumber.CucumberJava8ToJava
+displayName: Cucumber-Java8 migration to Cucumber-Java
+description: Migrates Cucumber-Java8 step definitions and LambdaGlue hooks to Cucumber-Java annotated methods.
+tags:
+  - testing
+  - cucumber
+recipeList:
   - org.openrewrite.java.testing.cucumber.CucumberJava8HookDefinitionToCucumberJava
   - org.openrewrite.java.testing.cucumber.CucumberJava8StepDefinitionToCucumberJava
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -241,6 +241,25 @@ class RegexToCucumberExpressionTest implements RewriteTest {
                     17));
         }
 
+        @Test
+        void disabled() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+                    import org.junit.jupiter.api.Disabled;
+
+                    public class ExpressionDefinitions {
+                        @Disabled("/for now/")
+                        public void disabled() {
+                        }
+                        @Given("^cukes$")
+                        public void cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
     }
 
 }

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -253,8 +253,8 @@ class RegexToCucumberExpressionTest implements RewriteTest {
                         @Disabled("/for now/")
                         public void disabled() {
                         }
-                        @Given("^cukes$")
-                        public void cukes() {
+                        @Given("trigger getSingleSourceApplicableTest")
+                        public void trigger() {
                         }
                     }"""),
                     17));

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -48,7 +48,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-                public class CucumberJava8Definitions {
+                public class ExpressionDefinitions {
 
                     private int a;
 
@@ -76,7 +76,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-                public class CucumberJava8Definitions {
+                public class ExpressionDefinitions {
 
                     private int a;
 
@@ -110,7 +110,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("^five cukes")
                         public void five_cukes() {
                         }
@@ -119,7 +119,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("five cukes")
                         public void five_cukes() {
                         }
@@ -134,7 +134,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("five cukes$")
                         public void five_cukes() {
                         }
@@ -143,7 +143,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("five cukes")
                         public void five_cukes() {
                         }
@@ -158,7 +158,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("/five cukes/")
                         public void five_cukes() {
                         }
@@ -167,7 +167,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("five cukes")
                         public void five_cukes() {
                         }
@@ -188,7 +188,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("^some (foo|bar)$")
                         public void five_cukes(String fooOrBar) {
                         }
@@ -203,7 +203,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("^(\\\\d+) cukes$")
                         public void int_cukes(int cukes) {
                         }
@@ -218,7 +218,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("^cukes?$")
                         public void cukes() {
                         }
@@ -233,7 +233,7 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     import io.cucumber.java.en.Given;
 
-                    public class CucumberJava8Definitions {
+                    public class ExpressionDefinitions {
                         @Given("^cukes+$")
                         public void cukes() {
                         }

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.cucumber;
 
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.cucumber;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -183,7 +182,6 @@ class RegexToCucumberExpressionTest implements RewriteTest {
     class ShouldNotConvert {
 
         @Test
-        @Disabled("non-standard matcher would need custom ParameterType which is out scope for now")
         void unrecognized_capturing_groups() {
             rewriteRun(version(java("""
                     package com.example.app;
@@ -192,14 +190,13 @@ class RegexToCucumberExpressionTest implements RewriteTest {
 
                     public class CucumberJava8Definitions {
                         @Given("^some (foo|bar)$")
-                        public void five_cukes() {
+                        public void five_cukes(String fooOrBar) {
                         }
                     }"""),
                     17));
         }
 
         @Test
-        @Disabled("needs method arguments to convert")
         void integer_matchers() {
             rewriteRun(version(java("""
                     package com.example.app;
@@ -207,17 +204,38 @@ class RegexToCucumberExpressionTest implements RewriteTest {
                     import io.cucumber.java.en.Given;
 
                     public class CucumberJava8Definitions {
-                        @Given("^(\\d+) cukes$")
+                        @Given("^(\\\\d+) cukes$")
                         public void int_cukes(int cukes) {
                         }
-                    }""", """
+                    }"""),
+                    17));
+        }
+
+        @Test
+        void regex_question_mark_optional() {
+            rewriteRun(version(java("""
                     package com.example.app;
 
                     import io.cucumber.java.en.Given;
 
                     public class CucumberJava8Definitions {
-                        @Given("{int} cukes")
-                        public void int_cukes(int cukes) {
+                        @Given("^cukes?$")
+                        public void cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
+        @Test
+        void regex_one_or_more() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("^cukes+$")
+                        public void cukes() {
                         }
                     }"""),
                     17));

--- a/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpressionTest.java
@@ -1,0 +1,213 @@
+package org.openrewrite.java.testing.cucumber;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.version;
+
+@Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/264")
+class RegexToCucumberExpressionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RegexToCucumberExpression());
+        spec.parser(JavaParser.fromJavaVersion()
+                .logCompilationWarningsAndErrors(true)
+                .classpath("junit-jupiter-api", "cucumber-java"));
+    }
+
+    @Test
+    void regex_to_cucumber_expression() {
+        rewriteRun(version(java("""
+                package com.example.app;
+
+                import io.cucumber.java.Before;
+                import io.cucumber.java.en.Given;
+                import io.cucumber.java.en.Then;
+
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                public class CucumberJava8Definitions {
+
+                    private int a;
+
+                    @Before
+                    public void before() {
+                        a = 0;
+                    }
+
+                    @Given("^five cukes$")
+                    public void five_cukes() {
+                        a = 5;
+                    }
+
+                    @Then("^I expect (\\\\d+)$")
+                    public void i_expect_int(Integer c) {
+                        assertEquals(c, a);
+                    }
+
+                }""", """
+                package com.example.app;
+
+                import io.cucumber.java.Before;
+                import io.cucumber.java.en.Given;
+                import io.cucumber.java.en.Then;
+
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+
+                public class CucumberJava8Definitions {
+
+                    private int a;
+
+                    @Before
+                    public void before() {
+                        a = 0;
+                    }
+
+                    @Given("five cukes")
+                    public void five_cukes() {
+                        a = 5;
+                    }
+
+                    @Then("^I expect (\\\\d+)$")
+                    public void i_expect_int(Integer c) {
+                        assertEquals(c, a);
+                    }
+
+                }"""),
+                17));
+    }
+
+    @Nested
+    @DisplayName("should convert")
+    class ShouldConvert {
+
+        @Test
+        void only_leading_anchor() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("^five cukes")
+                        public void five_cukes() {
+                        }
+                    }""", """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("five cukes")
+                        public void five_cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
+        @Test
+        void only_trailing_anchor() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("five cukes$")
+                        public void five_cukes() {
+                        }
+                    }""", """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("five cukes")
+                        public void five_cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
+        @Test
+        void forward_slashes() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("/five cukes/")
+                        public void five_cukes() {
+                        }
+                    }""", """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("five cukes")
+                        public void five_cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("should not convert")
+    class ShouldNotConvert {
+
+        @Test
+        @Disabled("non-standard matcher would need custom ParameterType which is out scope for now")
+        void unrecognized_capturing_groups() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("^some (foo|bar)$")
+                        public void five_cukes() {
+                        }
+                    }"""),
+                    17));
+        }
+
+        @Test
+        @Disabled("needs method arguments to convert")
+        void integer_matchers() {
+            rewriteRun(version(java("""
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("^(\\d+) cukes$")
+                        public void int_cukes(int cukes) {
+                        }
+                    }""", """
+                    package com.example.app;
+
+                    import io.cucumber.java.en.Given;
+
+                    public class CucumberJava8Definitions {
+                        @Given("{int} cukes")
+                        public void int_cukes(int cukes) {
+                        }
+                    }"""),
+                    17));
+        }
+
+    }
+
+}


### PR DESCRIPTION
For now only converts the trivial cases of regex expressions that could be cucumber expressions, by stripping the leading/trailing anchors.