### PR TITLE
Support member references in AssertJ assertThrows

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -63,4 +63,39 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void memberReference() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+              import java.util.concurrent.CompletableFuture;
+              import java.util.concurrent.ExecutionException;
+
+              public class MemberReferenceTest {
+
+                  public void throwsWithMemberReference() {
+                      CompletableFuture<Boolean> future = new CompletableFuture<>();
+                      assertThrows(ExecutionException.class, future::get);
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+              import java.util.concurrent.CompletableFuture;
+              import java.util.concurrent.ExecutionException;
+
+              public class MemberReferenceTest {
+
+                  public void throwsWithMemberReference() {
+                      CompletableFuture<Boolean> future = new CompletableFuture<>();
+                      assertThatExceptionOfType(ExecutionException.class).isThrownBy(future::get);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
This PR adds support for rewriting JUnit assertions to AssertJ assertions for throwing member references.
Lambdas in the form of `() -> { throw new Exception(); }` were already supported. Now `var::throwingMemberReference` is  also supported.

I'm not really sure what rewrite's default behavior is for unsupported semantics; the added code simply does not rewrite unsupported semantics. Alternatively, the PR can be adjusted to throw an `IllegalArgumentException` in the last if-else branch.