### PR TITLE
verifyNoInteractions should not be removed

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -62,7 +62,7 @@ public class CleanupMockitoImports extends Recipe {
 
     public static class CleanupMockitoImportsVisitor extends JavaIsoVisitor<ExecutionContext> {
         private static final List<String> MOCKITO_METHOD_NAMES = Arrays.asList("mock", "mockingDetails", "spy",
-                "stub", "when", "verify", "reset", "verifyNoMoreInteractions", "verifyZeroInteractions", "stubVoid",
+                "stub", "when", "verify", "reset", "verifyNoMoreInteractions", "verifyZeroInteractions", "verifyNoInteractions", "stubVoid",
                 "doThrow", "doCallRealMethod", "doAnswer", "doNothing", "doReturn", "inOrder", "ignoreStubs",
                 "times", "never", "atLeastOnce", "atLeast", "atMost", "calls", "only", "timeout", "after",
                 "given", "then", "will", "willAnswer", "willCallRealMethod", "willDoNothing", "willReturn", "willThrow");

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -78,13 +78,16 @@ class CleanupMockitoImportsTest implements RewriteTest {
             """
               import static org.mockito.Mockito.when;
               import static org.mockito.BDDMockito.given;
+              import static org.mockito.Mockito.verifyNoInteractions;
 
               class MyObjectTest {
                 MyObject myObject;
+                MyMockClass myMock;
                             
                 void test() {
                   when(myObject.getSomeField()).thenReturn("testValue");
                   given(myObject.getSomeField()).willReturn("testValue");
+                  verifyNoInteractions(myMock);
                 }
               }
               """


### PR DESCRIPTION
By running the recipe, statements importing this method are removed.

This method still is in [Mockito](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#verifyNoInteractions(java.lang.Object...)) and is not deprecated.