### PR TITLE
Migrate Hamcrest `anyOf` matchers to AssertJ `satisfiesAnyOf` assertions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +63,12 @@ public class HamcrestAnyOfToAssertJ extends Recipe {
                 return mi;
             }
 
+            // Skip anyOf(Iterable)
+            List<Expression> anyOfArguments = ((J.MethodInvocation) anyOfExpression).getArguments();
+            if (TypeUtils.isAssignableTo("java.lang.Iterable", anyOfArguments.get(0).getType())) {
+                return mi;
+            }
+
             StringBuilder template = new StringBuilder();
             List<Expression> parameters = new ArrayList<>();
 
@@ -77,7 +84,6 @@ public class HamcrestAnyOfToAssertJ extends Recipe {
 
             // .satisfiesAnyOf(...)
             template.append(".satisfiesAnyOf(\n");
-            List<Expression> anyOfArguments = ((J.MethodInvocation) anyOfExpression).getArguments();
             template.append(anyOfArguments.stream()
                     .map(arg -> "arg -> assertThat(arg, #{any()})")
                     .collect(Collectors.joining(",\n")));

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
@@ -1,0 +1,75 @@
+package org.openrewrite.java.testing.hamcrest;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("NullableProblems")
+public class HamcrestAnyOfToAssertJ extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate `anyOf` Hamcrest Matcher to AssertJ";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate the `anyOf` Hamcrest Matcher to AssertJ's `satisfiesAnyOf` assertion.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AnyOfToAssertJVisitor();
+    }
+
+    private static class AnyOfToAssertJVisitor extends JavaVisitor<ExecutionContext> {
+        private final MethodMatcher assertThatMatcher = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
+        private final MethodMatcher anyOfMatcher = new MethodMatcher("org.hamcrest.Matchers anyOf(..)");
+        @Override
+        public J visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+            J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(mi, ctx);
+            if (!assertThatMatcher.matches(m)) {
+                return m;
+            }
+
+            if (!anyOfMatcher.matches(m.getArguments().get(1))) {
+                return m;
+            }
+
+            Expression select = m.getArguments().get(0);
+            J.MethodInvocation anyOf = ((J.MethodInvocation)m.getArguments().get(1));
+            List<Expression> anyOfArguments = anyOf.getArguments();
+            List<Expression> templateFillIns = new ArrayList<>();
+            StringBuilder template = new StringBuilder();
+            template.append("assertThat(#{any()}).satisfiesAnyOf(");
+            templateFillIns.add(select);
+
+            for (Expression exp : anyOfArguments) {
+                template.append("\n() -> assertThat(#{any()}, #{any()}),");
+                templateFillIns.add(select);
+                templateFillIns.add(exp);
+            }
+            template.deleteCharAt(template.length()-1);
+            template.append("\n);");
+
+            JavaTemplate fullTemplate = JavaTemplate.builder(template.toString())
+                    .contextSensitive()
+                    .staticImports("org.assertj.core.api.Assertions.assertThat")
+                    .imports("org.assertj.core.api.AbstractAssert")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24", "hamcrest-2.2", "junit-jupiter-api-5.9"))
+                    .build();
+
+            maybeAddImport("org.assertj.core.api.AbstractAssert");
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            return fullTemplate.apply(getCursor(), m.getCoordinates().replace(), templateFillIns.toArray());
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJ.java
@@ -19,7 +19,10 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
@@ -67,7 +70,7 @@ public class HamcrestAnyOfToAssertJ extends Recipe {
             if (arguments.size() == 3) {
                 template.append("assertThat(#{any()})\n.as(#{any(java.lang.String)})\n.satisfiesAnyOf(");
                 parameters.add(arguments.get(0));
-            }else {
+            } else {
                 template.append("assertThat(#{any()}).satisfiesAnyOf(");
             }
 

--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -48,6 +48,9 @@ recipeList:
   # Flatten calls to `MatcherAssert.assertThat(.., allOf(..))` to easier to migrate individual statements
   - org.openrewrite.java.testing.hamcrest.FlattenAllOf
 
+  # Then remove calls to `MatcherAssert.assertThat(String, anyOf(..))`
+  - org.openrewrite.java.testing.hamcrest.HamcrestAnyOfToAssertJ
+
   # Then remove calls to `MatcherAssert.assertThat(String, boolean)`
   - org.openrewrite.java.testing.hamcrest.AssertThatBooleanToAssertJ
 

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -75,4 +75,120 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void anyOfHasALotOfArguments() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      assertThat("hello world", anyOf(equalTo("hello world"), hasLength(12), hasLength(12), hasLength(12), hasLength(12)));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      assertThat("hello world").satisfiesAnyOf(
+                              arg -> assertThat(arg, equalTo("hello world")),
+                              arg -> assertThat(arg, hasLength(12)),
+                              arg -> assertThat(arg, hasLength(12)),
+                              arg -> assertThat(arg, hasLength(12)),
+                              arg -> assertThat(arg, hasLength(12))
+                      );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void anyOfArgumentIsIterable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              
+              import java.util.ArrayList;
+              import java.util.Arrays;
+              import java.util.Iterator;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      ArrayList<Matcher<Integer>> matcherList = Arrays.asList(hasLength(12), hasLength(12), hasLength(12));
+                      assertThat("hello world", anyOf(matcherList));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void assertThatHasReasonArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      assertThat("reason", "hello world", anyOf(equalTo("hello world"), hasLength(12)));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      assertThat("hello world")
+                          .as("reason")
+                          .satisfiesAnyOf(
+                                  arg -> assertThat(arg, equalTo("hello world")),
+                                  arg -> assertThat(arg, hasLength(12))
+                          );
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.hamcrest;
 
 import org.junit.jupiter.api.Test;
@@ -8,7 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class HamcrestAnyOfToAssertJTest implements RewriteTest {
+class HamcrestAnyOfToAssertJTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -35,30 +50,24 @@ public class HamcrestAnyOfToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      String str1 = "hello world";
-                      String str2 = "hello world";
-                      assertThat(str1, anyOf(equalTo(str2), hasLength(12)));
+                      assertThat("hello world", anyOf(equalTo("hello world"), hasLength(12)));
                   }
               }
               """,
             """
               import org.junit.jupiter.api.Test;
-              import org.assertj.core.api.AbstractAssert;
-              
+
               import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
-              import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
-              
+
               class MyTest {
                   @Test
                   void testMethod() {
-                      String str1 = "hello world";
-                      String str2 = "hello world";
-                      assertThat(str1).satisfiesAnyOf(
-                              () -> assertThat(str1, equalTo(str2)),
-                              () -> assertThat(str1, hasLength(12))
+                      assertThat("hello world").satisfiesAnyOf(
+                              arg -> assertThat(arg, equalTo("hello world")),
+                              arg -> assertThat(arg, hasLength(12))
                       );
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -41,12 +41,12 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
-              
+                            
               class MyTest {
                   @Test
                   void testMethod() {
@@ -83,12 +83,12 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
-              
+                            
               class MyTest {
                   @Test
                   void testMethod() {
@@ -128,14 +128,14 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import java.util.ArrayList;
               import java.util.Arrays;
               import java.util.Iterator;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.hasLength;
-              
+                            
               class MyTest {
                   @Test
                   void testMethod() {
@@ -155,12 +155,12 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
-              
+                            
               class MyTest {
                   @Test
                   void testMethod() {
@@ -175,7 +175,7 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
-              
+                            
               class MyTest {
                   @Test
                   void testMethod() {

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -180,11 +180,11 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
                   @Test
                   void testMethod() {
                       assertThat("hello world")
-                          .as("reason")
-                          .satisfiesAnyOf(
-                                  arg -> assertThat(arg, equalTo("hello world")),
-                                  arg -> assertThat(arg, hasLength(12))
-                          );
+                              .as("reason")
+                              .satisfiesAnyOf(
+                                      arg -> assertThat(arg, equalTo("hello world")),
+                                      arg -> assertThat(arg, hasLength(12))
+                              );
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -1,0 +1,69 @@
+package org.openrewrite.java.testing.hamcrest;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class HamcrestAnyOfToAssertJTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "junit-jupiter-api-5.9",
+            "hamcrest-2.2",
+            "assertj-core-3.24"))
+          .recipe(new HamcrestAnyOfToAssertJ());
+    }
+
+    @Test
+    void anyOfMigrate() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "hello world";
+                      String str2 = "hello world";
+                      assertThat(str1, anyOf(equalTo(str2), hasLength(12)));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.assertj.core.api.AbstractAssert;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
+              
+              class MyTest {
+                  @Test
+                  void testMethod() {
+                      String str1 = "hello world";
+                      String str2 = "hello world";
+                      assertThat(str1).satisfiesAnyOf(
+                              () -> assertThat(str1, equalTo(str2)),
+                              () -> assertThat(str1, hasLength(12))
+                      );
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -65,10 +65,11 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world").satisfiesAnyOf(
-                              arg -> assertThat(arg, equalTo("hello world")),
-                              arg -> assertThat(arg, hasLength(12))
-                      );
+                      assertThat("hello world")
+                              .satisfiesAnyOf(
+                                      arg -> assertThat(arg, equalTo("hello world")),
+                                      arg -> assertThat(arg, hasLength(12))
+                              );
                   }
               }
               """
@@ -107,13 +108,14 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world").satisfiesAnyOf(
-                              arg -> assertThat(arg, equalTo("hello world")),
-                              arg -> assertThat(arg, hasLength(12)),
-                              arg -> assertThat(arg, hasLength(12)),
-                              arg -> assertThat(arg, hasLength(12)),
-                              arg -> assertThat(arg, hasLength(12))
-                      );
+                      assertThat("hello world")
+                              .satisfiesAnyOf(
+                                      arg -> assertThat(arg, equalTo("hello world")),
+                                      arg -> assertThat(arg, hasLength(12)),
+                                      arg -> assertThat(arg, hasLength(12)),
+                                      arg -> assertThat(arg, hasLength(12)),
+                                      arg -> assertThat(arg, hasLength(12))
+                              );
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestAnyOfToAssertJTest.java
@@ -130,19 +130,17 @@ class HamcrestAnyOfToAssertJTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-                            
-              import java.util.ArrayList;
+
               import java.util.Arrays;
-              import java.util.Iterator;
+
               import static org.hamcrest.MatcherAssert.assertThat;
-              import static org.hamcrest.Matchers.anyOf;
               import static org.hamcrest.Matchers.hasLength;
-                            
+              import static org.hamcrest.Matchers.anyOf;
+
               class MyTest {
                   @Test
                   void testMethod() {
-                      ArrayList<Matcher<Integer>> matcherList = Arrays.asList(hasLength(12), hasLength(12), hasLength(12));
-                      assertThat("hello world", anyOf(matcherList));
+                      assertThat("hello world", anyOf(Arrays.asList(hasLength(11), hasLength(11))));
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
This PR adds a recipe that migrates Hamcrest `anyOf` matchers to AssertJ `satisfiesAnyOf` assertions.

## What's your motivation?
[#357](https://github.com/openrewrite/rewrite-testing-frameworks/issues/357)

## Anything in particular you'd like reviewers to focus on?
This first test almost passes, however it does not add the needed import for AssertJ's `AbstractAssert`. I've added the classpath resources in the `JavaTemplate`, and used both `.imports()` and `maybeAddImport()`.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [ ] I've used the IntelliJ auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
