### PR TITLE
Restore now Scanning AnyToNullable, as it does not affect Mockito 2+

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -39,6 +39,7 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.mockito.MockitoAnnotations.Mock
       newFullyQualifiedTypeName: org.mockito.Mock
+  - org.openrewrite.java.testing.mockito.AnyToNullable
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.mockito.Matchers
       newFullyQualifiedTypeName: org.mockito.ArgumentMatchers


### PR DESCRIPTION
## What's changed?
Restore AnyToNullable after 7b2c98bf2792ce59afc31ab649ea3c4c1b9db126 and reimplementation in #378 by @nmck257

## What's your motivation?
Recipe should no longer make excessive changes; meaning it can be restored to migrate from Mockito v1 to v2 without semantic changes and potential breaking tests.