### PR TITLE
Migrate Hamcrest Matchers to AssertJ Assertions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJAssertion.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJAssertion.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class HamcrestMatcherToAssertJAssertion extends Recipe {
+
+    @Option(displayName = "Hamcrest Matcher",
+            description = "The Hamcrest matcher to migrate to JUnit5.",
+            example = "equalTo",
+            required = false)
+    @Nullable
+    String matcher;
+
+    @Option(displayName = "AssertJ Assertion",
+            description = "The AssertJ method to migrate to.",
+            example = "isEqualTo",
+            required = false)
+    @Nullable
+    String assertion;
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate from Hamcrest to AssertJ";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate from Hamcrest Matchers to AssertJ assertions.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MigrationFromHamcrestVisitor();
+    }
+
+    private class MigrationFromHamcrestVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private final MethodMatcher matcherAssertMatcher = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+            J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+            if (matcherAssertMatcher.matches(mi) && mi.getArguments().size() == 2) {
+                Expression firstArgument = mi.getArguments().get(0);
+                Expression secondArgument = mi.getArguments().get(1);
+                if (!new MethodMatcher("org.hamcrest.Matchers " + matcher + "(..)").matches(secondArgument)) {
+                    return mi;
+                }
+                String actual = TypeUtils.isString(firstArgument.getType()) ? "#{any(java.lang.String)}" : "#{any(java.lang.Object)}";
+                J.MethodInvocation matcherInvocation = (J.MethodInvocation) secondArgument;
+                List<Expression> originalArguments = matcherInvocation.getArguments().stream()
+                        .filter(a -> !(a instanceof J.Empty))
+                        .collect(Collectors.toList());
+                String assertionArguments = String.join(", ", Collections.nCopies(originalArguments.size(), "#{any(java.lang.Object)}"));
+                JavaTemplate template = JavaTemplate.builder(String.format("assertThat(%s).%s(%s)", actual, assertion, assertionArguments))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(executionContext, "junit-jupiter-api-5.9", "assertj-core-3.24"))
+                        .staticImports("org.assertj.core.api.Assertions.assertThat")
+                        .build();
+                maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                maybeRemoveImport("org.hamcrest.Matchers." + matcher);
+                maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+
+                List<Expression> templateArguments = new ArrayList<>();
+                templateArguments.add(firstArgument);
+                templateArguments.addAll(originalArguments);
+                return template.apply(getCursor(), method.getCoordinates().replace(), templateArguments.toArray());
+            }
+            // TODO Also handle assertThat(String, boolean) and assertThat(String, Object, Matcher)
+            return mi;
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -29,3 +29,19 @@ recipeList:
       version: 2.x
       onlyIfUsing: org.hamcrest.Matchers
       acceptTransitive: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ
+displayName: Migrate to JUnit Jupiter assertions
+description: Migrate Hamcrest `assertThat(Object, Matcher)` to JUnit Jupiter `Assertions`.
+tags:
+  - testing
+  - hamcrest
+  - junit
+recipeList:
+  - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJAssertion:
+      matcher: equalTo
+      assertion: isEqualTo
+  - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJAssertion:
+      matcher: isEmptyString
+      assertion: isEmpty

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJAssertionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJAssertionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class HamcrestMatcherToAssertJAssertionTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-jupiter-api-5.9",
+              "hamcrest-2.2",
+              "assertj-core-3.24"));
+    }
+
+    @Nested
+    class NoArgument {
+        @Test
+        void isEmpty() {
+            rewriteRun(
+              spec -> spec.recipe(new HamcrestMatcherToAssertJAssertion("isEmptyString", "isEmpty")),
+              //language=java
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.isEmptyString;
+                              
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          assertThat(str1, isEmptyString());
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          assertThat(str1).isEmpty();
+                      }
+                  }
+                  """)
+            );
+        }
+    }
+
+    @Nested
+    class SingleArgument {
+
+        @Test
+        void equalToObject() {
+            rewriteRun(
+              spec -> spec.recipe(new HamcrestMatcherToAssertJAssertion("equalTo", "isEqualTo")),
+              //language=java
+              java("""
+                class Biscuit {
+                    String name;
+                    Biscuit(String name) {
+                        this.name = name;
+                    }
+                }
+                """),
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.equalTo;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          Biscuit theBiscuit = new Biscuit("Ginger");
+                          Biscuit myBiscuit = new Biscuit("Ginger");
+                          assertThat(theBiscuit, equalTo(myBiscuit));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          Biscuit theBiscuit = new Biscuit("Ginger");
+                          Biscuit myBiscuit = new Biscuit("Ginger");
+                          assertThat(theBiscuit).isEqualTo(myBiscuit);
+                      }
+                  }
+                  """)
+            );
+        }
+
+        @Test
+        void equalToString() {
+            rewriteRun(
+              spec -> spec.recipe(new HamcrestMatcherToAssertJAssertion("equalTo", "isEqualTo")),
+              //language=java
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.equalTo;
+                              
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          String str2 = "Hello world!";
+                          assertThat(str1, equalTo(str2));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          String str2 = "Hello world!";
+                          assertThat(str1).isEqualTo(str2);
+                      }
+                  }
+                  """)
+            );
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateHamcrestToAssertJTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-jupiter-api-5.9",
+              "hamcrest-2.2",
+              "assertj-core-3.24"))
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.testing.hamcrest")
+            .build()
+            .activateRecipes("org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ"));
+    }
+
+    @Nested
+    class NoArgument {
+        @Test
+        void isEmpty() {
+            //language=java
+            rewriteRun(
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.isEmptyString;
+                              
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          assertThat(str1, isEmptyString());
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          assertThat(str1).isEmpty();
+                      }
+                  }
+                  """)
+            );
+        }
+    }
+
+    @Nested
+    class SingleArgument {
+
+        @Test
+        void equalToObject() {
+            //language=java
+            rewriteRun(
+              java("""
+                class Biscuit {
+                    String name;
+                    Biscuit(String name) {
+                        this.name = name;
+                    }
+                }
+                """),
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.equalTo;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          Biscuit theBiscuit = new Biscuit("Ginger");
+                          Biscuit myBiscuit = new Biscuit("Ginger");
+                          assertThat(theBiscuit, equalTo(myBiscuit));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          Biscuit theBiscuit = new Biscuit("Ginger");
+                          Biscuit myBiscuit = new Biscuit("Ginger");
+                          assertThat(theBiscuit).isEqualTo(myBiscuit);
+                      }
+                  }
+                  """)
+            );
+        }
+
+        @Test
+        void equalToString() {
+            //language=java
+            rewriteRun(
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.equalTo;
+                              
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          String str2 = "Hello world!";
+                          assertThat(str1, equalTo(str2));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class BiscuitTest {
+                      @Test
+                      void testEquals() {
+                          String str1 = "Hello world!";
+                          String str2 = "Hello world!";
+                          assertThat(str1).isEqualTo(str2);
+                      }
+                  }
+                  """)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a generic recipe to replace Hamcrest Matchers with AssertJ Assertions.

## What's your motivation?
Hamcrest has not been released in a _long_ time, whereas AssertJ is more actively maintained.
https://github.com/openrewrite/rewrite-testing-frameworks/issues/212

## Anything in particular you'd like reviewers to focus on?
If there's any additional matchers we can replace, or argument number corner cases missed.

## Anyone you would like to review specifically?
@knutwannheden @kunli2 

## Have you considered any alternatives or workarounds?
I'd assume it's easier to do it this way rather than go for Java templates for match & replacement, since there's less code to maintain this way and this way there's no templates that depend on multiple libraries. We can still use templates for the more complicated cases.

## Any additional context
Similar to #343 ; this is mostly to demonstrate the Yaml recipes I had intended there.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
