### PR TITLE
Replace JUnit @Test when it is fully qualified

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
     runtimeOnly("io.cucumber:cucumber-plugin:7.+")
     runtimeOnly("io.cucumber:cucumber-junit-platform-engine:7.+")
     runtimeOnly("org.junit.platform:junit-platform-suite-api:latest.release")
-
+    runtimeOnly("org.junit.jupiter:junit-jupiter-api:latest.release")
 
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
@@ -158,8 +158,6 @@ dependencies {
     testRuntimeOnly("org.hamcrest:hamcrest:latest.release")
     testRuntimeOnly("pl.pragmatists:JUnitParams:1.+")
     testRuntimeOnly("com.squareup.okhttp3:mockwebserver:3.+")
-    
-
 
     "testWithMockito_3RuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:latest.release")
     "testWithMockito_3RuntimeOnly"("junit:junit:latest.release")

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationJavaTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationJavaTest.java
@@ -42,7 +42,7 @@ public class UpdateTestAnnotationJavaTest implements RewriteTest {
             """
               import org.junit.Test;
               /** @see org.junit.Test */
-              public class Tests {
+              public class MyTest {
                   @Test
                   public void test() {
                   }
@@ -50,11 +50,71 @@ public class UpdateTestAnnotationJavaTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               /**  */
-              public class Tests {
+              public class MyTest {
                   @Test
                   void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fullyQualified() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.Test;
+              public class MyTest {
+                  @org.junit.Test
+                  public void feature1() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              
+              public class MyTest {
+                  @org.junit.jupiter.api.Test
+                  void feature1() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mixedFullyQualifiedAndNot() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.Test;
+              public class MyTest {
+                  @org.junit.Test
+                  public void feature1() {
+                  }
+                  
+                  @Test
+                  void feature2() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              
+              public class MyTest {
+                  @org.junit.jupiter.api.Test
+                  void feature1() {
+                  }
+                  
+                  @Test
+                  void feature2() {
                   }
               }
               """


### PR DESCRIPTION
To work correctly, we need to fix a bug in `JavaTemplate` for using the replace coordinate on a `J.Annotation`. Currently creates an uncompilable template:

<img width="596" alt="image" src="https://user-images.githubusercontent.com/1697736/196924180-ee57ba5d-faa9-4727-b2f9-c213cbbeaf30.png">
