### PR TITLE
Test to ParameterizedTest annotation

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -1,0 +1,67 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+
+public class AddParameterizedTestAnnotation extends Recipe {
+    private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
+    private static final AnnotationMatcher VALUE_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.ValueSource");
+    private static final AnnotationMatcher CSV_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.CsvSource");
+    private static final AnnotationMatcher METHOD_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.MethodSource");
+    boolean foundTestAnnotation = false;
+
+    @Override
+    public String getDisplayName() {
+        return "Add missing @ParameterizedTest annotation when @ValueSource is used or " +
+               "replace @Test with @ParameterizedTest";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Add missing @ParameterizedTest annotation when @ValueSource is used or " +
+               "replace @Test with @ParameterizedTest.";
+    }
+
+    @Override
+    public JavaVisitor<ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                J.Annotation ann = (J.Annotation) super.visitAnnotation(annotation, ctx);
+                // check if @Test is present
+                if (TEST_ANNOTATION_MATCHER.matches(ann)) { foundTestAnnotation = true; }
+
+                System.out.println(ann.getAnnotationType());
+                System.out.println(VALUE_SOURCE_ANNOTATION_MATCHER.matches(ann));
+
+                // check if source annotation is present
+                if (
+                    VALUE_SOURCE_ANNOTATION_MATCHER.matches(ann) ||
+                    CSV_SOURCE_ANNOTATION_MATCHER.matches(ann)   ||
+                    METHOD_SOURCE_ANNOTATION_MATCHER.matches(ann)
+                ) {
+                    System.out.println("passing source conditional");
+                    if (foundTestAnnotation) {
+                        // replace @Test with @ParameterizedTest
+                        System.out.println("REPLACING");
+                        //JavaTemplate test = JavaTemplate.builder("@ParameterizedTest").build();
+                        //test.apply(getCursor(), annotation.getCoordinates().replace(), annotation);
+                    }else {
+                        // add @ParameterizedTest
+                        System.out.println("ADDING");
+                    }
+                }
+
+                // this could replace the first conditional check, but let's get that working first
+                //foundTestAnnotation = TEST_ANNOTATION_MATCHER.matches(ann);
+
+                System.out.println("--------------");
+                return ann;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -48,11 +48,18 @@ public class AddParameterizedTestAnnotation extends Recipe {
                     if (foundTestAnnotation) {
                         // replace @Test with @ParameterizedTest
                         System.out.println("REPLACING");
-                        //JavaTemplate test = JavaTemplate.builder("@ParameterizedTest").build();
-                        //test.apply(getCursor(), annotation.getCoordinates().replace(), annotation);
+                        JavaTemplate replaceTemplate = JavaTemplate.builder("@ParameterizedTest").build();
+                        replaceTemplate.apply(getCursor(), annotation.getCoordinates().replace(), annotation);
                     }else {
                         // add @ParameterizedTest
                         System.out.println("ADDING");
+                        maybeAddImport("@org.junit.jupiter.params.ParameterizedTest");
+                        //return JavaTemplate.builder("@ParameterizedTest")
+                        //        .imports("@org.junit.jupiter.params.ParameterizedTest")
+                        //        .build().apply(
+                        //                getCursor(),
+                        //                annotation.getCoordinates().addAnnotation(annotation)
+                        //        );
                     }
                 }
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -3,16 +3,14 @@ package org.openrewrite.java.testing.junit5;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
+import java.util.List;
 
 public class AddParameterizedTestAnnotation extends Recipe {
     private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
-    private static final AnnotationMatcher VALUE_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.ValueSource");
-    private static final AnnotationMatcher CSV_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.CsvSource");
-    private static final AnnotationMatcher METHOD_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.MethodSource");
-    boolean foundTestAnnotation = false;
 
     @Override
     public String getDisplayName() {
@@ -30,44 +28,28 @@ public class AddParameterizedTestAnnotation extends Recipe {
     public JavaVisitor<ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
             @Override
-            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                J.Annotation ann = (J.Annotation) super.visitAnnotation(annotation, ctx);
-                // check if @Test is present
-                if (TEST_ANNOTATION_MATCHER.matches(ann)) { foundTestAnnotation = true; }
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
+                J.MethodDeclaration m = (J.MethodDeclaration) super.visitMethodDeclaration(md, ctx);
 
-                System.out.println(ann.getAnnotationType());
-                System.out.println(VALUE_SOURCE_ANNOTATION_MATCHER.matches(ann));
+                List<J.Annotation> annotations = md.getLeadingAnnotations();
 
-                // check if source annotation is present
-                if (
-                    VALUE_SOURCE_ANNOTATION_MATCHER.matches(ann) ||
-                    CSV_SOURCE_ANNOTATION_MATCHER.matches(ann)   ||
-                    METHOD_SOURCE_ANNOTATION_MATCHER.matches(ann)
-                ) {
-                    System.out.println("passing source conditional");
-                    if (foundTestAnnotation) {
-                        // replace @Test with @ParameterizedTest
-                        System.out.println("REPLACING");
-                        JavaTemplate replaceTemplate = JavaTemplate.builder("@ParameterizedTest").build();
-                        replaceTemplate.apply(getCursor(), annotation.getCoordinates().replace(), annotation);
-                    }else {
-                        // add @ParameterizedTest
-                        System.out.println("ADDING");
-                        maybeAddImport("@org.junit.jupiter.params.ParameterizedTest");
-                        //return JavaTemplate.builder("@ParameterizedTest")
-                        //        .imports("@org.junit.jupiter.params.ParameterizedTest")
-                        //        .build().apply(
-                        //                getCursor(),
-                        //                annotation.getCoordinates().addAnnotation(annotation)
-                        //        );
-                    }
+                if (annotations.size() != 2) { return m; }
+
+                J.Annotation firstAnn = annotations.get(0);
+                J.Annotation secondAnn = annotations.get(1);
+
+                if (TEST_ANNOTATION_MATCHER.matches(firstAnn) && secondAnn.getArguments() != null) {
+                   maybeRemoveImport("org.junit.jupiter.api.Test");
+                   maybeAddImport("org.junit.jupiter.params.ParameterizedTest");
+                   return JavaTemplate.builder("@ParameterizedTest")
+                           .javaParser(JavaParser.fromJavaVersion())
+                           .build()
+                           .apply(getCursor(), firstAnn.getCoordinates().replace());
+                }else if (firstAnn.getArguments() != null && annotations.size() == 1) {
+                    // insert @ParameterizedTest
                 }
 
-                // this could replace the first conditional check, but let's get that working first
-                //foundTestAnnotation = TEST_ANNOTATION_MATCHER.matches(ann);
-
-                System.out.println("--------------");
-                return ann;
+                return m;
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -1,17 +1,18 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Recipe;
-import org.openrewrite.java.AnnotationMatcher;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.*;
 import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public class AddParameterizedTestAnnotation extends Recipe {
     private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
+    private static final AnnotationMatcher VALUE_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.ValueSource()");
+    private static final AnnotationMatcher CSV_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.CsvSource()");
+    private static final AnnotationMatcher METHOD_SOURCE_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.provider.MethodSource()");
 
     @Override
     public String getDisplayName() {
@@ -26,32 +27,51 @@ public class AddParameterizedTestAnnotation extends Recipe {
     }
 
     @Override
-    public JavaVisitor<ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+    public JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            public boolean checkForValueAnnotations(J.Annotation ann) {
+                return (VALUE_SOURCE_ANNOTATION_MATCHER.matches(ann) ||
+                        CSV_SOURCE_ANNOTATION_MATCHER.matches(ann) ||
+                        METHOD_SOURCE_ANNOTATION_MATCHER.matches(ann));
+            }
+
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
                 J.MethodDeclaration m = (J.MethodDeclaration) super.visitMethodDeclaration(md, ctx);
 
-                List<J.Annotation> annotations = md.getLeadingAnnotations();
+                // TODO Figure out if we're using @Test combined with @ValueSource and siblings; if not, return early
 
-                if (annotations.size() != 2) { return m; }
+                List<J.Annotation> oldAnnotations = md.getLeadingAnnotations();
+                List<J.Annotation> newAnnotations = new ArrayList<>(oldAnnotations);
 
-                J.Annotation firstAnn = annotations.get(0);
-                J.Annotation secondAnn = annotations.get(1);
+                for (int i = 0; i < oldAnnotations.size(); i++) {
+                    J.Annotation currAnn = oldAnnotations.get(i);
 
-                if (TEST_ANNOTATION_MATCHER.matches(firstAnn) && secondAnn.getArguments() != null) {
-                   maybeRemoveImport("org.junit.jupiter.api.Test");
-                   maybeAddImport("org.junit.jupiter.params.ParameterizedTest");
-                   return JavaTemplate.builder("@ParameterizedTest")
-                           .javaParser(JavaParser.fromJavaVersion()
-                                   .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9.+"))
-                           .build()
-                           .apply(getCursor(), firstAnn.getCoordinates().replace());
-                }else if (firstAnn.getArguments() != null && annotations.size() == 1) {
-                    // insert @ParameterizedTest
+                    if (TEST_ANNOTATION_MATCHER.matches(currAnn)) {
+                        if (i + 1 >= oldAnnotations.size()) {break;}
+
+                        if (checkForValueAnnotations(oldAnnotations.get(i + 1))) {
+                            // replace @Test with @ParameterizedTest
+                            newAnnotations.remove(currAnn);
+                            J.Annotation parameterizedTest = JavaTemplate.builder("@ParameterizedTest")
+                                            .build()
+                                            .apply(getCursor(), currAnn.getCoordinates().replace());
+                            newAnnotations.add(parameterizedTest);
+                            maybeRemoveImport("org.junit.jupiter.api.Test");
+                            maybeAddImport("org.junit.jupiter.params.ParameterizedTest");
+                        }
+                    } else if (checkForValueAnnotations(currAnn)) {
+                        // value source annotations being used without @ParameterizedTest
+                        J.Annotation parameterizedTest = JavaTemplate.builder("@ParameterizedTest")
+                                .build()
+                                .apply(getCursor(), currAnn.getCoordinates().replace());
+                        newAnnotations.add(0, parameterizedTest);
+                        maybeAddImport("org.junit.jupiter.params.ParameterizedTest");
+                        break;
+                    }
                 }
 
-                return m;
+                return m.withLeadingAnnotations(newAnnotations);
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -1,6 +1,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaParser;
@@ -42,7 +43,8 @@ public class AddParameterizedTestAnnotation extends Recipe {
                    maybeRemoveImport("org.junit.jupiter.api.Test");
                    maybeAddImport("org.junit.jupiter.params.ParameterizedTest");
                    return JavaTemplate.builder("@ParameterizedTest")
-                           .javaParser(JavaParser.fromJavaVersion())
+                           .javaParser(JavaParser.fromJavaVersion()
+                                   .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9.+"))
                            .build()
                            .apply(getCursor(), firstAnn.getCoordinates().replace());
                 }else if (firstAnn.getArguments() != null && annotations.size() == 1) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -14,7 +14,7 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9.+"))
           .recipe(new AddParameterizedTestAnnotation());
     }
 
@@ -66,8 +66,8 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
               
               class NumbersTest {
                 @Test
-                void testIsOdd(int number) {
-                  assertTrue(number % 2 != 0);
+                void printMessage() {
+                    System.out.println("message");
                 }
               }
              """
@@ -128,12 +128,17 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
             """
               import org.junit.jupiter.params.ParameterizedTest;
               import org.junit.jupiter.params.provider.MethodSource;
+              import java.util.stream.Stream;
               
               class TestClass {
                 @ParameterizedTest
                 @MethodSource("someMethod")
                 void foo() {
                   System.out.println("bar");
+                }
+                
+                static Stream<String> someMethod() {
+                    return Stream.of("data1", "data2", "data3");
                 }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -1,6 +1,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
@@ -20,9 +21,10 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/314")
     @Test
+    @DocumentExample
     void replaceTestWithParameterizedTest() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.jupiter.api.Test;
@@ -53,13 +55,46 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
     }
 
     @Test
+    void replaceTestWithParameterizedTestRegardlessOfOrder() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.params.provider.ValueSource;
+              
+              class NumbersTest {
+                @ValueSource(ints = {1, 3, 5, -3, 15,Integer.MAX_VALUE})
+                @Test
+                void testIsOdd(int number) {
+                    assertTrue(number % 2 != 0);
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+              
+              class NumbersTest {
+                @ParameterizedTest
+                @ValueSource(ints = {1, 3, 5, -3, 15,Integer.MAX_VALUE})
+                void testIsOdd(int number) {
+                    assertTrue(number % 2 != 0);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void onlyReplacesWithValueSourceAnnotation() {
         /*
         This test ensures that the recipe will only run on code that includes a
         @ValueSource(...) annotation.
          */
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.jupiter.api.Test;
@@ -77,8 +112,8 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
 
     @Test
     void replacesCsvSource() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.jupiter.params.provider.CsvSource;
@@ -110,8 +145,8 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
 
     @Test
     void replacesMethodSource() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.jupiter.api.Test;
@@ -148,8 +183,8 @@ public class AddParameterizedTestAnnotationTest implements RewriteTest {
 
     @Test
     void addMissingAnnotation() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
              import org.junit.jupiter.params.provider.ValueSource;

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -1,0 +1,116 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AddParameterizedTestAnnotationTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "junit-jupiter-api-5.9"))
+          .recipe(new AddParameterizedTestAnnotation());
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/314")
+    @Test
+    void replaceTestWithParameterizedTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.params.provider.ValueSource;
+              
+              class NumbersTest {
+                @Test
+                @ValueSource(ints = {1, 3, 5, -3, 15,Integer.MAX_VALUE})
+                void testIsOdd(int number) {
+                    assertTrue(number % 2 != 0);
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+              
+              class NumbersTest {
+                @ParameterizedTest
+                @ValueSource(ints = {1, 3, 5, -3, 15,Integer.MAX_VALUE})
+                void testIsOdd(int number) {
+                    assertTrue(number % 2 != 0);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyReplacesWithValueSourceAnnotation() {
+        /*
+        This test ensures that the recipe will only run on code that includes a
+        @ValueSource(...) annotation.
+         */
+        rewriteRun(
+          java(
+            """
+              @Test
+              void testIsOdd(int number) {
+                assertTrue(number % 2 != 0);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replacesCsvSource() {
+        rewriteRun(
+          java(
+            """
+              @Test
+              @CsvSource({"test@test.com"})
+              void processUserData(String email) {
+                System.out.println(email);
+              }
+              """,
+            """
+              @ParameterizedTest
+              @CsvSource({"test@test.com"})
+              void processUserData(String email) {
+                System.out.println(email);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replacesMethodSource() {
+        rewriteRun(
+          java(
+            """
+              @Test
+              @MethodSource()
+              void foo() {
+                System.out.println("bar");
+              }
+              """,
+            """
+              @ParameterizedTest
+              @MethodSource()
+              void foo() {
+                System.out.println("bar");
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
This draft PR adds a new recipe which adds missing ParameterizedTest annotations when ValueSource is used or replaces Test with ParameterizedTest.

## What's your motivation?
https://github.com/openrewrite/rewrite-testing-frameworks/issues/314

## Anything in particular you'd like reviewers to focus on?
For some reason whenever the visitor gets to the ValueSource annotation the ValueSource AnnotationMatcher check does not return true. I was having a similar issue with the Test annotation but that was because I wasn't including junit and jupiter resources in the recipe spec. ValueSource is from jupiter so I don't think its the same issue now that I have included those resources in the spec.

## Anyone you would like to review specifically?
@timtebeek 
