### PR TITLE
Add test that generated invalid code

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
@@ -72,7 +72,9 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
-            if (ASSERT_THROWS_MATCHER.matches(mi) && mi.getArguments().size() == 2) {
+            if (ASSERT_THROWS_MATCHER.matches(mi)
+              && mi.getArguments().size() == 2
+              && getCursor().getParentTreeCursor().getValue() instanceof J.Block) {
                 J executable = mi.getArguments().get(1);
                 if (executable instanceof J.Lambda) {
                     executable = ((J.Lambda) executable).withType(THROWING_CALLABLE_TYPE);

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -118,4 +118,30 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
           )
         );
     }
+
+    /**
+     * A degenerate case showing we need to make sure the <code>assertThrows</code> appears
+     * immediately inside a J.Block.
+     */
+    @Test
+    void assertThrowsTernaryAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      NullPointerException npe = hashCode() == 42
+                        ? new NullPointerException()
+                        : assertThrows(NullPointerException.class, () -> {
+                          throw new NullPointerException();
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.testing.assertj;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -100,6 +101,7 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/331")
     void assertThrowsAssignment() {
         //language=java
         rewriteRun(
@@ -124,6 +126,7 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
      * immediately inside a J.Block.
      */
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/331")
     void assertThrowsTernaryAssignment() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -98,4 +98,24 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void assertThrowsAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      NullPointerException npe = assertThrows(NullPointerException.class, () -> {
+                          throw new NullPointerException();
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
This PR adds a unit test `assertThrowsAssignment` that generates invalid code. In JUnit `assertThrows` returns the exception that is thrown, while in AssertJ there is no way (currently) to obtain the exception that is thrown.

The purpose of this PR is check whether it is desired behavior open rewrite generates invalid Java code. A solution would be to skip rewriting cases where `assertThrows` is used as RHS in an assignment, but that would leave JUnit assertions in code bases.