### PR TITLE
Add JUnit ThrowingRunnableToExecutable recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -48,6 +48,7 @@ tags:
 recipeList:
   - org.openrewrite.java.testing.junit5.UseWiremockExtension
   - org.openrewrite.java.testing.junit5.IgnoreToDisabled
+  - org.openrewrite.java.testing.junit5.ThrowingRunnableToExecutable
   - org.openrewrite.java.testing.junit5.RemoveObsoleteRunners:
       obsoleteRunners:
         - org.junit.runners.JUnit4
@@ -192,6 +193,18 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.junit.Ignore
       newFullyQualifiedTypeName: org.junit.jupiter.api.Disabled
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.junit5.ThrowingRunnableToExecutable
+displayName: Use JUnit Jupiter `Executable`
+description: Migrates JUnit 4.x `ThrowingRunnable` to JUnit Jupiter `Executable`.
+tags:
+  - testing
+  - junit
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.junit.function.ThrowingRunnable
+      newFullyQualifiedTypeName: org.junit.jupiter.api.function.Executable
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.VertxUnitToVertxJunit5

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
@@ -189,4 +189,36 @@ class JUnit5BestPracticesTest implements RewriteTest {
           )
         );
     }
+    
+    @Test
+    void changeThrowingRunnableToExecutable() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import org.junit.function.ThrowingRunnable;
+              import org.junit.jupiter.api.Test;
+
+              public class Example {
+                @Test
+                public void testExpectedIOException() {
+                  ThrowingRunnable runnable = () -> throwsIOException("Simply throw an IOException");
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.function.Executable;
+
+              public class Example {
+                @Test
+                public void testExpectedIOException() {
+                  Executable runnable = () -> throwsIOException("Simply throw an IOException");
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Recently migrated using openrewrite and was missing this recipe. Possibly not as simple as a ChangeType recipe.