### PR TITLE
fix abstract class logic in TestsShouldNotBePublic

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.ChangeMethodAccessLevelVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.J.ClassDeclaration;
 import org.openrewrite.java.tree.J.MethodDeclaration;
@@ -136,6 +137,10 @@ public class TestsShouldNotBePublic extends Recipe {
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
             J.MethodDeclaration m = super.visitMethodDeclaration(method, executionContext);
+
+            if (method.getMethodType().getDeclaringType().hasFlags(Flag.Abstract, Flag.Public)) {
+                return m;
+            }
 
             if (m.getModifiers().stream().anyMatch(mod -> (mod.getType() == J.Modifier.Type.Public || (orProtected && mod.getType() == Type.Protected)))
                     && Boolean.FALSE.equals(TypeUtils.isOverride(method.getMethodType()))

--- a/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
@@ -110,12 +110,46 @@ class TestsShouldNotBePublicTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.junit.jupiter.api.AfterEach;
+              import org.junit.jupiter.api.BeforeEach;
               import org.junit.jupiter.api.Test;
 
               public abstract class ATest {
 
+                  @BeforeEach
+                  public void beforeEach_public() {
+                  }
+
+                  @BeforeEach
+                  protected void beforeEach_protected() {
+                  }
+
+                  @BeforeEach
+                  void beforeEach_packagePrivate() {
+                  }
+
+                  @AfterEach
+                  public void afterEach_public() {
+                  }
+
+                  @AfterEach
+                  protected void afterEach_protected() {
+                  }
+
+                  @AfterEach
+                  void afterEach_packagePrivate() {
+                  }
+
                   @Test
-                  void testMethod() {
+                  void testMethod_packagePrivate() {
+                  }
+
+                  @Test
+                  public void testMethod_public() {
+                  }
+
+                  @Test
+                  protected void testMethod_protected() {
                   }
               }
               """


### PR DESCRIPTION
TestsShouldNotBePublic recipe:  if the JUnit class is public and abstract, it should be ignored.