### PR TITLE
UpgradeDependencyVersion for io.cucumber:* to 7.x

### DIFF
--- a/src/main/resources/META-INF/rewrite/cucumber.yml
+++ b/src/main/resources/META-INF/rewrite/cucumber.yml
@@ -27,6 +27,10 @@ recipeList:
   - org.openrewrite.java.testing.cucumber.DropSummaryPrinter
   - org.openrewrite.java.testing.cucumber.RegexToCucumberExpression
   - org.openrewrite.java.testing.cucumber.CucumberToJunitPlatformSuite
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: io.cucumber
+      artifactId: "*"
+      newVersion: 7.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.cucumber.UpgradeCucumber5x


### PR DESCRIPTION
This was missing in the 7.x upgrade; didn't think it necessary to add this into older versions.