### PR TITLE
Remove ReplacePowerMockito from inclusion in Mockito1to3

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -111,7 +111,7 @@ recipeList:
   - org.openrewrite.java.testing.mockito.CleanupMockitoImports
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
-  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
+#  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-junit-jupiter


### PR DESCRIPTION
## What's changed?
Disabled ReplacePowerMockito

## What's your motivation?
https://github.com/openrewrite/rewrite-testing-frameworks/issues/358