### PR TITLE
Bugfix/358 powermock

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -23,6 +23,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.*;
+import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 
@@ -49,13 +50,7 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                     new UsesType<>("org.powermock..*", false),
                     new UsesType<>("org.mockito..*", false)
                 ),
-                new JavaVisitor<ExecutionContext>(){
-                    @Override
-                    public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                        doAfterVisit(new PowerMockitoToMockitoVisitor());
-                        return super.visitClassDeclaration(classDecl, ctx);
-                    }
-                }
+                new PowerMockitoToMockitoVisitor()
         );
     }
 
@@ -88,11 +83,14 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
         private String tearDownMethodAnnotationParameters = "";
 
         @Override
-        public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-            boolean useTestNg = containsTestNgTestMethods(classDecl.getBody().getStatements().stream()
-                    .filter(J.MethodDeclaration.class::isInstance)
-                    .map(J.MethodDeclaration.class::cast).collect(Collectors.toList()));
+        public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+            boolean useTestNg = !FindAnnotations.find(cu, "org.testng.annotations.Test").isEmpty();
             initTestFrameworkInfo(useTestNg);
+            return super.visitCompilationUnit(cu, ctx);
+        }
+
+        @Override
+        public J visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             getCursor().putMessage(MOCK_STATIC_INVOCATIONS, new HashMap<>());
 
             // Add the classes of the arguments in the annotation @PrepareForTest as fields
@@ -224,19 +222,6 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                 }
             }
             return null;
-        }
-
-        private static boolean containsTestNgTestMethods(List<J.MethodDeclaration> methods) {
-            for (J.MethodDeclaration methodDeclaration : methods) {
-                for (J.Annotation annotation : methodDeclaration.getAllAnnotations()) {
-                    JavaType annotationType = annotation.getAnnotationType().getType();
-                    if (annotationType instanceof JavaType.Class && "org.testng.annotations.Test".equals(((JavaType.Class) annotationType)
-                            .getFullyQualifiedName())) {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         private static boolean hasMethodWithAnnotation(J.ClassDeclaration classDecl, AnnotationMatcher annotationMatcher) {

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -111,7 +111,7 @@ recipeList:
   - org.openrewrite.java.testing.mockito.CleanupMockitoImports
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
-#  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
+  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-junit-jupiter

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -160,3 +160,6 @@ recipeList:
       matchOverrides: null
       matchUnknownTypes: null
   - org.openrewrite.java.testing.mockito.PowerMockitoMockStaticToMockito
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.powermock
+      artifactId: powermock-api-mockito*

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -18,10 +18,12 @@ package org.openrewrite.java.testing.mockito;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 
 class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
@@ -570,5 +572,14 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
               public class MyPowerMockConfiguration {}
               """
           ));
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/358")
+    void doesNotExplodeOnTopLevelMethodDeclaration() {
+        rewriteRun(
+          groovy(
+          "def myFun() { }"
+        ));
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -18,8 +18,6 @@ package org.openrewrite.java.testing.mockito;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Recipe;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -30,10 +28,6 @@ import static org.openrewrite.java.Assertions.java;
 class ReplacePowerMockitoIntegrationTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
-        Recipe recipe = Environment.builder()
-          .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
-          .build()
-          .activateRecipes("org.openrewrite.java.testing.mockito.ReplacePowerMockito");
         spec
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
@@ -50,7 +44,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
             .identifiers(false)
             .methodInvocations(false)
             .build())
-          .recipe(recipe);
+          .recipeFromResources("org.openrewrite.java.testing.mockito.ReplacePowerMockito");
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Fixes #358, and puts the powermock recipe back in the mockito 1-3 (and therefore junit 5) recipe.

## What's your motivation?
A project trying to use JUnit 5 cannot use powermock, so any progress moving away from powermock is valuable.
And now this recipe shouldn't throw surprising exceptions, so it should be safe to include.

## Any additional context

Some additional opportunities for contribution:
- The current recipe only focuses on PowerMockito, but in theory *any* `PowerMock` library is incompatible with JUnit 5, so it would be good to expand scope to others.
- Some PowerMockito methods are still not handled, such as:
  - `whenNew`
  - `verifyPrivate`
  - `verifyStatic`
  - maybe others?

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [ ] I've added the license header to any new files through `./gradlew licenseFormat`
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
