### PR TITLE
Flatten Hamcrest assertThat allOf

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,5 @@
 @file:Suppress("GradlePackageUpdate")
 
-import java.util.*
-
 plugins {
     id("org.openrewrite.build.recipe-library") version "latest.release"
 }
@@ -34,6 +32,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-gradle")
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
+    implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
     compileOnly("org.projectlombok:lombok:latest.release")

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
@@ -1,0 +1,81 @@
+package org.openrewrite.java.testing.hamcrest;
+
+import org.openrewrite.*;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaCoordinates;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FlattenAllOf extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Convert Hamcrest `allOf(Matcher...)` to individual `assertThat` statements";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Convert Hamcrest `allOf(Matcher...)` to individual `assertThat` statements for easier migration.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesMethod<>("org.hamcrest.Matchers allOf(..)"),
+                new FlattenAllOfVisitor());
+    }
+}
+
+class FlattenAllOfVisitor extends JavaVisitor<ExecutionContext> {
+    private final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
+    private final MethodMatcher ALL_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers allOf(..)");
+
+    @Override
+    public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+        J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+
+        List<Statement> newStatements = new ArrayList<>();
+        for (Statement statement : md.getBody().getStatements()) {
+            if (statement instanceof J.MethodInvocation) {
+                J.MethodInvocation assertThat = (J.MethodInvocation) statement;
+                if (ASSERT_THAT_MATCHER.matches(assertThat)) {
+                    List<Expression> assertThatArguments = assertThat.getArguments();
+                    Expression actual = assertThatArguments.get(assertThatArguments.size() - 2);
+                    Expression matcherExpression = assertThatArguments.get(assertThatArguments.size() - 1);
+                    if (ALL_OF_MATCHER.matches(matcherExpression)) {
+                        J.MethodInvocation allOf = (J.MethodInvocation) matcherExpression;
+                        List<Expression> matchers = allOf.getArguments();
+                        if (1 < matchers.size()) { // Iterable? Inadvertent use of allOf with single Matcher?
+                            for (Expression matcher : matchers) {
+                                JavaTemplate template = JavaTemplate.builder("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});")
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
+                                        .staticImports("org.hamcrest.MatcherAssert.assertThat")
+                                        .build();
+                                // TODO figure out correct use of cooridnates and cursor when inserting multiple new statements
+                                JavaCoordinates coordinates = newStatements.isEmpty() ?
+                                        assertThat.getCoordinates().replace() :
+                                        newStatements.get(newStatements.size() - 1).getCoordinates().after();
+                                Cursor cursor = null;
+                                J.MethodInvocation newAssertThat = template.apply(cursor, coordinates, actual, matcher);
+                                newStatements.add(newAssertThat);
+                            }
+                            continue;
+                        }
+                    }
+
+                }
+            }
+            // Keep the original statement
+            newStatements.add(statement);
+        }
+
+        return md.withBody(md.getBody().withStatements(newStatements));
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
@@ -61,7 +61,7 @@ class FlattenAllOfVisitor extends JavaVisitor<ExecutionContext> {
 
         List<Expression> arguments = mi.getArguments();
         Expression allOf = arguments.get(arguments.size() - 1);
-        if (!ASSERT_THAT_MATCHER.matches(mi) && !ALL_OF_MATCHER.matches(allOf)) {
+        if (!ASSERT_THAT_MATCHER.matches(mi) || !ALL_OF_MATCHER.matches(allOf)) {
             return mi;
         }
 

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.hamcrest;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
@@ -11,8 +11,10 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaCoordinates;
 import org.openrewrite.java.tree.Statement;
 
+import javax.naming.ldap.ExtendedRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class FlattenAllOf extends Recipe {
     @Override
@@ -33,49 +35,73 @@ public class FlattenAllOf extends Recipe {
     }
 }
 
+@SuppressWarnings("NullableProblems")
 class FlattenAllOfVisitor extends JavaVisitor<ExecutionContext> {
     private final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
     private final MethodMatcher ALL_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers allOf(..)");
 
+    //@Override
+    //public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+    //    J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+    //    if (md.getBody() == null) { return md; }
+
+    //    List<Statement> newStatements = md.getBody().getStatements().stream().map(statement -> {
+    //        if (statement instanceof J.MethodInvocation) {
+    //            J.MethodInvocation assertThat = (J.MethodInvocation) statement;
+    //            if (ASSERT_THAT_MATCHER.matches(assertThat)) {
+    //                List<Expression> assertThatArguments = assertThat.getArguments();
+    //                Expression actual = assertThatArguments.get(assertThatArguments.size() - 2);
+    //                Expression matcherExpression = assertThatArguments.get(assertThatArguments.size() - 1);
+    //                if (ALL_OF_MATCHER.matches(matcherExpression)) {
+    //                    J.MethodInvocation allOf = (J.MethodInvocation) matcherExpression;
+    //                    List<Expression> matchers = allOf.getArguments();
+    //                    for (Expression matcher : matchers) {
+    //                        JavaTemplate template = JavaTemplate.builder("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});")
+    //                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
+    //                                .staticImports("org.hamcrest.MatcherAssert.assertThat")
+    //                                .build();
+    //                        // TODO figure out correct use of coordinates and cursor when inserting multiple new statements
+    //                        JavaCoordinates coordinates = assertThat.getCoordinates().replace();
+    //                        Cursor cursor = null;
+    //                        return template.apply(getCursor(), coordinates, actual, matcher);
+    //                    }
+    //                    //continue;
+    //                }
+    //            }
+    //        }
+    //        // Keep the original statement
+    //        return statement;
+    //    }).collect(Collectors.toList());
+
+
+    //    return md.withBody(md.getBody().withStatements(newStatements));
+    //}
+
     @Override
-    public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-        J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
+    public J visitMethodInvocation(J.MethodInvocation invocation, ExecutionContext ctx) {
+        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(invocation, ctx);
 
-        List<Statement> newStatements = new ArrayList<>();
-        for (Statement statement : md.getBody().getStatements()) {
-            if (statement instanceof J.MethodInvocation) {
-                J.MethodInvocation assertThat = (J.MethodInvocation) statement;
-                if (ASSERT_THAT_MATCHER.matches(assertThat)) {
-                    List<Expression> assertThatArguments = assertThat.getArguments();
-                    Expression actual = assertThatArguments.get(assertThatArguments.size() - 2);
-                    Expression matcherExpression = assertThatArguments.get(assertThatArguments.size() - 1);
-                    if (ALL_OF_MATCHER.matches(matcherExpression)) {
-                        J.MethodInvocation allOf = (J.MethodInvocation) matcherExpression;
-                        List<Expression> matchers = allOf.getArguments();
-                        if (1 < matchers.size()) { // Iterable? Inadvertent use of allOf with single Matcher?
-                            for (Expression matcher : matchers) {
-                                JavaTemplate template = JavaTemplate.builder("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});")
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
-                                        .staticImports("org.hamcrest.MatcherAssert.assertThat")
-                                        .build();
-                                // TODO figure out correct use of cooridnates and cursor when inserting multiple new statements
-                                JavaCoordinates coordinates = newStatements.isEmpty() ?
-                                        assertThat.getCoordinates().replace() :
-                                        newStatements.get(newStatements.size() - 1).getCoordinates().after();
-                                Cursor cursor = null;
-                                J.MethodInvocation newAssertThat = template.apply(cursor, coordinates, actual, matcher);
-                                newStatements.add(newAssertThat);
-                            }
-                            continue;
-                        }
-                    }
-
-                }
-            }
-            // Keep the original statement
-            newStatements.add(statement);
+        List<Expression> arguments = mi.getArguments();
+        if (!ASSERT_THAT_MATCHER.matches(mi) && !ALL_OF_MATCHER.matches(arguments.get(arguments.size() - 1))) {
+            return mi;
         }
 
-        return md.withBody(md.getBody().withStatements(newStatements));
+        Expression actual = arguments.get(arguments.size() - 2);
+        List<Expression> allOfArgs = ((J.MethodInvocation) arguments.get(arguments.size() - 1)).getArguments();
+
+        StringBuilder stringBuilderTemplate = new StringBuilder();
+        List<Expression> replacements = new ArrayList<>();
+        for (Expression matcher : allOfArgs) {
+            stringBuilderTemplate.append("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});\n");
+            replacements.add(actual);
+            replacements.add(matcher);
+        }
+        JavaTemplate template = JavaTemplate.builder(stringBuilderTemplate.toString())
+                .contextSensitive()
+                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
+                .staticImports("org.hamcrest.MatcherAssert.assertThat")
+                .build();
+
+        return template.apply(getCursor(), mi.getCoordinates().replace(), replacements.toArray());
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/FlattenAllOf.java
@@ -1,6 +1,9 @@
 package org.openrewrite.java.testing.hamcrest;
 
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -8,13 +11,10 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaCoordinates;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.staticanalysis.RemoveUnneededBlock;
 
-import javax.naming.ldap.ExtendedRequest;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class FlattenAllOf extends Recipe {
     @Override
@@ -40,68 +40,44 @@ class FlattenAllOfVisitor extends JavaVisitor<ExecutionContext> {
     private final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
     private final MethodMatcher ALL_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers allOf(..)");
 
-    //@Override
-    //public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-    //    J.MethodDeclaration md = (J.MethodDeclaration) super.visitMethodDeclaration(method, ctx);
-    //    if (md.getBody() == null) { return md; }
-
-    //    List<Statement> newStatements = md.getBody().getStatements().stream().map(statement -> {
-    //        if (statement instanceof J.MethodInvocation) {
-    //            J.MethodInvocation assertThat = (J.MethodInvocation) statement;
-    //            if (ASSERT_THAT_MATCHER.matches(assertThat)) {
-    //                List<Expression> assertThatArguments = assertThat.getArguments();
-    //                Expression actual = assertThatArguments.get(assertThatArguments.size() - 2);
-    //                Expression matcherExpression = assertThatArguments.get(assertThatArguments.size() - 1);
-    //                if (ALL_OF_MATCHER.matches(matcherExpression)) {
-    //                    J.MethodInvocation allOf = (J.MethodInvocation) matcherExpression;
-    //                    List<Expression> matchers = allOf.getArguments();
-    //                    for (Expression matcher : matchers) {
-    //                        JavaTemplate template = JavaTemplate.builder("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});")
-    //                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
-    //                                .staticImports("org.hamcrest.MatcherAssert.assertThat")
-    //                                .build();
-    //                        // TODO figure out correct use of coordinates and cursor when inserting multiple new statements
-    //                        JavaCoordinates coordinates = assertThat.getCoordinates().replace();
-    //                        Cursor cursor = null;
-    //                        return template.apply(getCursor(), coordinates, actual, matcher);
-    //                    }
-    //                    //continue;
-    //                }
-    //            }
-    //        }
-    //        // Keep the original statement
-    //        return statement;
-    //    }).collect(Collectors.toList());
-
-
-    //    return md.withBody(md.getBody().withStatements(newStatements));
-    //}
-
     @Override
     public J visitMethodInvocation(J.MethodInvocation invocation, ExecutionContext ctx) {
         J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(invocation, ctx);
 
         List<Expression> arguments = mi.getArguments();
-        if (!ASSERT_THAT_MATCHER.matches(mi) && !ALL_OF_MATCHER.matches(arguments.get(arguments.size() - 1))) {
+        Expression allOf = arguments.get(arguments.size() - 1);
+        if (!ASSERT_THAT_MATCHER.matches(mi) && !ALL_OF_MATCHER.matches(allOf)) {
             return mi;
         }
 
+        Expression reason = arguments.size() == 3 ? arguments.get(0) : null;
         Expression actual = arguments.get(arguments.size() - 2);
-        List<Expression> allOfArgs = ((J.MethodInvocation) arguments.get(arguments.size() - 1)).getArguments();
 
-        StringBuilder stringBuilderTemplate = new StringBuilder();
-        List<Expression> replacements = new ArrayList<>();
-        for (Expression matcher : allOfArgs) {
-            stringBuilderTemplate.append("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});\n");
-            replacements.add(actual);
-            replacements.add(matcher);
+        // Wrap statements in a block, as JavaTemplate can only return one element
+        StringBuilder blockTemplate = new StringBuilder();
+        blockTemplate.append("{");
+        List<Expression> parameters = new ArrayList<>();
+        for (Expression matcher : ((J.MethodInvocation) allOf).getArguments()) {
+            if (reason == null) {
+                blockTemplate.append("assertThat(#{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});");
+            } else {
+                blockTemplate.append("assertThat(#{any(java.lang.String)}, #{any(java.lang.Object)}, #{any(org.hamcrest.Matcher)});");
+                parameters.add(reason);
+            }
+            parameters.add(actual);
+            parameters.add(matcher);
         }
-        JavaTemplate template = JavaTemplate.builder(stringBuilderTemplate.toString())
+        blockTemplate.append("}");
+
+        JavaTemplate template = JavaTemplate.builder(blockTemplate.toString())
                 .contextSensitive()
                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "hamcrest-2.2"))
                 .staticImports("org.hamcrest.MatcherAssert.assertThat")
                 .build();
 
-        return template.apply(getCursor(), mi.getCoordinates().replace(), replacements.toArray());
+        // Remove wrapping block and allOf import after template is applied
+        doAfterVisit(new RemoveUnneededBlock().getVisitor());
+        maybeRemoveImport("org.hamcrest.Matchers.allOf");
+        return template.apply(getCursor(), mi.getCoordinates().replace(), parameters.toArray());
     }
 }

--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -42,6 +42,9 @@ recipeList:
   # First remove wrapping `is(Matcher)` calls such that further recipes will match
   - org.openrewrite.java.testing.hamcrest.RemoveIsMatcher
 
+  # Flatten calls to `MatcherAssert.assertThat(.., allOf(..))` to easier to migrate individual statements
+  - org.openrewrite.java.testing.hamcrest.FlattenAllOf
+
   # Then remove calls to `MatcherAssert.assertThat(String, boolean)`
   - org.openrewrite.java.testing.hamcrest.AssertThatBooleanToAssertJ
 

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/FlattenAllOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/FlattenAllOfTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class FlattenAllOfTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new FlattenAllOf())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-jupiter-api-5.9",
+              "hamcrest-2.2",
+              "assertj-core-3.24"));
+    }
+
+    @DocumentExample
+    @Test
+    void flattenAllOfStringMatchers() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.allOf;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.hasLength;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1, allOf(equalTo(str2), hasLength(12)));
+                }
+            }
+            ""","""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.hasLength;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1, equalTo(str2));
+                    assertThat(str1, hasLength(12));
+                }
+            }
+            """));
+    }
+
+    @Test
+    void flattenAllOfStringMatchersWithReason() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.allOf;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.hasLength;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat("str1 and str2 should be equal", str1, allOf(equalTo(str2), hasLength(12)));
+                }
+            }
+            ""","""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.hasLength;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat("str1 and str2 should be equal", str1, equalTo(str2));
+                    assertThat("str1 and str2 should be equal", str1, hasLength(12));
+                }
+            }
+            """));
+    }
+
+    @Test
+    void flattenAllOfIntMatchers() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.allOf;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.greaterThan;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    int i = 1;
+                    assertThat(i, allOf(equalTo(1), greaterThan(0)));
+                }
+            }
+            ""","""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.greaterThan;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    int i = 1;
+                    assertThat(i, equalTo(1));
+                    assertThat(i, greaterThan(0));
+                }
+            }
+            """));
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -81,6 +81,43 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
             }
             """));
     }
+    @DocumentExample
+    @Test
+    void flattenAllOfStringMatchersAndConvert() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.allOf;
+            import static org.hamcrest.Matchers.equalTo;
+            import static org.hamcrest.Matchers.hasLength;
+                            
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1, allOf(equalTo(str2), hasLength(12)));
+                }
+            }
+            ""","""
+            import org.junit.jupiter.api.Test;
+
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            class ATest {
+                @Test
+                void test() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1).isEqualTo(str2);
+                    assertThat(str1).hasSize(12);
+                }
+            }
+            """));
+    }
 
     private static Stream<Arguments> arrayReplacements() {
         return Stream.of(


### PR DESCRIPTION
## What's changed?
Convert Hamcrest `allOf(Matcher...)` to individual `assertThat` statements for easier migration.

## What's your motivation?
For #357

## Anything in particular you'd like reviewers to focus on?
Correct use of cursor & coordinates.

## Have you considered any alternatives or workarounds?
Initially tried with `visitMethodInvocation`, but that also complained when inserting more than one statement, even when part of the same JavaTemplate string.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
