### PR TITLE
removed containsInRelativeOrder from yaml list

### DIFF
--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -145,9 +145,6 @@ recipeList:
       matcher: containsInAnyOrder
       assertion: containsExactlyInAnyOrder
   - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJ:
-      matcher: containsInRelativeOrder
-      assertion: containsExactly
-  - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJ:
       matcher: empty
       assertion: isEmpty
   - org.openrewrite.java.testing.hamcrest.HamcrestMatcherToAssertJ:

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -231,7 +231,6 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         return Stream.of(
           Arguments.arguments("list1", "contains", "item", "containsExactly"),
           Arguments.arguments("list1", "containsInAnyOrder", "item", "containsExactlyInAnyOrder"),
-          Arguments.arguments("list1", "containsInRelativeOrder", "item", "containsExactly"),
           Arguments.arguments("list1", "empty", "", "isEmpty"),
           Arguments.arguments("list1", "hasSize", "5", "hasSize"),
           Arguments.arguments("list1", "hasItem", "item", "contains"),


### PR DESCRIPTION
## What's changed?
The containsInRelativeOrder matcher recipe has been removed from the `hamcrest.yml` list. 

## What's your motivation?
[this issue](https://github.com/openrewrite/rewrite-testing-frameworks/pull/371#issuecomment-1622442507)

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
It seems that there is currently no direct replacement for the hamcrest matcher `containsInRelativeOrder`in AssertJ. The closest method in AssetJ would be `containsExactlyInOrder` but these two methods are not *quite* the same. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
