### PR TITLE
Add BDDMockito methods to the MOCKITO_METHOD_NAMES

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -64,7 +64,8 @@ public class CleanupMockitoImports extends Recipe {
         private static final List<String> MOCKITO_METHOD_NAMES = Arrays.asList("mock", "mockingDetails", "spy",
                 "stub", "when", "verify", "reset", "verifyNoMoreInteractions", "verifyZeroInteractions", "stubVoid",
                 "doThrow", "doCallRealMethod", "doAnswer", "doNothing", "doReturn", "inOrder", "ignoreStubs",
-                "times", "never", "atLeastOnce", "atLeast", "atMost", "calls", "only", "timeout", "after");
+                "times", "never", "atLeastOnce", "atLeast", "atMost", "calls", "only", "timeout", "after",
+                "given", "then", "will", "willAnswer", "willCallRealMethod", "willDoNothing", "willReturn", "willThrow");
         @Override
         public JavaSourceFile visitJavaSourceFile(JavaSourceFile cu, ExecutionContext executionContext) {
             JavaSourceFile sf = super.visitJavaSourceFile(cu, executionContext);

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -77,12 +77,14 @@ class CleanupMockitoImportsTest implements RewriteTest {
           java(
             """
               import static org.mockito.Mockito.when;
+              import static org.mockito.BDDMockito.given;
 
               class MyObjectTest {
                 MyObject myObject;
                             
                 void test() {
                   when(myObject.getSomeField()).thenReturn("testValue");
+                  given(myObject.getSomeField()).willReturn("testValue");
                 }
               }
               """


### PR DESCRIPTION
When i tried this recipe on my project there where soms imports that where removed while stil in use. That is because i used given() and this is in mockito core (BDDMockito) and those where not in this recipe that is why i made this pr

See here for the BDDMockito java doc
https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/BDDMockito.html

I appriciate the feedback, thanks for this project