### PR TITLE
fix: assertj contains is weaker than hamcrests contains

### DIFF
--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -140,7 +140,7 @@ recipeList:
   # List Matchers
   - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJ:
       matcher: contains
-      assertion: contains
+      assertion: containsExactly
   - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJ:
       matcher: containsInAnyOrder
       assertion: containsExactlyInAnyOrder

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -229,7 +229,7 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
 
     private static Stream<Arguments> listReplacements() {
         return Stream.of(
-          Arguments.arguments("list1", "contains", "item", "contains"),
+          Arguments.arguments("list1", "contains", "item", "containsExactly"),
           Arguments.arguments("list1", "containsInAnyOrder", "item", "containsExactlyInAnyOrder"),
           Arguments.arguments("list1", "containsInRelativeOrder", "item", "containsExactly"),
           Arguments.arguments("list1", "empty", "", "isEmpty"),


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Hamcrest's `contains` matches AssertJ's `containsExactly`. AssertJs `contains` does not care about order and completeness. Hamcrests `contains` does, see the [docs](https://hamcrest.org/JavaHamcrest/javadoc/2.1/org/hamcrest/Matchers.html#contains-E...-)!

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Fix this bug.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Should I create an issue or is just the pr fine?

Another topic: I am not so sure about the mapping of [containsInRelativeOrder to containsExactly](https://github.com/openrewrite/rewrite-testing-frameworks/blob/main/src/main/resources/META-INF/rewrite/hamcrest.yml#L148C30-L148C30) as I don't know how `containsInRelativeOrder` works. From the docs I don't understand if it matches for completeness in both directions. Kind of related to this pr, but also a different topic.

## Anyone you would like to review specifically?
<!-- @mention them here -->
no

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
It is a bug to me.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
