### PR TITLE
Fix problem with incorrectly removed Mockito imports

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -29,13 +29,11 @@ import org.openrewrite.java.tree.TypeUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Removes unused "org.mockito" imports.
  */
 public class CleanupMockitoImports extends Recipe {
-    private static final Pattern MOCKITO_CLASS_PATTERN = Pattern.compile("org.mockito.Mockito");
 
     @Override
     public String getDisplayName() {
@@ -52,7 +50,7 @@ public class CleanupMockitoImports extends Recipe {
         return Preconditions.check(new UsesType<>("org.mockito.*", false), new CleanupMockitoImportsVisitor());
     }
 
-    public static class CleanupMockitoImportsVisitor extends JavaIsoVisitor<ExecutionContext> {
+    private static class CleanupMockitoImportsVisitor extends JavaIsoVisitor<ExecutionContext> {
         private static final List<String> MOCKITO_METHOD_NAMES = Arrays.asList(
                 "after",
                 "atLeast",
@@ -149,8 +147,7 @@ public class CleanupMockitoImports extends Recipe {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, qualifiedMethods);
                 if (MOCKITO_METHOD_NAMES.contains(mi.getSimpleName())
                         && mi.getSelect() != null
-                        && mi.getSelect().getType() != null
-                        && mi.getSelect().getType().isAssignableFrom(MOCKITO_CLASS_PATTERN)) {
+                        && TypeUtils.isAssignableTo("org.mockito.Mockito", mi.getSelect().getType())) {
                     qualifiedMethods.add(mi.getSimpleName());
                 }
                 return mi;

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -98,6 +98,60 @@ class CleanupMockitoImportsTest implements RewriteTest {
     }
 
     @Test
+    void doNotRemoveImportsAssociatedWithAnUntypedMockitoMethodMixed() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.Mockito;
+              import static org.mockito.Mockito.when;
+              import static org.mockito.BDDMockito.given;
+              import static org.mockito.Mockito.verifyNoInteractions;
+
+              class MyObjectTest {
+                MyObject myObject;
+                MyMockClass myMock;
+                            
+                void test() {
+                  when(myObject.getSomeField()).thenReturn("testValue");
+                  given(myObject.getSomeField()).willReturn("testValue");
+                  verifyNoInteractions(myMock);
+                  Mockito.reset();
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveImportsAssociatedWithATypedMockitoMethodMixed() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.Mockito;
+              import static org.mockito.Mockito.when;
+              import static org.mockito.BDDMockito.given;
+              import static org.mockito.Mockito.verifyNoInteractions;
+
+              class MyObjectTest {
+                MyObject myObject;
+                MyMockClass myMock;
+                            
+                void test() {
+                  when(myObject.getSomeField()).thenReturn("testValue");
+                  given(myObject.getSomeField()).willReturn("testValue");
+                  verifyNoInteractions(myMock);
+                  Mockito.mock(OtherClass.class);
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotRemoveStartImportsPossiblyAssociatedWithAnUntypedMockitoMethod() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Don't attempt to remove Mockito class import when we know method calls use it

## What's your motivation?
Without this change, in classes that use both Class-qualified method calls and static method calls, 
the recipe will attempt to remove the Mockito class import.
RemoveImports is smart enough to not do this, but it does remove the static method import instead,
even if it is used. I do not fully understand why, so I don't feel comfortable proposing a fix to RemoveImports.
Instead, I accept it as a limitation of RemoveImports and have added logic to the recipe to not attempt to remove the class import if we know it is directly referenced.

## Anything in particular you'd like reviewers to focus on?
This might not be the most elegant solution, so please let me know if there is a better way to handle this.
Also, let me know if there are any other test cases that should be covered


## Have you considered any alternatives or workarounds?
The recipe _could_ reorganize imports to use _only_ static import or class imports, and not mix.
That would be a more significant change, and would inject some opinions that might not be expected by users of the recipe.

## Any additional context
fixes #280 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ auto-formatter on affected files

