### PR TITLE
Hamcrest to AssertJ dependency tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,4 +40,9 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-groovy")
+
+    testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")
+
+//    testImplementation("org.hamcrest:hamcrest:latest.release")
+//    testImplementation("org.assertj:assertj-core:latest.release")
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -469,45 +469,45 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
             rewriteRun(
               mavenProject("project",
                 //language=java
-                srcTestJava(java(JAVA_BEFORE, JAVA_AFTER),
-                  //language=xml
-                  pomXml("""
-                    <project>
-                        <modelVersion>4.0.0</modelVersion>
-                        <groupId>com.example</groupId>
-                        <artifactId>demo</artifactId>
-                        <version>0.0.1-SNAPSHOT</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.hamcrest</groupId>
-                                <artifactId>hamcrest</artifactId>
-                                <version>2.2</version>
-                                <scope>test</scope>
-                            </dependency>
-                        </dependencies>
-                    </project>
-                    """, """
-                    <project>
-                        <modelVersion>4.0.0</modelVersion>
-                        <groupId>com.example</groupId>
-                        <artifactId>demo</artifactId>
-                        <version>0.0.1-SNAPSHOT</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.assertj</groupId>
-                                <artifactId>assertj-core</artifactId>
-                                <version>3.24.2</version>
-                                <scope>test</scope>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.hamcrest</groupId>
-                                <artifactId>hamcrest</artifactId>
-                                <version>2.2</version>
-                                <scope>test</scope>
-                            </dependency>
-                        </dependencies>
-                    </project>
-                    """))));
+                srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
+                //language=xml
+                pomXml("""
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.hamcrest</groupId>
+                              <artifactId>hamcrest</artifactId>
+                              <version>2.2</version>
+                              <scope>test</scope>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """, """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.example</groupId>
+                      <artifactId>demo</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.assertj</groupId>
+                              <artifactId>assertj-core</artifactId>
+                              <version>3.24.2</version>
+                              <scope>test</scope>
+                          </dependency>
+                          <dependency>
+                              <groupId>org.hamcrest</groupId>
+                              <artifactId>hamcrest</artifactId>
+                              <version>2.2</version>
+                              <scope>test</scope>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """)));
         }
 
         @Test
@@ -516,34 +516,34 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               spec -> spec.beforeRecipe(withToolingApi()),
               mavenProject("project",
                 //language=java
-                srcTestJava(java(JAVA_BEFORE, JAVA_AFTER),
-                  //language=groovy
-                  buildGradle("""
-                    plugins {
-                        id "java-library"
-                    }
-                    
-                    repositories {
-                        mavenCentral()
-                    }
-                    
-                    dependencies {
-                        testImplementation "org.hamcrest:hamcrest:2.2"
-                    }
-                    """, """
-                    plugins {
-                        id "java-library"
-                    }
-                    
-                    repositories {
-                        mavenCentral()
-                    }
-                    
-                    dependencies {
-                        testImplementation "org.assertj:assertj-core:3.24.2"
-                        testImplementation "org.hamcrest:hamcrest:2.2"
-                    }
-                    """))));
+                srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
+                //language=groovy
+                buildGradle("""
+                  plugins {
+                      id "java-library"
+                  }
+                                      
+                  repositories {
+                      mavenCentral()
+                  }
+                                      
+                  dependencies {
+                      testImplementation "org.hamcrest:hamcrest:2.2"
+                  }
+                  """, """
+                  plugins {
+                      id "java-library"
+                  }
+                                      
+                  repositories {
+                      mavenCentral()
+                  }
+                                      
+                  dependencies {
+                      testImplementation "org.assertj:assertj-core:3.24.2"
+                      testImplementation "org.hamcrest:hamcrest:2.2"
+                  }
+                  """)));
         }
     }
 


### PR DESCRIPTION
## What's changed?
Add tests to verify hamcrest to assertj dependencies are added with correct scope.

## What's your motivation?
When running through the platform, I saw Gradle dependencies added where they might not have been needed. 

## Anything in particular you'd like reviewers to focus on?
Potentially limited value having these here. Should we still add them?

## Have you considered any alternatives or workarounds?
Might need to troubleshoot elsewhere, but this is at least a sanity check that dependencies are added with the right scope and only if using.