### PR TITLE
Alek/remove try catch blocks fix

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.junit5;
 
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -27,12 +28,13 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Collections;
 import java.util.Set;
 
 public class RemoveTryCatchFailBlocks extends Recipe {
-    private static final MethodMatcher ASSERT_FAIL_NO_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(..)");
+    private static final MethodMatcher ASSERT_FAIL_NO_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail()");
     private static final MethodMatcher ASSERT_FAIL_STRING_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(String)");
     private static final MethodMatcher GET_MESSAGE_MATCHER = new MethodMatcher("java.lang.Throwable getMessage()");
 
@@ -43,8 +45,8 @@ public class RemoveTryCatchFailBlocks extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Replace `try-catch` blocks where `catch` merely contains a `fail(..)` statement with " +
-               "`Assertions.assertDoesNotThrow(() -> { ... })`.";
+        return "Replace `try-catch` blocks where `catch` merely contains a `fail()` for `fail(String)` statement " +
+               "with `Assertions.assertDoesNotThrow(() -> { ... })`.";
     }
 
     @Override
@@ -80,42 +82,36 @@ public class RemoveTryCatchFailBlocks extends Recipe {
                 return try_;
             }
             J.MethodInvocation failCall = (J.MethodInvocation) statement;
-            if (failCall.getArguments().get(0) instanceof J.Binary) {
-                J.Binary binaryArg = (J.Binary)failCall.getArguments().get(0);
-                // check if either side is a method
-                if (binaryArg.getLeft() instanceof J.MethodInvocation || binaryArg.getRight() instanceof J.MethodInvocation) {
-                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft()) && binaryArg.getRight() instanceof J.Literal) {
-                        return try_;
-                    }else if (!GET_MESSAGE_MATCHER.matches(binaryArg.getRight()) && binaryArg.getLeft() instanceof J.Literal) {
-                        return try_;
-                    }
-                }else if (!(binaryArg.getRight() instanceof J.Literal) || !(binaryArg.getLeft() instanceof J.Literal)) {
-                    return try_;
-                }
-            }
-
-            if (!ASSERT_FAIL_NO_ARG.matches(failCall) || !ASSERT_FAIL_STRING_ARG.matches(failCall)) {
+            if (!ASSERT_FAIL_NO_ARG.matches(failCall) && !ASSERT_FAIL_STRING_ARG.matches(failCall)) {
                 return try_;
             }
 
-            // only valid method that returns string should be getMessage()
-            if (ASSERT_FAIL_STRING_ARG.matches(failCall)) {
-                Expression failCallString = failCall.getArguments().get(0);
-                if (failCallString instanceof J.MethodInvocation && !GET_MESSAGE_MATCHER.matches((J.MethodInvocation) failCallString)) {
-                    return try_;
-                }
-                if (failCallString instanceof J.Literal) {
-                    // Retain the fail(String) call argument
-                    maybeAddImport("org.junit.jupiter.api.Assertions");
-                    return JavaTemplate.builder("Assertions.assertDoesNotThrow(() -> #{any()}, #{any(String)})")
-                            .contextSensitive()
-                            .imports("org.junit.jupiter.api.Assertions")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9"))
-                            .build()
-                            .apply(getCursor(), try_.getCoordinates().replace(), try_.getBody(), failCallString);
+            // Only replace known cases
+            Expression failCallArgument = failCall.getArguments().get(0);
+            if (failCallArgument instanceof J.Empty) {
+                return replaceWithAssertDoesNotThrowWithoutStringExpression(ctx, try_);
+            } else if (failCallArgument instanceof J.MethodInvocation && GET_MESSAGE_MATCHER.matches(failCallArgument)) {
+                return replaceWithAssertDoesNotThrowWithoutStringExpression(ctx, try_);
+            } else if (failCallArgument instanceof J.Literal) {
+                return replaceWithAssertDoesNotThrowWithStringExpression(ctx, try_, failCallArgument);
+            } else if (failCallArgument instanceof J.Binary) {
+                J.Binary binaryArg = (J.Binary) failCallArgument;
+                Expression left = binaryArg.getLeft();
+                Expression right = binaryArg.getRight();
+                // Rewrite fail("message: " + e), fail("message: " + e.getMessage())
+                if (left instanceof J.Literal
+                    && (GET_MESSAGE_MATCHER.matches(right)
+                        || (right instanceof J.Identifier && TypeUtils.isAssignableTo("java.lang.Throwable", right.getType())))) {
+                    return replaceWithAssertDoesNotThrowWithStringExpression(ctx, try_, left);
                 }
             }
 
+            // Fall back to making no change at all
+            return try_;
+        }
+
+        @NotNull
+        private J.MethodInvocation replaceWithAssertDoesNotThrowWithoutStringExpression(ExecutionContext ctx, J.Try try_) {
             maybeAddImport("org.junit.jupiter.api.Assertions");
             return JavaTemplate.builder("Assertions.assertDoesNotThrow(() -> #{any()})")
                     .contextSensitive()
@@ -123,6 +119,18 @@ public class RemoveTryCatchFailBlocks extends Recipe {
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9"))
                     .build()
                     .apply(getCursor(), try_.getCoordinates().replace(), try_.getBody());
+        }
+
+        @NotNull
+        private J.MethodInvocation replaceWithAssertDoesNotThrowWithStringExpression(ExecutionContext ctx, J.Try try_, Expression failCallArgument) {
+            // Retain the fail(String) call argument
+            maybeAddImport("org.junit.jupiter.api.Assertions");
+            return JavaTemplate.builder("Assertions.assertDoesNotThrow(() -> #{any()}, #{any(String)})")
+                    .contextSensitive()
+                    .imports("org.junit.jupiter.api.Assertions")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9"))
+                    .build()
+                    .apply(getCursor(), try_.getCoordinates().replace(), try_.getBody(), failCallArgument);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
@@ -80,6 +80,34 @@ public class RemoveTryCatchFailBlocks extends Recipe {
                 return try_;
             }
             J.MethodInvocation failCall = (J.MethodInvocation) statement;
+            if (failCall.getArguments().get(0) instanceof J.Binary) {
+                J.Binary binaryArg = (J.Binary)failCall.getArguments().get(0);
+                // check if either side is a method
+                //if (binaryArg.getLeft() instanceof J.MethodInvocation || binaryArg.getRight() instanceof J.MethodInvocation) {
+                //    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft()) || !GET_MESSAGE_MATCHER.matches(binaryArg.getRight())) {
+                //        return try_;
+                //    }
+                //}
+                if (binaryArg.getLeft() instanceof J.MethodInvocation) {
+                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft())) {
+                        return try_;
+                    }else {
+
+                    }
+                }else if (binaryArg.getRight() instanceof J.MethodInvocation) {
+                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getRight())) {
+                        return try_;
+                    }else {
+                        
+                    }
+                }
+
+                // check if either side is not string then -> return
+                if (!(binaryArg.getRight() instanceof J.Literal) || !(binaryArg.getLeft() instanceof J.Literal)) {
+                    return try_;
+                }
+            }
+
             if (!ASSERT_FAIL_NO_ARG.matches(failCall) || !ASSERT_FAIL_STRING_ARG.matches(failCall)) {
                 return try_;
             }

--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
@@ -83,27 +83,13 @@ public class RemoveTryCatchFailBlocks extends Recipe {
             if (failCall.getArguments().get(0) instanceof J.Binary) {
                 J.Binary binaryArg = (J.Binary)failCall.getArguments().get(0);
                 // check if either side is a method
-                //if (binaryArg.getLeft() instanceof J.MethodInvocation || binaryArg.getRight() instanceof J.MethodInvocation) {
-                //    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft()) || !GET_MESSAGE_MATCHER.matches(binaryArg.getRight())) {
-                //        return try_;
-                //    }
-                //}
-                if (binaryArg.getLeft() instanceof J.MethodInvocation) {
-                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft())) {
+                if (binaryArg.getLeft() instanceof J.MethodInvocation || binaryArg.getRight() instanceof J.MethodInvocation) {
+                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getLeft()) && binaryArg.getRight() instanceof J.Literal) {
                         return try_;
-                    }else {
-
-                    }
-                }else if (binaryArg.getRight() instanceof J.MethodInvocation) {
-                    if (!GET_MESSAGE_MATCHER.matches(binaryArg.getRight())) {
+                    }else if (!GET_MESSAGE_MATCHER.matches(binaryArg.getRight()) && binaryArg.getLeft() instanceof J.Literal) {
                         return try_;
-                    }else {
-                        
                     }
-                }
-
-                // check if either side is not string then -> return
-                if (!(binaryArg.getRight() instanceof J.Literal) || !(binaryArg.getLeft() instanceof J.Literal)) {
+                }else if (!(binaryArg.getRight() instanceof J.Literal) || !(binaryArg.getLeft() instanceof J.Literal)) {
                     return try_;
                 }
             }

--- a/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocks.java
@@ -36,8 +36,7 @@ import java.util.Set;
 public class RemoveTryCatchFailBlocks extends Recipe {
     private static final MethodMatcher ASSERT_FAIL_NO_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail()");
     private static final MethodMatcher ASSERT_FAIL_STRING_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(String)");
-    private static final MethodMatcher ASSERT_FAIL_THROWABLE_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(Throwable)");
-    private static final MethodMatcher ASSERT_FAIL_STRING_THROWABLE_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(String, Throwable)");
+    private static final MethodMatcher ASSERT_FAIL_THROWABLE_ARG = new MethodMatcher("org.junit.jupiter.api.Assertions fail(.., Throwable)");
     private static final MethodMatcher GET_MESSAGE_MATCHER = new MethodMatcher("java.lang.Throwable getMessage()");
 
     @Override
@@ -86,8 +85,7 @@ public class RemoveTryCatchFailBlocks extends Recipe {
             J.MethodInvocation failCall = (J.MethodInvocation) statement;
             if (!ASSERT_FAIL_NO_ARG.matches(failCall)
                 && !ASSERT_FAIL_STRING_ARG.matches(failCall)
-                && !ASSERT_FAIL_THROWABLE_ARG.matches(failCall)
-                && !ASSERT_FAIL_STRING_THROWABLE_ARG.matches(failCall)) {
+                && !ASSERT_FAIL_THROWABLE_ARG.matches(failCall)) {
                 return try_;
             }
 

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
   - org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation
   - org.openrewrite.java.testing.junit5.RemoveDuplicateTestTemplates
+  - org.openrewrite.java.testing.junit5.RemoveTryCatchFailBlocks
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.StaticImports

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
@@ -381,4 +381,52 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void failHasBinaryWithException() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+              
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      try {
+                          int divide = 50 / 0;
+                      } catch (ArithmeticException e) {
+                          Assertions.fail("The error is: " + e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void failHasBinaryWithMethodCall() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+              
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      try {
+                      } catch (Excpetion e) {
+                          Assertions.fail();
+                      }
+                  }
+              }
+              
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
@@ -319,13 +319,26 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                       }
                   }
               }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+                            
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      Assertions.assertDoesNotThrow(() -> {
+                          int divide = 50 / 0;
+                      });
+                  }
+              }
               """
           )
         );
     }
 
     @Test
-    void failWithSupplierString() {
+    void failWithSupplierStringAsIdentifier() {
         //language=java
         rewriteRun(
           java(
@@ -351,6 +364,31 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
     }
 
     @Test
+    void failWithSupplierStringAsLambda() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+              import java.util.function.Supplier;
+                            
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      try {
+                          int divide = 50 / 0;
+                      } catch (Exception e) {
+                          Assertions.fail(() -> "error");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void failWithThrowable() {
         //language=java
         rewriteRun(
@@ -367,6 +405,19 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                       } catch (Exception e) {
                           Assertions.fail(e);
                       }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+                            
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      Assertions.assertDoesNotThrow(() -> {
+                          int divide = 50 / 0;
+                      });
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
@@ -49,8 +49,45 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                   public void testMethod() {
                       try {
                           int divide = 50 / 0;
-                      }catch (ArithmeticException e) {
+                      } catch (ArithmeticException e) {
                           Assertions.fail(e.getMessage());
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+                            
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      Assertions.assertDoesNotThrow(() -> {
+                          int divide = 50 / 0;
+                      });
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeTryCatchBlockWithoutMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+                            
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      try {
+                          int divide = 50 / 0;
+                      } catch (ArithmeticException e) {
+                          Assertions.fail();
                       }
                   }
               }
@@ -401,6 +438,19 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                       }
                   }
               }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+               
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      Assertions.assertDoesNotThrow(() -> {
+                          int divide = 50 / 0;
+                      }, "The error is: ");
+                  }
+              }
               """
           )
         );
@@ -463,7 +513,7 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                   public void testMethod() {
                       Assertions.assertDoesNotThrow(() -> {
                           int divide = 50 / 0;
-                      });
+                      }, "The error is: ");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/RemoveTryCatchFailBlocksTest.java
@@ -419,12 +419,53 @@ class RemoveTryCatchFailBlocksTest implements RewriteTest {
                   @Test
                   public void testMethod() {
                       try {
+                          int divide = 50 / 0;
                       } catch (Excpetion e) {
-                          Assertions.fail();
+                          Assertions.fail("The error is: " + anotherMethod());
+                      }
+                  }
+                  
+                  public String anotherMethod() {
+                      return "anotherMethod";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void failHasBinaryWithGetMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+              
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      try {
+                          int divide = 50 / 0;
+                      } catch (Exception e) {
+                          Assertions.fail("The error is: " + e.getMessage());
                       }
                   }
               }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
               
+              class MyTest {
+                  @Test
+                  public void testMethod() {
+                      Assertions.assertDoesNotThrow(() -> {
+                          int divide = 50 / 0;
+                      });
+                  }
+              }
               """
           )
         );


### PR DESCRIPTION
## What's changed?
The new try catch recipe was not handling cases where binary expressions were being passed into `Assertions.fail` correctly. This PR fixes that.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
