### PR TITLE
Avoid even more special characters to avoid alternative text expressions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
+++ b/src/main/java/org/openrewrite/java/testing/cucumber/RegexToCucumberExpression.java
@@ -105,7 +105,8 @@ public class RegexToCucumberExpression extends Recipe {
             String replacement = stripAnchors(possibleExpression.get());
 
             // Back off when special characters are encountered in regex
-            if (Stream.of("(", ")", "{", "}", "[", "]", "?", "*", "+").anyMatch(replacement::contains)) {
+            if (Stream.of("(", ")", "{", "}", "[", "]", "?", "*", "+", "/", "\\", "^", "|")
+                    .anyMatch(replacement::contains)) {
                 return annotation;
             }
 


### PR DESCRIPTION
https://github.com/cucumber/cucumber-expressions/blob/main/README.md#alternative-text

```
Alternative text
Sometimes you want to relax your language, to make it flow better. For example:

I have {int} cucumber(s) in my belly/stomach

This would match either of those texts:

I have 1 cucumber in my belly
I have 1 cucumber in my stomach
I have 42 cucumbers in my stomach
I have 42 cucumbers in my belly
```
