### PR TITLE
Alek/including new recipes in recipe list best practices

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -26,6 +26,8 @@ recipeList:
   - org.openrewrite.java.testing.junit5.JUnit4to5Migration
   - org.openrewrite.java.testing.junit5.CleanupAssertions
   - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
+  - org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation
+  - org.openrewrite.java.testing.junit5.RemoveDuplicateTestTemplates
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.StaticImports
@@ -81,8 +83,6 @@ recipeList:
   - org.openrewrite.java.testing.junit5.AddMissingNested
   - org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed
   - org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer
-  - org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation
-  - org.openrewrite.java.testing.junit5.RemoveDuplicateTestTemplates
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: junit
       artifactId: junit

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -81,6 +81,8 @@ recipeList:
   - org.openrewrite.java.testing.junit5.AddMissingNested
   - org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed
   - org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer
+  - org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation
+  - org.openrewrite.java.testing.junit5.RemoveDuplicateTestTemplates
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: junit
       artifactId: junit


### PR DESCRIPTION
## What's changed?
Accidentally placed the AddParameterizedTestAnnotation and RemoveDuplicateTestTemplate recipes in the JUnit4 to JUnit5 migration list, they should have been in the best practices list. I fixed that in the yml. 

## What's your motivation?
This [comment](https://github.com/openrewrite/rewrite-testing-frameworks/pull/362#discussion_r1234289224) from the last PR to do this last week. 

## Any additional context
This [discussion](https://github.com/openrewrite/rewrite-testing-frameworks/pull/362#discussion_r1234289224) is where this comes from.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
