### PR TITLE
Replace Hamcrest `is` with AssertJ

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJ.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HamcrestIsMatcherToAssertJ extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate Hamcrest `is(Object)` to AssertJ";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate Hamcrest `is(Object)` to AssertJ `Assertions.assertThat(..)`.";
+    }
+
+    static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
+
+    static final MethodMatcher IS_OBJECT_MATCHER = new MethodMatcher("org.hamcrest.Matchers is(..)");
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(ASSERT_THAT_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(methodInvocation, ctx);
+
+                List<Expression> arguments = mi.getArguments();
+                Expression isMatcher = arguments.get(arguments.size() - 1);
+                if (!ASSERT_THAT_MATCHER.matches(mi) || !IS_OBJECT_MATCHER.matches(isMatcher)) {
+                    return mi;
+                }
+                Expression reason = arguments.size() == 3 ? arguments.get(0) : null;
+                Expression actual = arguments.get(arguments.size() - 2);
+
+                // Handle `is(Matcher)` in src/main/resources/META-INF/rewrite/hamcrest.yml
+                Expression isMatcherArgument = ((J.MethodInvocation) isMatcher).getArguments().get(0);
+                if (TypeUtils.isOfClassType(isMatcherArgument.getType(), "org.hamcrest.Matcher")) {
+                    return mi;
+                }
+
+                if (TypeUtils.asArray(actual.getType()) != null) {
+                    return replace(ctx, mi, reason, actual, isMatcherArgument, "containsExactly");
+                }
+
+                // Replace with assertThat
+                return replace(ctx, mi, reason, actual, isMatcherArgument, "isEqualTo");
+            }
+
+            @NotNull
+            private J.MethodInvocation replace(ExecutionContext ctx, J.MethodInvocation mi, Expression reason, Expression actual, Expression isMatcherArgument, String replacement) {
+                List<Expression> parameters = new ArrayList<>();
+                parameters.add(actual);
+                final String template;
+                if (reason == null) {
+                    template = "assertThat(#{any(java.lang.Object)})." +
+                               replacement + "(#{any()});";
+                } else {
+                    template = "assertThat(#{any(java.lang.String)})" +
+                               ".as(#{any(String)})." +
+                               replacement + "(#{any()});";
+                    parameters.add(reason);
+                }
+                parameters.add(isMatcherArgument);
+
+                maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+                maybeRemoveImport("org.hamcrest.MatcherAssert");
+                maybeRemoveImport("org.hamcrest.Matchers.is");
+                maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+
+                return JavaTemplate.builder(template)
+                        .contextSensitive()
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
+                        .staticImports("org.assertj.core.api.Assertions.assertThat")
+                        .build()
+                        .apply(getCursor(), mi.getCoordinates().replace(), parameters.toArray());
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
@@ -137,6 +137,7 @@ public class HamcrestMatcherToAssertJ extends Recipe {
                     .build();
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers." + matcher);
+            maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 
             List<Expression> templateArguments = new ArrayList<>();

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
@@ -110,6 +110,7 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers.not");
             maybeRemoveImport("org.hamcrest.Matchers." + notMatcher);
+            maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 
             List<Expression> templateArguments = new ArrayList<>();
@@ -139,6 +140,7 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers.not");
             maybeRemoveImport("org.hamcrest.Matchers." + notMatcher);
+            maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 
             List<Expression> templateArguments = new ArrayList<>();

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
@@ -15,10 +15,13 @@
  */
 package org.openrewrite.java.testing.hamcrest;
 
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.TreeVisitingPrinter;
+import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
 @SuppressWarnings("NullableProblems")
@@ -38,7 +41,7 @@ public class RemoveIsMatcher extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesMethod<>(ASSERT_THAT_MATCHER), new JavaVisitor<ExecutionContext>() {
             @Override
             public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
                 if (ASSERT_THAT_MATCHER.matches(mi)) {
@@ -49,6 +52,6 @@ public class RemoveIsMatcher extends Recipe {
                 }
                 return super.visitMethodInvocation(mi, ctx);
             }
-        };
+        });
     }
 }

--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -42,6 +42,9 @@ recipeList:
   # First remove wrapping `is(Matcher)` calls such that further recipes will match
   - org.openrewrite.java.testing.hamcrest.RemoveIsMatcher
 
+  # Then remove calls to `MatcherAssert.assertThat(String, Matcher)`
+  - org.openrewrite.java.testing.hamcrest.HamcrestIsMatcherToAssertJ
+
   # Flatten calls to `MatcherAssert.assertThat(.., allOf(..))` to easier to migrate individual statements
   - org.openrewrite.java.testing.hamcrest.FlattenAllOf
 

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.hamcrest;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class HamcrestIsMatcherToAssertJTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-jupiter-api-5.9",
+              "hamcrest-2.2",
+              "assertj-core-3.24"))
+          .recipe(new HamcrestIsMatcherToAssertJ());
+    }
+
+    @Test
+    @DocumentExample
+    void isMatcher() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.is;
+                            
+            class ATest {
+                @Test
+                void testEquals() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1, is(str2));
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.Test;
+                        
+            import static org.assertj.core.api.Assertions.assertThat;
+                        
+            class ATest {
+                @Test
+                void testEquals() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    assertThat(str1).isEqualTo(str2);
+                }
+            }
+            """));
+    }
+
+    @Test
+    void isMatcherWithReason() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.is;
+                            
+            class ATest {
+                @Test
+                void testEquals() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    // Foo
+                    assertThat("Reason", str1, is(str2));
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.Test;
+                        
+            import static org.assertj.core.api.Assertions.assertThat;
+                        
+            class ATest {
+                @Test
+                void testEquals() {
+                    String str1 = "Hello world!";
+                    String str2 = "Hello world!";
+                    // Foo
+                    assertThat(str1).as("Reason").isEqualTo(str2);
+                }
+            }
+            """));
+    }
+
+    @Test
+    void isObjectArray() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.is;
+                            
+            class ATest {
+                @Test
+                void testEquals() {
+                    String[] str1 = new String[]{"Hello world!"};
+                    String[] str2 = new String[]{"Hello world!"};
+                    assertThat(str1, is(str2));
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.Test;
+                        
+            import static org.assertj.core.api.Assertions.assertThat;
+                        
+            class ATest {
+                @Test
+                void testEquals() {
+                    String[] str1 = new String[]{"Hello world!"};
+                    String[] str2 = new String[]{"Hello world!"};
+                    assertThat(str1).containsExactly(str2);
+                }
+            }
+            """));
+    }
+
+    @Test
+    void isPrimitiveArray() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.junit.jupiter.api.Test;
+            import static org.hamcrest.MatcherAssert.assertThat;
+            import static org.hamcrest.Matchers.is;
+                            
+            class ATest {
+                @Test
+                void testEquals() {
+                    int[] str1 = new int[]{1};
+                    int[] str2 = new int[]{1};
+                    assertThat(str1, is(str2));
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.Test;
+                        
+            import static org.assertj.core.api.Assertions.assertThat;
+                        
+            class ATest {
+                @Test
+                void testEquals() {
+                    int[] str1 = new int[]{1};
+                    int[] str2 = new int[]{1};
+                    assertThat(str1).containsExactly(str2);
+                }
+            }
+            """));
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJTest.java
@@ -104,6 +104,28 @@ class HamcrestIsMatcherToAssertJTest implements RewriteTest {
             """));
     }
 
+
+    @Test
+    void isMatcherWithMatcher() {
+        rewriteRun(
+          //language=java
+          java("""
+                import org.junit.jupiter.api.Test;
+                import static org.hamcrest.MatcherAssert.assertThat;
+                import static org.hamcrest.Matchers.is;
+                import static org.hamcrest.Matchers.equalTo;
+                                
+                class ATest {
+                    @Test
+                    void test() {
+                        String str1 = "Hello world!";
+                        String str2 = "Hello world!";
+                        assertThat(str1, is(equalTo(str2)));
+                    }
+                }
+                """));
+    }
+
     @Test
     void isObjectArray() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Replace Hamcrest `is` with AssertJ where the argument is not a matcher.

## What's your motivation?
https://github.com/openrewrite/rewrite-testing-frameworks/issues/357#issuecomment-1644743209