### PR TITLE
Adopt AssertJ duration assertions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -133,9 +133,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
                 return m;
             }
 
-            Long isEqualToArgRaw = SimplifyDurationCreationUnits.getConstantIntegralValue(isEqualToArg);
-            boolean isRelatedToDuration = checkIfRelatedToDuration(assertThatArg);
-            if (isEqualToArgRaw == 0 && isRelatedToDuration) {
+            if (isZero(isEqualToArg) && checkIfRelatedToDuration(assertThatArg)) {
                 String formatted_template = formatTemplate("assertThat(#{any()}).%s();", m.getSimpleName(), asDescription);
                 templateParameters.set(0, assertThatArg);
                 return applyTemplate(ctx, m, formatted_template, templateParameters.toArray());
@@ -152,6 +150,14 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             }
 
             return m;
+        }
+
+        private boolean isZero(Expression isEqualToArg) {
+            if (isEqualToArg instanceof J.Literal) {
+                J.Literal literal = (J.Literal) isEqualToArg;
+                return literal.getValue() instanceof Number && ((Number) literal.getValue()).longValue() == 0;
+            }
+            return false;
         }
 
         private J.MethodInvocation simplifyTimeUnits(J.MethodInvocation m, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -64,7 +64,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.or(
-                new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(int)"),
+                new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(int)", true),
                 new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)")
             ), new AdoptAssertJDurationAssertionsVisitor()
         );

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -15,9 +15,39 @@
  */
 package org.openrewrite.java.testing.assertj;
 
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class AdoptAssertJDurationAssertions extends Recipe {
+    static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.assertj.core.api.Assertions assertThat(..)");
+    static final MethodMatcher GET_NANO_MATCHER = new MethodMatcher("java.time.Duration getNano()");
+    static final MethodMatcher GET_SECONDS_MATCHER = new MethodMatcher("java.time.Duration getSeconds()");
+    static final MethodMatcher ISEQUALTO_MATCHER = new MethodMatcher("org.assertj.core.api.AbstractLongAssert isEqualTo(..)");
+    static final Map<String, String> methodMap = new HashMap<String, String>() {{
+        put("getSeconds", "hasSeconds");
+        put("getNano", "hasNanos");
+    }};
+    static List<MethodMatcher> timeUnitMatchers = Arrays.asList(
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasMillis(..)"),
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasSeconds(..)"),
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasNanos(..)"),
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasMinutes(..)"),
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasHours(..)"),
+            new MethodMatcher("org.assertj.core.api.DurationAssert hasDays(..)")
+    );
+
     @Override
     public String getDisplayName() {
         return "Adopt AssertJ Duration assertions";
@@ -26,5 +56,54 @@ public class AdoptAssertJDurationAssertions extends Recipe {
     @Override
     public String getDescription() {
         return "Adopt AssertJ DurationAssert assertions for more expressive messages.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AdoptAssertJDurationAssertionsVisitor();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    private static class AdoptAssertJDurationAssertionsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+            if (timeUnitMatchers.stream().anyMatch(matcher -> matcher.matches(mi))) {
+                return simplifyTimeUnits(mi, ctx);
+            }else if (ISEQUALTO_MATCHER.matches(mi)) {
+                return simplifyMultipleAssertions(mi, ctx);
+            }
+            return mi;
+        }
+
+        private J.MethodInvocation simplifyMultipleAssertions(J.MethodInvocation m, ExecutionContext ctx) {
+            if (!ISEQUALTO_MATCHER.matches(m)) {
+                return m;
+            }
+            Expression isEqualToArg = m.getArguments().get(0);
+            if (!ASSERT_THAT_MATCHER.matches(m.getSelect())) {
+                return m;
+            }
+
+            J.MethodInvocation assertThatArg = (J.MethodInvocation) ((J.MethodInvocation) m.getSelect()).getArguments().get(0);
+            if (!(assertThatArg instanceof J.MethodInvocation)) {
+                return m;
+            }
+            if (GET_NANO_MATCHER.matches(assertThatArg) || GET_SECONDS_MATCHER.matches(assertThatArg)) {
+                String methodName = assertThatArg.getSimpleName();
+                Expression assertThatArgSelect = assertThatArg.getSelect();
+                String formatted_template = String.format("assertThat(#{any()}).%s(#{any()});", methodMap.get(methodName));
+                return JavaTemplate.builder(formatted_template)
+                        .contextSensitive()
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9", "assertj-core-3.24"))
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace(), assertThatArgSelect, isEqualToArg);
+            }
+
+            return m;
+        }
+
+        private J.MethodInvocation simplifyTimeUnits(J.MethodInvocation m, ExecutionContext ctx) {
+            return m;
+        }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -65,7 +65,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(Preconditions.or(
                 new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(int)", true),
-                new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)")
+                new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)", true)
             ), new AdoptAssertJDurationAssertionsVisitor()
         );
     }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -232,17 +232,13 @@ public class AdoptAssertJDurationAssertions extends Recipe {
 
         @SuppressWarnings("ConstantValue")
         private String formatTemplate(String template, String methodName, Object asDescriptionArg) {
+            String replacementMethod = METHOD_MAP.get(methodName);
             if (asDescriptionArg == null) {
-                return String.format(template, METHOD_MAP.get(methodName));
+                return String.format(template, replacementMethod);
             }
-
-            StringBuilder descriptionArgsInsertion = new StringBuilder(".as(#{any()})");
-
             StringBuilder newTemplate = new StringBuilder(template);
-            int idx = newTemplate.indexOf(").");
-            newTemplate.insert(idx + 1, descriptionArgsInsertion);
-
-            return String.format(newTemplate.toString(), METHOD_MAP.get(methodName));
+            newTemplate.insert(newTemplate.indexOf(").") + 1, ".as(#{any()})");
+            return String.format(newTemplate.toString(), replacementMethod);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -97,12 +97,12 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             Expression isEqualToArg = m.getArguments().get(0);
             Expression select = m.getSelect();
             List<Object> templateParameters = new ArrayList<>();
+            templateParameters.add(null);
             Expression asDescription = null;
 
             if (AS_MATCHER.matches(select)) {
                 asDescription = ((J.MethodInvocation) select).getArguments().get(0);
                 select = ((J.MethodInvocation) select).getSelect();
-                templateParameters.add(null);
                 templateParameters.add(asDescription);
             }
 
@@ -120,7 +120,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             if (isEqualToArgRaw == 0 && isRelatedToDuration) {
                 String formatted_template = formatTemplate("assertThat(#{any()}).%s();", m.getSimpleName(), asDescription);
                 templateParameters.set(0, assertThatArg);
-                return applyTemplate(ctx, m, formatted_template, templateParameters);
+                return applyTemplate(ctx, m, formatted_template, templateParameters.toArray());
             }
 
             if (GET_NANO_MATCHER.matches(assertThatArg) || GET_SECONDS_MATCHER.matches(assertThatArg)) {
@@ -129,6 +129,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
                 String formatted_template = formatTemplate("assertThat(#{any()}).%s(#{any()});", methodName, asDescription);
                 templateParameters.set(0, assertThatArgSelect);
                 templateParameters.add(isEqualToArg);
+
                 return applyTemplate(ctx, m, formatted_template, templateParameters.toArray());
             }
 
@@ -190,22 +191,18 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             return false;
         }
 
-        private String formatTemplate(String template, String methodName, Object... asDescriptionArgs) {
-            if (asDescriptionArgs.length == 0) {
+        private String formatTemplate(String template, String methodName, Object asDescriptionArg) {
+            if (asDescriptionArg == null) {
                 return String.format(template, METHOD_MAP.get(methodName));
             }
 
-            StringBuilder descriptionArgsInsertion = new StringBuilder(".as(");
-            for (int i = 0; i < asDescriptionArgs.length; i++) {
-                descriptionArgsInsertion.append("#{any()}");
-            }
-            descriptionArgsInsertion.append(")");
+            StringBuilder descriptionArgsInsertion = new StringBuilder(".as(#{any()})");
 
             StringBuilder newTemplate = new StringBuilder(template);
             int idx = newTemplate.indexOf(").");
             newTemplate.insert(idx+1, descriptionArgsInsertion);
 
-            return newTemplate.toString();
+            return String.format(newTemplate.toString(), METHOD_MAP.get(methodName));
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -58,7 +58,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Adopt AssertJ DurationAssert assertions for more expressive messages.";
+        return "Adopt AssertJ `DurationAssert` assertions for more expressive messages.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -67,10 +67,10 @@ public class AdoptAssertJDurationAssertions extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         // TODO: figure out why this Precondition check doesn't quite work
         return Preconditions.check(Preconditions.or(
-                new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(..)", true),
-                new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)", true),
-                new UsesMethod<>("org.assertj.core.api.AbstractIntegerAssert isEqualTo(..)", true)
-            ), new AdoptAssertJDurationAssertionsVisitor()
+                        new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(..)", true),
+                        new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)", true),
+                        new UsesMethod<>("org.assertj.core.api.AbstractIntegerAssert isEqualTo(..)", true)
+                ), new AdoptAssertJDurationAssertionsVisitor()
         );
     }
 
@@ -81,7 +81,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
             if (timeUnitMatchers.stream().anyMatch(matcher -> matcher.matches(mi))) {
                 return simplifyTimeUnits(mi, ctx);
-            }else if (ISEQUALTO_INT_MATCHER.matches(mi) || ISEQUALTO_LONG_MATCHER.matches(mi)) {
+            } else if (ISEQUALTO_INT_MATCHER.matches(mi) || ISEQUALTO_LONG_MATCHER.matches(mi)) {
                 return simplifyMultipleAssertions(mi, ctx);
             }
             return mi;
@@ -118,8 +118,8 @@ public class AdoptAssertJDurationAssertions extends Recipe {
                 return m;
             }
             List<Object> unitInfo = getUnitInfo(m.getSimpleName(), Math.toIntExact(argValue));
-            String methodName = (String)unitInfo.get(0);
-            int methodArg = (int)unitInfo.get(1);
+            String methodName = (String) unitInfo.get(0);
+            int methodArg = (int) unitInfo.get(1);
 
             if (!(m.getSimpleName().equals(methodName))) {
                 // convert divided value to OpenRewrite LST type
@@ -128,7 +128,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
                 Expression methodSelect = m.getSelect();
                 return JavaTemplate.builder("#{any()}.#{}(#{any(int)})")
                         .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9", "assertj-core-3.24"))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
                         .build()
                         .apply(getCursor(), m.getCoordinates().replace(), methodSelect, methodName, newArg);
             }
@@ -140,14 +140,14 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             int timeLength = 60;
             if (name.equals("hasMillis")) {
                 timeLength = 1000;
-            }else if (name.equals("hasHours")) {
+            } else if (name.equals("hasHours")) {
                 timeLength = 24;
             }
 
             if (argValue % timeLength == 0) {
                 String newName = methodMap.get(name);
                 return getUnitInfo(newName, argValue / timeLength);
-            }else {
+            } else {
                 // returning name, newArg, isDivisible
                 return Arrays.asList(name, argValue);
             }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.openrewrite.Recipe;
+
+public class AdoptAssertJDurationAssertions extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public String getDescription() {
+        return "";
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -43,7 +43,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
         put("getNano", "hasNanos");
     }};
     static List<MethodMatcher> timeUnitMatchers = Arrays.asList(
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMillis(..)"),
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMillis(..)", true),
             new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasSeconds(..)"),
             new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasNanos(..)"),
             new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMinutes(..)"),

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -134,10 +134,9 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             String methodName = (String) unitInfo.get(0);
             int methodArg = (int) unitInfo.get(1);
             if (!(m.getSimpleName().equals(methodName))) {
-                // convert divided value to OpenRewrite LST type
-                J.Literal newArg = rawValueToExpression(methodArg);
                 // update method invocation with new name and arg
-                return applyTemplate(ctx, m, "#{any()}.#{}(#{any(int)})", m.getSelect(), methodName, newArg);
+                String template = String.format("#{any()}.%s(%d)", methodName, methodArg);
+                return applyTemplate(ctx, m, template, m.getSelect());
             }
 
             return m;
@@ -158,18 +157,6 @@ public class AdoptAssertJDurationAssertions extends Recipe {
                 // returning name, newArg
                 return Arrays.asList(name, argValue);
             }
-        }
-
-        private static J.Literal rawValueToExpression(int rawValue) {
-            return new J.Literal(
-                    UUID.randomUUID(),
-                    Space.EMPTY,
-                    Markers.EMPTY,
-                    rawValue,
-                    String.valueOf(rawValue),
-                    null,
-                    JavaType.Primitive.Int
-            );
         }
 
         private J.MethodInvocation applyTemplate(ExecutionContext ctx, J.MethodInvocation m, String template, Object... parameters) {

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -90,6 +90,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
             put("getSeconds", "hasSeconds");
             put("getNano", "hasNanos");
 
+            put("hasNanos", "hasMillis");
             put("hasMillis", "hasSeconds");
             put("hasSeconds", "hasMinutes");
             put("hasMinutes", "hasHours");
@@ -180,11 +181,15 @@ public class AdoptAssertJDurationAssertions extends Recipe {
         }
 
         private static List<Object> getUnitInfo(String name, int argValue) {
-            int timeLength = 60;
-            if (name.equals("hasMillis")) {
+            final int timeLength;
+            if (name.equals("hasSeconds") || name.equals("hasMinutes")) {
+                timeLength = 60;
+            } else if (name.equals("hasNanos") || name.equals("hasMillis")) {
                 timeLength = 1000;
             } else if (name.equals("hasHours")) {
                 timeLength = 24;
+            } else {
+                return Arrays.asList(name, argValue);
             }
 
             if (argValue % timeLength == 0) {

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -20,11 +20,11 @@ import org.openrewrite.Recipe;
 public class AdoptAssertJDurationAssertions extends Recipe {
     @Override
     public String getDisplayName() {
-        return "";
+        return "Adopt AssertJ Duration assertions";
     }
 
     @Override
     public String getDescription() {
-        return "";
+        return "Adopt AssertJ DurationAssert assertions for more expressive messages.";
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -67,6 +67,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // TODO: figure out why this Precondition check doesn't quite work
         //return Preconditions.check(Preconditions.or(
         //        new UsesMethod<>("org.assertj.core.api.AbstractDurationAssert has*(int)", true),
         //        new UsesMethod<>("org.assertj.core.api.AbstractLongAssert isEqualTo(..)", true)
@@ -118,6 +119,9 @@ public class AdoptAssertJDurationAssertions extends Recipe {
         private J.MethodInvocation simplifyTimeUnits(J.MethodInvocation m, ExecutionContext ctx) {
             Expression arg = m.getArguments().get(0);
             Long argValue = SimplifyDurationCreationUnits.getConstantIntegralValue(arg);
+            if (argValue == null) {
+                return m;
+            }
             List<Object> unitInfo = getUnitInfo(m.getSimpleName(), Math.toIntExact(argValue));
             String methodName = (String)unitInfo.get(0);
             int methodArg = (int)unitInfo.get(1);

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -48,11 +48,11 @@ public class AdoptAssertJDurationAssertions extends Recipe {
     }};
     static List<MethodMatcher> timeUnitMatchers = Arrays.asList(
             new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMillis(..)", true),
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasSeconds(..)"),
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasNanos(..)"),
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMinutes(..)"),
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasHours(..)"),
-            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasDays(..)")
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasSeconds(..)", true),
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasNanos(..)", true),
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasMinutes(..)", true),
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasHours(..)", true),
+            new MethodMatcher("org.assertj.core.api.AbstractDurationAssert hasDays(..)", true)
     );
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java
@@ -129,7 +129,7 @@ public class AdoptAssertJDurationAssertions extends Recipe {
 
                 // update method invocation with new name and arg
                 Expression methodSelect = m.getSelect();
-                return JavaTemplate.builder("#{any()}.#{any()}(#{int})")
+                return JavaTemplate.builder("#{any()}.#{any()}(#{any(int)})")
                         .contextSensitive()
                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9", "assertj-core-3.24"))
                         .build()

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -415,7 +415,7 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Durartion time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasDays(2);
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -24,13 +24,14 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
+class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
           .recipe(new AdoptAssertJDurationAssertions())
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"));
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"));
     }
 
     @Test
@@ -40,22 +41,22 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isEqualTo(1);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).hasSeconds(1);
                   }
@@ -71,23 +72,23 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(1);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).hasNanos(1);
                   }
@@ -104,24 +105,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasSeconds(600);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMinutes(10);
                   }
@@ -138,24 +139,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.juint.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMillis(5000);
                   }
               }
               """,
             """
-              import org.juint.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasSeconds(5);
                   }
@@ -172,24 +173,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMillis(300000);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMinutes(5);
                   }
@@ -206,24 +207,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMillis(18000000);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(5);
                   }
@@ -240,24 +241,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMillis(432000000);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasDays(5);
                   }
@@ -274,24 +275,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasMinutes(120);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(2);
                   }
@@ -308,24 +309,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(48);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasDays(2);
                   }
@@ -342,12 +343,12 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(34);
                   }
@@ -364,12 +365,12 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(34 + 5);
                       assertThat(time).hasHours(34 - 5);
@@ -388,12 +389,12 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time, int constant) {
                       assertThat(time).hasHours(34 * constant);
                   }
@@ -410,24 +411,24 @@ public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasHours(24 * 2);
                   }
               }
               """,
             """
-              import org.junit.jupiter.api.Test;
               import java.time.Duration;
               import java.time.temporal.Temporal;
               
+              import static org.assertj.core.api.Assertions.assertThat;
+              
               class Foo {
-                  @Test
                   void testMethod(Temporal time) {
                       assertThat(time).hasDays(2);
                   }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -101,40 +101,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //seconds to minutes
-    @Test
-    void secondsToMinutes() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              import java.time.temporal.Temporal;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Temporal time) {
-                      assertThat(time).hasSeconds(600);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              import java.time.temporal.Temporal;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Temporal time) {
-                      assertThat(time).hasMinutes(10);
-                  }
-              }
-              """
-          )
-        );
-    }
-
     //millis to seconds
     @Test
     void millisToSeconds() {
@@ -143,24 +109,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMillis(5000);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasSeconds(5);
                   }
               }
@@ -168,6 +132,40 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           )
         );
     }
+
+    //seconds to minutes
+    @Test
+    void secondsToMinutes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Duration time) {
+                      assertThat(time).hasSeconds(600);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Duration time) {
+                      assertThat(time).hasMinutes(10);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+
 
     //millis to minutes
     @Test
@@ -177,24 +175,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMillis(300000);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMinutes(5);
                   }
               }
@@ -211,24 +207,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMillis(18000000);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(5);
                   }
               }
@@ -245,24 +239,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMillis(432000000);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasDays(5);
                   }
               }
@@ -279,24 +271,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasMinutes(120);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(2);
                   }
               }
@@ -313,24 +303,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(48);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasDays(2);
                   }
               }
@@ -347,12 +335,11 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(34);
                   }
               }
@@ -369,12 +356,11 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(34 + 5);
                       assertThat(time).hasHours(34 - 5);
                       assertThat(time).hasHours(34 / 5);
@@ -393,12 +379,11 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time, int constant) {
+                  void testMethod(Duration time, int constant) {
                       assertThat(time).hasHours(34 * constant);
                   }
               }
@@ -415,24 +400,22 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Duration time) {
                       assertThat(time).hasHours(24 * 2);
                   }
               }
               """,
             """
               import java.time.Duration;
-              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
               class Foo {
-                  void testMethod(Temporal time) {
+                  void testMethod(Durartion time) {
                       assertThat(time).hasDays(2);
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -42,6 +42,7 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
+              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
@@ -53,6 +54,7 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
               """,
             """
               import java.time.Duration;
+              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               
@@ -73,6 +75,7 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
+              import java.time.temporal.Temporal;
               
               import static org.assertj.core.api.Assertions.assertThat;
               

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new AdoptAssertJDurationAssertions())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"));
+    }
+
+    @Test
+    @DocumentExample
+    void getSecondEqualToTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).isEqualTo(1);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB)).hasSeconds(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void worksWithGetNano() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(1);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB)).hasNanos(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //seconds to minutes
+    @Test
+    void secondsToMinutes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasSeconds(600);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMinutes(10);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //millis to seconds
+    @Test
+    void millisToSeconds() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.juint.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMillis(5000);
+                  }
+              }
+              """,
+            """
+              import org.juint.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasSeconds(5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //millis to minutes
+    @Test
+    void millisToMinutes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMillis(300000);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMinutes(5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //millis to hours
+    @Test
+    void millisToHours() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMillis(18000000);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //millis to days
+    @Test
+    void millisToDays() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMillis(432000000);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasDays(5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //minutes to hours
+    @Test
+    void minutesToHours() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasMinutes(120);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //hours to days
+    @Test
+    void hoursToDays() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(48);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasDays(2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //does not change when not able to be simplified
+    @Test
+    void cannotBeSimplified() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(34);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //does not run on non multiplication arithmetic
+    @Test
+    void doesNotRunOnNonMultArithmetic() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(34 + 5);
+                      assertThat(time).hasHours(34 - 5);
+                      assertThat(time).hasHours(34 / 5);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //does not change when constant is multiplied
+    @Test
+    void doesNotChangeWhenConstantIsMultiplied() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time, int constant) {
+                      assertThat(time).hasHours(34 * constant);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    //multiplication cases
+    @Test
+    void doesChangeOnMultiplication() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasHours(24 * 2);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              class Foo {
+                  @Test
+                  void testMethod(Temporal time) {
+                      assertThat(time).hasDays(2);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDuractionAssertionsTest.java
@@ -101,7 +101,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //millis to seconds
     @Test
     void millisToSeconds() {
         //language=java
@@ -133,7 +132,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //seconds to minutes
     @Test
     void secondsToMinutes() {
         //language=java
@@ -165,9 +163,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-
-
-    //millis to minutes
     @Test
     void millisToMinutes() {
         //language=java
@@ -199,7 +194,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //millis to hours
     @Test
     void millisToHours() {
         //language=java
@@ -231,7 +225,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //millis to days
     @Test
     void millisToDays() {
         //language=java
@@ -263,7 +256,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //minutes to hours
     @Test
     void minutesToHours() {
         //language=java
@@ -295,7 +287,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //hours to days
     @Test
     void hoursToDays() {
         //language=java
@@ -327,7 +318,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //does not change when not able to be simplified
     @Test
     void cannotBeSimplified() {
         //language=java
@@ -348,7 +338,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //does not run on non multiplication arithmetic
     @Test
     void doesNotRunOnNonMultArithmetic() {
         //language=java
@@ -371,7 +360,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //does not change when constant is multiplied
     @Test
     void doesNotChangeWhenConstantIsMultiplied() {
         //language=java
@@ -392,7 +380,6 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
         );
     }
 
-    //multiplication cases
     @Test
     void doesChangeOnMultiplication() {
         //language=java

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -137,6 +137,41 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
     }
 
     @Test
+    void isEqualToVariable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+                            
+              import static org.assertj.core.api.Assertions.assertThat;
+                            
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      int zero = 0;
+                      assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(zero);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+                            
+              import static org.assertj.core.api.Assertions.assertThat;
+                            
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      int zero = 0;
+                      assertThat(Duration.between(timestampA, timestampB)).hasNanos(zero);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void isGreaterThanZeroToIsPositive() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -509,4 +509,93 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldRetainAsDescription() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).as("description").isEqualTo(1);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB)).as("description").hasSeconds(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldRetainWhiteSpace() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds())
+                        .isEqualTo(1);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB))
+                        .hasSeconds(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotMatchUnrelatedToDurations() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod() {
+                      assertThat(bar()).isEqualTo(0);
+                  }
+                  int bar() {
+                      return 0;  
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -266,49 +266,7 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
     }
 
     @Test
-    void cannotBeSimplified() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-                            
-              import static org.assertj.core.api.Assertions.assertThat;
-                            
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(34);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotRunOnNonMultArithmetic() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-                            
-              import static org.assertj.core.api.Assertions.assertThat;
-                            
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(34 + 5);
-                      assertThat(time).hasHours(34 - 5);
-                      assertThat(time).hasHours(34 / 5);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotChangeWhenVariableIsMultiplied() {
+    void doNotSimplifyNonLiteralMultiplication() {
         //language=java
         rewriteRun(
           java(
@@ -319,6 +277,11 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
                             
               class Foo {
                   void testMethod(Duration time, int variable) {
+                      assertThat(time).hasHours(19 + 5);
+                      assertThat(time).hasHours(29 - 5);
+                      assertThat(time).hasHours(120 / 5);
+                      assertThat(time).hasHours(25);
+                      assertThat(time).hasHours(25 * 2);
                       assertThat(time).hasHours(2 * variable);
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
+class AdoptAssertJDurationAssertionsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -94,6 +94,105 @@ class AdoptAssertJDuractionAssertionsTest implements RewriteTest {
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).hasNanos(1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void isEqualToZeroToIsZero() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(0);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getNano()).isZero();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void isGreaterThanZeroToIsPositive() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).isGreaterThan(0);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).isPositive();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void isLessThanZeroToIsNegative() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).isLessThan(0);
+                  }
+              }
+              """,
+            """
+              import java.time.Duration;
+              import java.time.temporal.Temporal;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Foo {
+                  void testMethod(Temporal timestampA, Temporal timestampB) {
+                      assertThat(Duration.between(timestampA, timestampB).getSeconds()).isNegative();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -239,6 +239,7 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
 
     @ParameterizedTest
     @CsvSource({
+      "hasNanos(6000000L),hasSeconds(6)",
       "hasMillis(5000),hasSeconds(5)",
       "hasSeconds(600),hasMinutes(10)",
       "hasMillis(300000),hasMinutes(5)",

--- a/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertionsTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.java.testing.assertj;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -36,16 +38,16 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
 
     @Test
     @DocumentExample
-    void getSecondEqualToTest() {
+    void getSecondsToHasSeconds() {
         //language=java
         rewriteRun(
           java(
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isEqualTo(1);
@@ -55,9 +57,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).hasSeconds(1);
@@ -69,16 +71,16 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
     }
 
     @Test
-    void worksWithGetNano() {
+    void getNanoToHasNanos() {
         //language=java
         rewriteRun(
           java(
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(1);
@@ -88,9 +90,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).hasNanos(1);
@@ -109,9 +111,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getNano()).isEqualTo(0);
@@ -121,9 +123,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getNano()).isZero();
@@ -142,9 +144,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isGreaterThan(0);
@@ -154,9 +156,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isPositive();
@@ -175,9 +177,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isLessThan(0);
@@ -187,9 +189,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).isNegative();
@@ -200,221 +202,31 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
         );
     }
 
-    @Test
-    void millisToSeconds() {
+    @ParameterizedTest
+    @CsvSource({
+      "hasMillis(5000),hasSeconds(5)",
+      "hasSeconds(600),hasMinutes(10)",
+      "hasMillis(300000),hasMinutes(5)",
+      "hasMillis(18000000),hasHours(5)",
+      "hasMillis(432000000),hasDays(5)",
+      "hasMinutes(120),hasHours(2)",
+      "hasHours(48),hasDays(2)",
+      "hasHours(24 * 2),hasDays(2)",
+    })
+    void simplifyDurationAssertions(String before, String after) {
         //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMillis(5000);
-                  }
+        String template = """
+          import java.time.Duration;
+                        
+          import static org.assertj.core.api.Assertions.assertThat;
+                        
+          class Foo {
+              void testMethod(Duration time) {
+                  assertThat(time).%s;
               }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasSeconds(5);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void secondsToMinutes() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasSeconds(600);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMinutes(10);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void millisToMinutes() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMillis(300000);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMinutes(5);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void millisToHours() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMillis(18000000);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(5);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void millisToDays() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMillis(432000000);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasDays(5);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void minutesToHours() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasMinutes(120);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(2);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void hoursToDays() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(48);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasDays(2);
-                  }
-              }
-              """
-          )
-        );
+          }
+          """;
+        rewriteRun(java(template.formatted(before), template.formatted(after)));
     }
 
     @Test
@@ -424,9 +236,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Duration time) {
                       assertThat(time).hasHours(34);
@@ -444,9 +256,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
           java(
             """
               import java.time.Duration;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Duration time) {
                       assertThat(time).hasHours(34 + 5);
@@ -460,49 +272,18 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
     }
 
     @Test
-    void doesNotChangeWhenConstantIsMultiplied() {
+    void doesNotChangeWhenVariableIsMultiplied() {
         //language=java
         rewriteRun(
           java(
             """
               import java.time.Duration;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
-                  void testMethod(Duration time, int constant) {
-                      assertThat(time).hasHours(34 * constant);
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesChangeOnMultiplication() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasHours(24 * 2);
-                  }
-              }
-              """,
-            """
-              import java.time.Duration;
-              
-              import static org.assertj.core.api.Assertions.assertThat;
-              
-              class Foo {
-                  void testMethod(Duration time) {
-                      assertThat(time).hasDays(2);
+                  void testMethod(Duration time, int variable) {
+                      assertThat(time).hasHours(2 * variable);
                   }
               }
               """
@@ -518,9 +299,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds()).as("description").isEqualTo(1);
@@ -530,9 +311,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB)).as("description").hasSeconds(1);
@@ -551,9 +332,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB).getSeconds())
@@ -564,9 +345,9 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
             """
               import java.time.Duration;
               import java.time.temporal.Temporal;
-              
+                            
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod(Temporal timestampA, Temporal timestampB) {
                       assertThat(Duration.between(timestampA, timestampB))
@@ -585,13 +366,13 @@ class AdoptAssertJDurationAssertionsTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-              
+                            
               class Foo {
                   void testMethod() {
                       assertThat(bar()).isEqualTo(0);
                   }
                   int bar() {
-                      return 0;  
+                      return 0;
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
This PR introduces a recipe that simplifies some AssertJ duration assertions with dedicated asserts and also simplifies some `Duration`s to easier to read forms.
Ex:
```
- .hasHours(48)
+ .hasDays(2)
```

## What's your motivation?
[#400](https://github.com/openrewrite/rewrite-testing-frameworks/issues/400)

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
- [ ] I've updated the documentation (if applicable)
