### PR TITLE
Assert instance of migration

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -1,0 +1,91 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "assertTrue(x instanceof y) to assertInstanceOf(y.class, x)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migration of JUnit4 (or potentially JUnit5) test case in form of assertTrue(x instanceof y) to assertInstanceOf(y.class, x).";
+    }
+
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
+                MethodMatcher junit5Matcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(* instanceof *,String)");
+                MethodMatcher junit4Matcher = new MethodMatcher("org.junit.Assert assertTrue(..,* instanceof *)");
+
+                J clazz;
+                Expression expression;
+                Expression reason;
+
+                if (junit5Matcher.matches(mi)) {
+                    System.out.println("matched");
+                    maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
+                    Expression argument = mi.getArguments().get(0);
+                    if (mi.getArguments().size() == 1) {
+                        reason = null;
+                    } else if (mi.getArguments().size() == 2) {
+                        reason = mi.getArguments().get(1);
+                    } else return mi;
+
+                    if (argument instanceof J.InstanceOf) {
+                        J.InstanceOf instanceOf = (J.InstanceOf) argument;
+                        expression = instanceOf.getExpression();
+                        clazz = instanceOf.getClazz();
+                    } else {
+                        return mi;
+                    }
+                } else if (junit4Matcher.matches(mi)) {
+                    maybeRemoveImport("org.junit.Assert.assertTrue");
+                    Expression argument;
+                    if (mi.getArguments().size() == 1) {
+                        reason = null;
+                        argument = mi.getArguments().get(0);
+                    } else if (mi.getArguments().size() == 2) {
+                        reason = mi.getArguments().get(0);
+                        argument = mi.getArguments().get(1);
+                    } else return mi;
+
+                    if (argument instanceof J.InstanceOf) {
+                        J.InstanceOf instanceOf = (J.InstanceOf) argument;
+                        expression = instanceOf.getExpression();
+                        clazz = instanceOf.getClazz();
+                    } else {
+                        return mi;
+                    }
+                } else {
+                    return mi;
+                }
+
+
+                JavaTemplate template = JavaTemplate
+                    .builder("assertInstanceOf(#{}.class, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(executionContext, "junit-jupiter-api-5.9", "junit-4.13"))
+                    .staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf")
+                    .build();
+
+                J.MethodInvocation methodd = reason != null
+                    ? template.apply(getCursor(), mi.getCoordinates().replace(), clazz.toString(), expression, reason)
+                    : template.apply(getCursor(), mi.getCoordinates().replace(), clazz.toString(), expression);
+                maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
+                return methodd;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -42,8 +42,8 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, executionContext);
-                MethodMatcher junit5Matcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(* instanceof *,String)");
-                MethodMatcher junit4Matcher = new MethodMatcher("org.junit.Assert assertTrue(..,* instanceof *)");
+                MethodMatcher junit5Matcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(boolean, ..)");
+                MethodMatcher junit4Matcher = new MethodMatcher("org.junit.Assert assertTrue(.., boolean)");
 
                 J clazz;
                 Expression expression;

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.openrewrite.ExecutionContext;

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -1,0 +1,171 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9", "junit-4.13"))
+          .recipe(new AssertTrueInstanceofToAssertInstanceOf());
+    }
+
+    @Test
+    void testJUnit5() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertTrue(list instanceof Iterable);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertInstanceOf(Iterable.class, list);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void testJUnit5WithReason() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertTrue(list instanceof Iterable, "Not instance of Iterable");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertInstanceOf(Iterable.class, list, "Not instance of Iterable");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void testJUnit4() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.Assert.assertTrue;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertTrue(list instanceof Iterable);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertInstanceOf(Iterable.class, list);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void testJUnit4WithReason() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.Assert.assertTrue;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertTrue("Not instance of Iterable", list instanceof Iterable);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+              
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertInstanceOf(Iterable.class, list, "Not instance of Iterable");
+                  }
+              }
+              """
+          ));
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Added recipe which migrates JUnit4 (or JUnit5) assertTrue(x instanceof y) into JUnit5 assertInstanceOf(y.class, x)

## What's changed?
Added recipe which migrates JUnit4 (or JUnit5) assertTrue(x instanceof y) into JUnit5 assertInstanceOf(y.class, x)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)