### PR TITLE
Added recipe to use explicit isEmpty in AssertJ assertions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitContains.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitContains.java
@@ -38,8 +38,8 @@ public class UseExplicitContains extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Convert AssertJ `assertThat(collection.contains(element)).isTrue()` with assertThat(collection).contains(element) "
-                + "and `assertThat(collection.contains(element)).isFalse()` with assertThat(collection).doesNotContain(element).";
+        return "Convert AssertJ `assertThat(collection.contains(element)).isTrue()` to `assertThat(collection).contains(element)` "
+                + "and `assertThat(collection.contains(element)).isFalse()` to `assertThat(collection).doesNotContain(element)`.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
@@ -39,7 +39,7 @@ public class UseExplicitIsEmpty extends Recipe {
     @Override
     public String getDescription() {
         return "Convert AssertJ `assertThat(collection.isEmpty()).isTrue()` with assertThat(collection).isEmpty() "
-                + "and `assertThat(collection.isEmpty()).isFalse()` with assertThat(collection).isNotEmpty().";
+                + "and `assertThat(collection.isEmpty()).isFalse()` to `assertThat(collection).isNotEmpty()`.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
@@ -38,7 +38,7 @@ public class UseExplicitIsEmpty extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Convert AssertJ `assertThat(collection.isEmpty()).isTrue()` with assertThat(collection).isEmpty() "
+        return "Convert AssertJ `assertThat(collection.isEmpty()).isTrue()` to `assertThat(collection).isEmpty()` "
                 + "and `assertThat(collection.isEmpty()).isFalse()` to `assertThat(collection).isNotEmpty()`.";
     }
 

--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitIsEmpty.java
@@ -100,7 +100,7 @@ public class UseExplicitIsEmpty extends Recipe {
                 return method;
             }
 
-            Expression list =  isEmpty.getSelect();
+            Expression collection =  isEmpty.getSelect();
 
             String template = isTrue ? "assertThat(#{any()}).isEmpty();" :
                 "assertThat(#{any()}).isNotEmpty();";
@@ -110,7 +110,7 @@ public class UseExplicitIsEmpty extends Recipe {
             return method.withTemplate(
                     builtTemplate,
                     method.getCoordinates().replace(),
-                    list);
+                    collection);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitSize.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/UseExplicitSize.java
@@ -37,7 +37,7 @@ public class UseExplicitSize extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Convert `assertThat(collection.size()).isEqualTo(Y)` with AssertJ's `assertThat(collection).hasSize()`.";
+        return "Convert `assertThat(collection.size()).isEqualTo(Y)` to AssertJ's `assertThat(collection).hasSize()`.";
     }
 
     @Override

--- a/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
@@ -80,7 +80,6 @@ class UseExplicitisEmptyTest implements RewriteTest {
     }
 
     @Test
-    @DocumentExample
     void IsEmptyAndIsFalseBecomeIsNotEmpty() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+@SuppressWarnings("ConstantConditions")
+class UseExplicitisEmptyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpath("junit", "assertj-core"))
+          .recipe(new UseExplicitIsEmpty());
+    }
+
+    @Test
+    void IsEmptyAndIsTrueBecomeIsEmpty() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+                import java.util.Collection;
+                import java.util.ArrayList;
+                
+                import org.junit.jupiter.api.Test;
+                
+                import static org.assertj.core.api.Assertions.assertThat;
+                
+                public class MyTest {
+                
+                    @Test
+                    public void test() {
+                        Collection<String> collection = new ArrayList<>();
+                        collection.add("3");
+                        assertThat(collection.isEmpty()).isTrue();
+                    }
+                }
+              """,
+            """
+                import java.util.Collection;
+                import java.util.ArrayList;
+                
+                import org.junit.jupiter.api.Test;
+                
+                import static org.assertj.core.api.Assertions.assertThat;
+                
+                public class MyTest {
+                
+                    @Test
+                    public void test() {
+                        Collection<String> collection = new ArrayList<>();
+                        collection.add("3");
+                        assertThat(collection).isEmpty();
+                    }
+                }
+              """
+          )
+        );
+    }
+
+    @Test
+    void IsEmptyAndIsFalseBecomeIsNotEmpty() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+                import java.util.Collection;
+                import java.util.ArrayList;
+                
+                import org.junit.jupiter.api.Test;
+                
+                import static org.assertj.core.api.Assertions.assertThat;
+                
+                public class MyTest {
+                
+                    @Test
+                    public void test() {
+                        Collection<String> collection = new ArrayList<>();
+                        assertThat(collection.isEmpty()).isFalse();
+                    }
+                }
+              """,
+            """
+                import java.util.Collection;
+                import java.util.ArrayList;
+                
+                import org.junit.jupiter.api.Test;
+                
+                import static org.assertj.core.api.Assertions.assertThat;
+                
+                public class MyTest {
+                
+                    @Test
+                    public void test() {
+                        Collection<String> collection = new ArrayList<>();
+                        assertThat(collection).isNotEmpty();
+                    }
+                }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.assertj;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -33,6 +34,7 @@ class UseExplicitisEmptyTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void IsEmptyAndIsTrueBecomeIsEmpty() {
         //language=java
         rewriteRun(
@@ -78,6 +80,7 @@ class UseExplicitisEmptyTest implements RewriteTest {
     }
 
     @Test
+    @DocumentExample
     void IsEmptyAndIsFalseBecomeIsNotEmpty() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/UseExplicitisEmptyTest.java
@@ -28,7 +28,7 @@ class UseExplicitisEmptyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .parser(JavaParser.fromJavaVersion().classpath("junit", "assertj-core"))
+          .parser(JavaParser.fromJavaVersion().classpath("junit-jupiter-api", "assertj-core"))
           .recipe(new UseExplicitIsEmpty());
     }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
I have added a new recipe to simplify assertions in tests that use AssertJ isEmpty().
Specifically, this recipe simplifies assertThat(collection.isEmpty()).isTrue() into assertThat(collection).isEmpty() and assertThat(collection.isEmpty()).isFalse() into assertThat(collection).isNotEmpty()

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
I work a lot with AssertJ and I have lots of legacy code to cleanup assertions.

## Anything in particular you'd like reviewers to focus on?
This is similar to other recipes I have contributed, so there should be no big issue.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
