### PR TITLE
Changed type to functional interface 

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -121,7 +121,7 @@ public class UpdateTestAnnotation extends Recipe {
                             .visitNonNull(m, ctx, getCursor().getParentOrThrow());
                 }
                 if (cta.expectedException != null) {
-                    m = JavaTemplate.builder("Object o = () -> #{};")
+                    m = JavaTemplate.builder("org.junit.jupiter.api.function.Executable o = () -> #{};")
                             .contextSensitive()
                             .build()
                             .apply(


### PR DESCRIPTION
## What's changed?
The recipe UpdateTestAnnotation was causing a `ClassCastException` because the generated code in a JavaTemplate was invalid. It was trying to assign a lambda expression to an `Object` variable. It seems that this is possible in general, since it's done in the tests and those are passing. However, when trying to apply the recipe to the spring-petclinic workshop, it was causing this exception in a test, and causing the recipe to fail to apply changes in this specific file.
Changing the type of the variable to a functional interface (`org.junit.jupiter.api.function.Executable` has been chosen since it makes sense in the context of the recipe, actually, we cast the lambda expression to this type afterwards), causes no harm to the already passing tests without any change, and also works well on the spring-petclinic workshop.

## What's your motivation?
To have a clean run execution of the recipe on the spring-petclinic repository, and probably others too.
