### PR TITLE
Limit `RemoveIsMatcher` to invocations within `assertThat`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
@@ -41,15 +41,11 @@ public class RemoveIsMatcher extends Recipe {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-                Cursor c = getCursor().dropParentWhile(cr -> cr instanceof J.Block ||
-                                                             cr instanceof J.Identifier ||
-                                                             !(cr instanceof Tree));
-
-                if (IS_MATCHER.matches(mi) && c.getMessage("CHANGES_KEY") != null) {
+                if (ASSERT_THAT_MATCHER.matches(mi)) {
+                    getCursor().putMessage("ASSERT_THAT", mi);
+                } else if (IS_MATCHER.matches(mi) && getCursor().pollNearestMessage("ASSERT_THAT") != null) {
                     maybeRemoveImport("org.hamcrest.Matchers.is");
                     return mi.getArguments().get(0).withPrefix(mi.getPrefix());
-                }else if (ASSERT_THAT_MATCHER.matches(mi)) {
-                    getCursor().putMessage("CHANGES_KEY", mi);
                 }
                 return super.visitMethodInvocation(mi, ctx);
             }

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
@@ -15,13 +15,13 @@
  */
 package org.openrewrite.java.testing.hamcrest;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.TreeVisitingPrinter;
 import org.openrewrite.java.tree.J;
 
+@SuppressWarnings("NullableProblems")
 public class RemoveIsMatcher extends Recipe {
     @Override
     public String getDisplayName() {
@@ -34,15 +34,22 @@ public class RemoveIsMatcher extends Recipe {
     }
 
     static final MethodMatcher IS_MATCHER = new MethodMatcher("org.hamcrest.Matchers is(org.hamcrest.Matcher)");
+    static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-                if (IS_MATCHER.matches(mi)) {
+                Cursor c = getCursor().dropParentWhile(cr -> cr instanceof J.Block ||
+                                                             cr instanceof J.Identifier ||
+                                                             !(cr instanceof Tree));
+
+                if (IS_MATCHER.matches(mi) && c.getMessage("CHANGES_KEY") != null) {
                     maybeRemoveImport("org.hamcrest.Matchers.is");
                     return mi.getArguments().get(0).withPrefix(mi.getPrefix());
+                }else if (ASSERT_THAT_MATCHER.matches(mi)) {
+                    getCursor().putMessage("CHANGES_KEY", mi);
                 }
                 return super.visitMethodInvocation(mi, ctx);
             }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -98,8 +98,7 @@ class RemoveIsMatcherTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
               import static org.hamcrest.MatcherAssert.assertThat;
-              import static org.hamcrest.Matchers.is;
-              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.*;
               
               class ATest {
                   @Test

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -68,4 +68,28 @@ class RemoveIsMatcherTest implements RewriteTest {
             """));
     }
 
+    @Test
+    void isNotCalledInAssertThat() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.Matchers.is;
+              import static org.hamcrest.Matchers.equalTo;
+              
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "Hello world!";
+                      Matcher<String> x = is(equalTo(str1));
+                  }
+              }
+              """,
+            """
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -113,4 +113,30 @@ class RemoveIsMatcherTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noReplacementForOtherMethodInvocations() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matcher;
+              import static org.hamcrest.Matchers.*;
+              
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      foo(is(equalTo(str2)));
+                  }
+                  
+                  void foo(Matcher<String> matcher) {
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -105,7 +105,7 @@ class RemoveIsMatcherTest implements RewriteTest {
                   void testMethod() {
                       String str1 = "Hello world!";
                       String str2 = "Hello world!";
-                      assertThat(str1, contains(is(equalTo(str2))));
+                      assertThat(str1, not(is(equalTo(str2))));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -108,6 +108,21 @@ class RemoveIsMatcherTest implements RewriteTest {
                       assertThat(str1, not(is(equalTo(str2))));
                   }
               }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.not;
+              import static org.hamcrest.Matchers.equalTo;
+              
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, not(equalTo(str2)));
+                  }
+              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcherTest.java
@@ -85,8 +85,30 @@ class RemoveIsMatcherTest implements RewriteTest {
                       Matcher<String> x = is(equalTo(str1));
                   }
               }
-              """,
+              """
+          )
+        );
+    }
+
+    @Test
+    void isNotDirectlyInAssertThat() {
+        //language=java
+        rewriteRun(
+          java(
             """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.is;
+              import static org.hamcrest.Matchers.equalTo;
+              
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, contains(is(equalTo(str2))));
+                  }
+              }
               """
           )
         );


### PR DESCRIPTION
## What's changed?
This PR fixes an issue where the recipe that removed `is()` invocations would remove them even when they were not found directly inside of an `assertThat` invocation.

## What's your motivation?
[#365](https://github.com/openrewrite/rewrite-testing-frameworks/issues/365)

## Anything in particular you'd like reviewers to focus on?
I added two tests based off of the last comment on the ticket. Both tests now pass in this PR, so I think the bug should be fixed. I think how I implemented the fix shouldn't interfere with any other parts of the recipe.

## Anyone you would like to review specifically?
@timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
