### PR TITLE
Fix `HamcrestMatcherToAssertJ` when applied to arrays

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
@@ -143,9 +143,16 @@ public class HamcrestMatcherToAssertJ extends Recipe {
         }
 
         private String typeToIndicator(JavaType type) {
-            String str = type instanceof JavaType.Primitive || type.toString().startsWith("java.") ?
-                    type.toString().replaceAll("<.*>", "") : "java.lang.Object";
-            return String.format("#{any(%s)}", str);
+            if (type instanceof JavaType.Array) {
+                type = ((JavaType.Array) type).getElemType();
+                String str = type instanceof JavaType.Primitive || type.toString().startsWith("java.") ?
+                        type.toString().replaceAll("<.*>", "") : "java.lang.Object";
+                return String.format("#{anyArray(%s)}", str);
+            } else {
+                String str = type instanceof JavaType.Primitive || type.toString().startsWith("java.") ?
+                        type.toString().replaceAll("<.*>", "") : "java.lang.Object";
+                return String.format("#{any(%s)}", str);
+            }
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJTest.java
@@ -323,6 +323,49 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
                   """)
             );
         }
+
+        @SuppressWarnings("DataFlowIssue")
+        @Test
+        void containsInAnyOrderWithArray() {
+            rewriteRun(
+              spec -> spec.recipe(new HamcrestMatcherToAssertJ("containsInAnyOrder", "containsExactlyInAnyOrder")),
+              //language=java
+              java("""
+                  import org.junit.jupiter.api.Test;
+                                
+                  import java.util.ArrayList;
+                  import java.util.List;
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.Matchers.containsInAnyOrder;
+                              
+                  class ATest {
+                      @Test
+                      void test() {
+                          List<String> list = new ArrayList<>();
+                          List<String> states = null;
+                          assertThat(list, containsInAnyOrder(states.toArray()));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import java.util.ArrayList;
+                  import java.util.List;
+                  
+                  import static org.assertj.core.api.Assertions.assertThat;
+                              
+                  class ATest {
+                      @Test
+                      void test() {
+                          List<String> list = new ArrayList<>();
+                          List<String> states = null;
+                          assertThat(list).containsExactlyInAnyOrder(states.toArray());
+                      }
+                  }
+                  """)
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes: #364
