### PR TITLE
Alek/remove duplicate test templates

### DIFF
--- a/gradle/licenseHeader.txt
+++ b/gradle/licenseHeader.txt
@@ -1,4 +1,4 @@
-Copyright 2021 the original author or authors.
+Copyright 2023 the original author or authors.
 <p>
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplates.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplates.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplates.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplates.java
@@ -1,0 +1,46 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+public class RemoveDuplicateTestTemplates extends Recipe {
+    private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
+    private static final AnnotationMatcher REPEATED_TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.RepeatedTest");
+
+    public String getDisplayName() {
+        return "Remove duplicates uses of @TestTemplate implementations for a single method";
+    }
+
+    public String getDescription() {
+        return "Remove duplicates uses of @TestTemplate implementations for a single method.";
+    }
+
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("org.junit.jupiter.api.*", false), new RemoveDuplicateTestTemplateVisitor());
+    }
+
+    private static class RemoveDuplicateTestTemplateVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(md, ctx);
+            // first check if @Test or @RepeatedTest is present, else return early
+            if (m.getLeadingAnnotations().stream().noneMatch(TEST_ANNOTATION_MATCHER::matches) ||
+                m.getLeadingAnnotations().stream().noneMatch(REPEATED_TEST_ANNOTATION_MATCHER::matches)) {
+                return m;
+            }
+
+            m = m.withLeadingAnnotations(ListUtils.map(m.getLeadingAnnotations(),
+                    ann -> TEST_ANNOTATION_MATCHER.matches(ann) ? null : ann));
+            maybeRemoveImport("org.junit.jupiter.api.Test");
+
+            return autoFormat(m, ctx);
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
@@ -27,13 +28,15 @@ import static org.openrewrite.java.Assertions.java;
 public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.parser(JavaParser.fromJavaVersion()
-          .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
           .recipe(new RemoveDuplicateTestTemplates());
     }
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/314")
     @Test
+    @DocumentExample
     void removeDuplicate() {
         //language=java
         rewriteRun(
@@ -47,7 +50,7 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
                   @Test
                   @RepeatedTest(3)
                   @DisplayName("When an entry does not exist, it should be created and initialized to 0")
-                  void TestMethod() {
+                  void testMethod() {
                       System.out.println("foobar");
                   }
               }
@@ -55,12 +58,67 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
             """
               import org.junit.jupiter.api.RepeatedTest;
               import org.junit.jupiter.api.DisplayName;
-                            
-              class MyTest {
               
+              class MyTest {
                   @RepeatedTest(3)
                   @DisplayName("When an entry does not exist, it should be created and initialized to 0")
-                  void TestMethod() {
+                  void testMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDuplicateOnly() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+              
+              class MyTest {
+                  @Test
+                  @RepeatedTest(3)
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  void testMethodA() {
+                      System.out.println("foobar");
+                  }
+
+                  @Test
+                  void testMethodB() {
+                      System.out.println("foobar");
+                  }
+
+                  @RepeatedTest(3)
+                  void testMethodC() {
+                      System.out.println("foobar");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+              
+              class MyTest {
+                  @RepeatedTest(3)
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  void testMethodA() {
+                      System.out.println("foobar");
+                  }
+
+                  @Test
+                  void testMethodB() {
+                      System.out.println("foobar");
+                  }
+
+                  @RepeatedTest(3)
+                  void testMethodC() {
                       System.out.println("foobar");
                   }
               }
@@ -83,7 +141,7 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
                   @DisplayName("When an entry does not exist, it should be created and initialized to 0")
                   @RepeatedTest(3)
                   @Test
-                  void TestMethod() {
+                  void testMethod() {
                       System.out.println("foobar");
                   }
               }
@@ -95,7 +153,7 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
               class MyTest {
                   @DisplayName("When an entry does not exist, it should be created and initialized to 0")
                   @RepeatedTest(3)
-                  void TestMethod() {
+                  void testMethod() {
                       System.out.println("foobar");
                   }
               }
@@ -114,7 +172,7 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
               
               class MyTest {
                   @Test
-                  void TestMethod() {
+                  void testMethod() {
                       System.out.println("foobar");
                   }
               }
@@ -133,7 +191,7 @@ public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
               
               class MyTest {
                   @RepeatedTest(3)
-                  void TestMethod() {
+                  void testMethod() {
                       System.out.println("foobar");
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
@@ -1,0 +1,129 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class RemoveDuplicateTestTemplatesTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion()
+          .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
+          .recipe(new RemoveDuplicateTestTemplates());
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/314")
+    @Test
+    void removeDuplicate() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+              
+              class MyTest {
+                  @Test
+                  @RepeatedTest(3)
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+                            
+              class MyTest {
+              
+                  @RepeatedTest(3)
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removesWhenOutOfOrder() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+              
+              class MyTest {
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  @RepeatedTest(3)
+                  @Test
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.RepeatedTest;
+              import org.junit.jupiter.api.DisplayName;
+              
+              class MyTest {
+                  @DisplayName("When an entry does not exist, it should be created and initialized to 0")
+                  @RepeatedTest(3)
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotRemoveWithOnlyTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              
+              class MyTest {
+                  @Test
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotRemoveWithOnlyRepeatedTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.RepeatedTest;
+              
+              class MyTest {
+                  @RepeatedTest(3)
+                  void TestMethod() {
+                      System.out.println("foobar");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveDuplicateTestTemplatesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?
Remove duplicates uses of @TestTemplate implementations for a single method.

## What's your motivation?
[#314](https://github.com/openrewrite/rewrite-testing-frameworks/issues/314)

## Anything in particular you'd like reviewers to focus on?
I think maybe there could be more test cases but I can't think of anymore scenarios to test right now.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
