### PR TITLE
Changed AnyToNullable from declarative to imperative so that it can h…

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/AnyToNullable.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AnyToNullable.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.java.ChangeMethodTargetToStatic;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AnyToNullable extends ScanningRecipe<AtomicBoolean> {
+    @Override
+    public String getDisplayName() {
+        return "Replace Mockito 1.x `anyString()`/`any()` with `nullable(Class)`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Since Mockito 2.10 `anyString()` and `any()` no longer matches null values. Use `nullable(Class)` instead.";
+    }
+
+    @Override
+    public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+        return new AtomicBoolean();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
+        org.openrewrite.maven.search.FindDependency mavenFindDependency =
+                new org.openrewrite.maven.search.FindDependency("org.mockito", "mockito-all");
+        org.openrewrite.gradle.search.FindDependency gradleFindDependency =
+                new org.openrewrite.gradle.search.FindDependency("org.mockito", "mockito-all", null);
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (!acc.get()) {
+                    if (tree instanceof Xml.Document && tree != mavenFindDependency.getVisitor().visit(tree, ctx)) {
+                        acc.set(true);
+                    } else if (tree instanceof J && tree != gradleFindDependency.getVisitor().visit(tree, ctx)) {
+                        acc.set(true);
+                    }
+                }
+                return tree;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean acc) {
+        ChangeMethodName changeMethodName = new ChangeMethodName(
+                "org.mockito.Mockito any(java.lang.Class)", "nullable", null, null);
+        ChangeMethodTargetToStatic changeMethodTargetToStatic = new ChangeMethodTargetToStatic(
+                "org.mockito.Mockito nullable(java.lang.Class)", "org.mockito.ArgumentMatchers", null, null);
+        AnyStringToNullable anyStringToNullable = new AnyStringToNullable();
+        return Preconditions.check(acc.get(), new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof J) {
+                    doAfterVisit(changeMethodName.getVisitor());
+                    doAfterVisit(changeMethodTargetToStatic.getVisitor());
+                    doAfterVisit(anyStringToNullable.getVisitor());
+                }
+                return super.visit(tree, ctx);
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -123,37 +123,6 @@ recipeList:
       newVersion: 3.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.testing.mockito.UsesMockitoAll
-displayName: Uses Mockito all from v1.x
-description: Finds projects that depend on `mockito-all` through Maven or Gradle.
-tags:
-  - testing
-  - mockito
-recipeList:
-  - org.openrewrite.maven.search.FindDependency:
-      groupId: org.mockito
-      artifactId: mockito-all
-  - org.openrewrite.gradle.search.FindDependency:
-      groupId: org.mockito
-      artifactId: mockito-all
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.testing.mockito.AnyToNullable
-displayName: Replace Mockito 1.x `any(Class)` and `anyString()` with `nullable(Class)`
-description: Since Mockito 2.10 `any(Class)` and `anyString()` no longer match null values. Use `nullable(Class)` instead.
-tags:
-  - testing
-  - mockito
-recipeList:
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.mockito.Mockito any(java.lang.Class)
-      newMethodName: nullable
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: org.mockito.Mockito nullable(java.lang.Class)
-      fullyQualifiedTargetTypeName: org.mockito.ArgumentMatchers
-  - org.openrewrite.java.testing.mockito.AnyStringToNullable
----
-type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.mockito.ReplacePowerMockito
 displayName: Replace PowerMock with raw Mockito
 description: Replace PowerMock with raw Mockito.

--- a/src/test/java/org/openrewrite/java/testing/mockito/AnyStringToNullableTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/AnyStringToNullableTest.java
@@ -50,7 +50,7 @@ class AnyStringToNullableTest implements RewriteTest {
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
-
+              
               class MyTest {
                   void test() {
                       Example example = mock(Example.class);
@@ -62,7 +62,7 @@ class AnyStringToNullableTest implements RewriteTest {
               import static org.mockito.ArgumentMatchers.nullable;
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
-
+              
               class MyTest {
                   void test() {
                       Example example = mock(Example.class);
@@ -90,7 +90,7 @@ class AnyStringToNullableTest implements RewriteTest {
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
               import static org.mockito.Mockito.anyInt;
-
+              
               class MyTest {
                    void test() {
                       Example example = mock(Example.class);


### PR DESCRIPTION
…ave a precondition on the project using mockito 1.x

closes #377

I expect that nothing and no one is using `org.openrewrite.java.testing.mockito.UsesMockitoAll`, since it was introduced to act as a declarative applicability test for this recipe. So, removed that too.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ auto-formatter on affected files
- ~~[] I've updated the documentation (if applicable)~~
