### PR TITLE
Add failing test for CleanupMockitoImports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,4 +40,5 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-groovy")
+    testImplementation("org.junit-pioneer:junit-pioneer:2.0.1")
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -16,8 +16,10 @@
 package org.openrewrite.java.testing.mockito;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -202,6 +204,58 @@ class CleanupMockitoImportsTest implements RewriteTest {
               """,
             """
               public class MockitoArgumentMatchersTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("#3111") //maybe not exactly the same issue though?
+    @ExpectedToFail
+    @Test
+    void removeUnusedArgumentMatchersOnly() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  String doAThing(Object other, String value){return value;}
+              }
+              """
+          ),
+          java(
+            """
+              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.after;
+              import static org.mockito.ArgumentMatchers.any;
+              import static org.mockito.ArgumentMatchers.anyString;
+              import static org.mockito.ArgumentMatchers.eq;
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              class MyObjectTest {
+                @Mock
+                MyObject myObject;
+                            
+                void test() {
+                  when(myObject.doAThing(any(), eq("testValue"))).thenReturn("testValue");
+                }
+              }
+              """,
+            """
+              import static org.mockito.Mockito.when;
+              import static org.mockito.ArgumentMatchers.any;
+              import static org.mockito.ArgumentMatchers.eq;
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              class MyObjectTest {
+                @Mock
+                MyObject myObject;
+                            
+                void test() {
+                  when(myObject.doAThing(any(), eq("testValue"))).thenReturn("testValue");
+                }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -210,9 +210,9 @@ class CleanupMockitoImportsTest implements RewriteTest {
         );
     }
 
-    @Issue("#3111") //maybe not exactly the same issue though?
-    @ExpectedToFail
     @Test
+    @ExpectedToFail
+    @Issue("https://github.com/openrewrite/rewrite/issues/3111") // maybe not exactly the same issue
     void removeUnusedArgumentMatchersOnly() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
Recipe `CleanupMockitoImports` cleans too much. My argument matchers are being cleaned up while used. I have reproduced the problem with a new failing test.

I needed to add junit-pioneer as it was not yet present, I added with a fixed version as it looks like it is not part of the platform.