### PR TITLE
Migrate assertEquals with array parameter to assertArrayEquals

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
@@ -82,19 +82,14 @@ public class AssertToAssertions extends Recipe {
                     "org.junit.jupiter.api.Assertions", null, null, true)
                     .getVisitor());
 
-            if (isAssertEqualsWithArrayArguments(m)) {
-                // rename so we maintain the expected behaviour
-                m = m.withName(m.getName().withSimpleName("assertArrayEquals"));
-            }
-
             List<Expression> args = m.getArguments();
             Expression firstArg = args.get(0);
             // Suppress arg-switching for Assertions.assertEquals(String, String)
             if (args.size() == 2) {
                 if ("assertSame".equals(m.getSimpleName()) ||
-                        "assertNotSame".equals(m.getSimpleName()) ||
-                        "assertEquals".equals(m.getSimpleName()) ||
-                        "assertNotEquals".equals(m.getSimpleName())) {
+                    "assertNotSame".equals(m.getSimpleName()) ||
+                    "assertEquals".equals(m.getSimpleName()) ||
+                    "assertNotEquals".equals(m.getSimpleName())) {
                     return m;
                 }
             }
@@ -116,15 +111,6 @@ public class AssertToAssertions extends Recipe {
             }
 
             return m;
-        }
-
-        private static boolean isAssertEqualsWithArrayArguments(J.MethodInvocation method) {
-            if (!("assertEquals".equals(method.getSimpleName()))) {
-                return false;
-            }
-            // Detection based on 2nd argument which is the same in both overloads with and without message
-            Expression secondArg = method.getArguments().get(1);
-            return secondArg.getType() instanceof JavaType.Array;
         }
 
         private static boolean isJunitAssertMethod(J.MethodInvocation method) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
@@ -81,6 +81,12 @@ public class AssertToAssertions extends Recipe {
             doAfterVisit(new ChangeMethodTargetToStatic("org.junit.Assert " + m.getSimpleName() + "(..)",
                     "org.junit.jupiter.api.Assertions", null, null, true)
                     .getVisitor());
+
+            if (isAssertEqualsWithArrayArguments(m)) {
+                // rename so we maintain the expected behaviour
+                m = m.withName(m.getName().withSimpleName("assertArrayEquals"));
+            }
+
             List<Expression> args = m.getArguments();
             Expression firstArg = args.get(0);
             // Suppress arg-switching for Assertions.assertEquals(String, String)
@@ -110,6 +116,15 @@ public class AssertToAssertions extends Recipe {
             }
 
             return m;
+        }
+
+        private static boolean isAssertEqualsWithArrayArguments(J.MethodInvocation method) {
+            if (!("assertEquals".equals(method.getSimpleName()))) {
+                return false;
+            }
+            // Detection based on 2nd argument which is the same in both overloads with and without message
+            Expression secondArg = method.getArguments().get(1);
+            return secondArg.getType() instanceof JavaType.Array;
         }
 
         private static boolean isJunitAssertMethod(J.MethodInvocation method) {

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -65,6 +65,9 @@ recipeList:
   - org.openrewrite.java.testing.junit5.UseMockitoExtension
   - org.openrewrite.java.testing.junit5.UseTestMethodOrder
   - org.openrewrite.java.testing.junit5.MigrateJUnitTestCase
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "org.junit.Assert assertEquals(.., Object[], Object[])"
+      newMethodName: assertArrayEquals
   - org.openrewrite.java.testing.junit5.AssertToAssertions
   - org.openrewrite.java.testing.junit5.CategoryToTag
   - org.openrewrite.java.testing.junit5.CleanupJUnitImports

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
@@ -462,4 +462,35 @@ class AssertToAssertionsTest implements RewriteTest {
           )
         );
     }
+
+    // edge case for deprecated use of assertEquals
+    // https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
+    @Issue("#383")
+    @Test
+    void assertEqualsWithArrayArgumentToAssertArrayEquals() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import org.junit.Assert;
+              
+              class MyTest {
+                  void test() {
+                       Assert.assertEquals(new Object[1], new Object[1]);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              
+              class MyTest {
+                  void test() {
+                       Assertions.assertArrayEquals(new Object[1], new Object[1]);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
@@ -465,12 +465,11 @@ class AssertToAssertionsTest implements RewriteTest {
 
     // edge case for deprecated use of assertEquals
     // https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
-    @Issue("#383")
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/384")
     @Test
     void assertEqualsWithArrayArgumentToAssertArrayEquals() {
         //language=java
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(
             """
               import org.junit.Assert;

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
@@ -462,34 +462,4 @@ class AssertToAssertionsTest implements RewriteTest {
           )
         );
     }
-
-    // edge case for deprecated use of assertEquals
-    // https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
-    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/384")
-    @Test
-    void assertEqualsWithArrayArgumentToAssertArrayEquals() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Assert;
-              
-              class MyTest {
-                  void test() {
-                       Assert.assertEquals(new Object[1], new Object[1]);
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.Assertions;
-              
-              class MyTest {
-                  void test() {
-                       Assertions.assertArrayEquals(new Object[1], new Object[1]);
-                  }
-              }
-              """
-          )
-        );
-    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -161,5 +161,33 @@ class JUnit5MigrationTest implements RewriteTest {
         );
     }
 
-
+    // edge case for deprecated use of assertEquals
+    // https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/384")
+    @Test
+    void assertEqualsWithArrayArgumentToAssertArrayEquals() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Assert;
+              
+              class MyTest {
+                  void test() {
+                       Assert.assertEquals(new Object[1], new Object[1]);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+              
+              class MyTest {
+                  void test() {
+                       Assertions.assertArrayEquals(new Object[1], new Object[1]);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a test case to cover the mentioned use case.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- assertEquals in JUnit4 accepts Object[], to preserve the behaviour we need to rewrite it into assertArrayEquals
https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files
- [x] I've updated the documentation (if applicable)
