### PR TITLE
adding recipe to replace Test annotation with ParameterizedTest annot…

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -1,0 +1,37 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+
+public class AddParameterizedTestAnnotation extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Add missing @ParameterizedTest annotation when @ValueSource is used or " +
+               "replace @Test with @ParameterizedTest";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add missing @ParameterizedTest annotation when @ValueSource is used or " +
+               "replace @Test with @ParameterizedTest";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        AnnotationMatcher annotationMatcher = new AnnotationMatcher("@Test");
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                J.Annotation a = (J.Annotation) super.visitAnnotation(annotation, ctx);
+                if (annotationMatcher.matches(annotation)) {
+                    a = annotation;
+                }
+                return a;
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -1,0 +1,50 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AddParameterizedTestAnnotationTest implements RewriteTest {
+    @Test
+    void replaceTestWithParameterizedTest() {
+        rewriteRun(
+          java(
+            """
+              @Test
+              @ValueSource(ints = {1, 3, 5, -3, 15, Integer.MAX_VALUE})
+              void testIsOdd(int number) {
+                  assertTrue(number % 2 != 0);
+              }
+              """,
+            """
+              @ParameterizedTest
+              @ValueSource(ints = {1, 3, 5, -3, 15, Integer.MAX_VALUE})
+              void testIsOdd(int number) {
+                  assertTrue(number % 2 != 0);
+              } 
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyReplacesWithValueSourceAnnotation() {
+        rewriteRun(
+          java(
+            """
+              @Test
+              void testIsOdd(int number) {
+                assertTrue(number % 2 != 0);
+              }
+              """,
+            """
+              @Test
+              void testIsOdd(int number) {
+                assertTrue(number % 2 != 0);
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
…ation when value source annotation is provided

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This is a draft pull request for a recipe that adds missing @ParameterizedTest annotation when @ValueSource is used or replace @Test with @ParameterizedTest.

## What's your motivation?
[issue #208](https://github.com/openrewrite/rewrite-testing-frameworks/issues/208)

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
I currently have two tests created but I think there are probably still a couple more that should be added. 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
