### PR TITLE
Jmockit Expectations - Handle Additional Cases

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -107,15 +107,15 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
 
                     // TODO: handle additional jmockit expectations features
 
-                    if (expectationStatement instanceof J.MethodInvocation && !templateParams.isEmpty()) {
-                        newBody = buildNewBody(ctx, templateParams, i);
+                    if (expectationStatement instanceof J.MethodInvocation) {
+                        if (!templateParams.isEmpty()) {
+                            // apply template to build new method body
+                            newBody = buildNewBody(ctx, templateParams, i);
 
-                        // reset for next statement
-                        cursorLocation = newBody;
-                        templateParams = new ArrayList<>();
-                        templateParams.add(expectationStatement);
-                    } else if (expectationStatement instanceof J.MethodInvocation) {
-                        // fresh expectation
+                            // reset for next statement
+                            cursorLocation = newBody;
+                            templateParams = new ArrayList<>();
+                        }
                         templateParams.add(expectationStatement);
                     } else {
                         // assignment

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -108,6 +108,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                 List<Statement> expectationStatements = expectationsBlock.getStatements();
                 List<Object> templateParams = new ArrayList<>();
 
+                // iterate over the expectations statements and rebuild the method body
                 for (Statement expectationStatement : expectationStatements) {
                     // TODO: handle void methods (including final statement)
 
@@ -128,6 +129,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                     }
                 }
 
+                // handle the last statement
                 if (!templateParams.isEmpty()) {
                     newBody = buildNewBody(ctx, templateParams, i);
                 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.jmockit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
@@ -61,6 +62,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
         private static final String PRIMITIVE_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{});";
         private static final String OBJECT_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{any(java.lang.String)});";
         private static final String EXCEPTION_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
+        private static final Pattern EXPECTATIONS_PATTERN = Pattern.compile("mockit.Expectations");
 
         private Object cursorLocation;
         private JavaCoordinates coordinates;
@@ -85,7 +87,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                     continue;
                 }
                 J.Identifier clazz = (J.Identifier) nc.getClazz();
-                if (!clazz.getSimpleName().equals("Expectations")) {
+                if (clazz.getType() == null || !clazz.getType().isAssignableFrom(EXPECTATIONS_PATTERN)) {
                     continue;
                 }
                 // empty Expectations block is considered invalid

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -66,7 +66,6 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
 
         private Object cursorLocation;
         private JavaCoordinates coordinates;
-        private Space prefix;
 
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
@@ -75,8 +74,8 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                 return md;
             }
             cursorLocation = md.getBody();
-            List<Statement> statements = md.getBody().getStatements();
             J.Block newBody = md.getBody();
+            List<Statement> statements = md.getBody().getStatements();
             for (int i = 0; i < statements.size(); i++) {
                 Statement s = statements.get(i);
                 if (!(s instanceof J.NewClass)) {
@@ -99,7 +98,6 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                 // prepare the statements for moving
                 J.Block innerBlock = (J.Block) nc.getBody().getStatements().get(0);
 
-                prefix = nc.getPrefix();
                 coordinates = nc.getCoordinates().replace();
                 List<Statement> expectationStatements = innerBlock.getStatements();
                 List<Object> templateParams = new ArrayList<>();
@@ -154,7 +152,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
                     // next statement should go immediately after one just added
                     coordinates = s.getCoordinates().after();
                 }
-                newStatements.add(s.withPrefix(prefix));
+                newStatements.add(s);
             }
             return newBody.withStatements(newStatements);
         }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -15,108 +15,168 @@
  */
 package org.openrewrite.java.testing.jmockit;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaCoordinates;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class JMockitExpectationsToMockitoWhen extends Recipe {
-  @Override
-  public String getDisplayName() {
-    return "Rewrite JMockit Expectations";
-  }
-
-  @Override
-  public String getDescription() {
-    return "Rewrites JMockit `Expectations` to `Mockito.when`.";
-  }
-
-  @Override
-  public TreeVisitor<?, ExecutionContext> getVisitor() {
-    return Preconditions.check(new UsesType<>("mockit.*", false),
-        new RewriteExpectationsVisitor());
-  }
-
-  private static class RewriteExpectationsVisitor extends JavaVisitor<ExecutionContext> {
-
-    private static final String PRIMITIVE_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{});";
-    private static final String OBJECT_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{any(java.lang.String)});";
-    private static final String EXCEPTION_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
+    @Override
+    public String getDisplayName() {
+        return "Rewrite JMockit Expectations";
+    }
 
     @Override
-    public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
-      J.NewClass nc = (J.NewClass) super.visitNewClass(newClass, ctx);
-      if (!(nc.getClazz() instanceof J.Identifier)) {
-        return nc;
-      }
-      J.Identifier clazz = (J.Identifier) nc.getClazz();
-      if (!clazz.getSimpleName().equals("Expectations")) {
-        return nc;
-      }
-
-      // empty Expectations block is considered invalid
-      assert nc.getBody() != null : "Expectations block is empty";
-
-      // prepare the statements for moving
-      J.Block innerBlock = (J.Block) nc.getBody().getStatements().get(0);
-
-      // TODO: handle multiple mock statements
-      Statement mockInvocation = innerBlock.getStatements().get(0);
-      Expression result = ((J.Assignment) innerBlock.getStatements().get(1)).getAssignment();
-      String template = getTemplate(result);
-
-      // apply the template and replace the `new Expectations()` statement coordinates
-      J.MethodInvocation newMethod = JavaTemplate.builder(template)
-          .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
-          .staticImports("org.mockito.Mockito.when")
-          .build()
-          .apply(
-              getCursor(),
-              nc.getCoordinates().replace(),
-              mockInvocation,
-              result
-          );
-
-      // handle import changes
-      maybeAddImport("org.mockito.Mockito", "when");
-      maybeRemoveImport("mockit.Expectations");
-
-      return newMethod.withPrefix(nc.getPrefix());
+    public String getDescription() {
+        return "Rewrites JMockit `Expectations` to `Mockito.when`.";
     }
 
-    /*
-     * Based on the result type, we need to use a different template.
-     */
-    private static String getTemplate(Expression result) {
-      String template;
-      JavaType resultType = Objects.requireNonNull(result.getType());
-      if (resultType instanceof JavaType.Primitive) {
-        template = PRIMITIVE_RESULT_TEMPLATE;
-      } else if (resultType instanceof JavaType.Class) {
-        Class<?> resultClass;
-        try {
-          resultClass = Class.forName(((JavaType.Class) resultType).getFullyQualifiedName());
-        } catch (ClassNotFoundException e) {
-          throw new RuntimeException(e);
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("mockit.*", false),
+                new RewriteExpectationsVisitor());
+    }
+
+    private static class RewriteExpectationsVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private static final String PRIMITIVE_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{});";
+        private static final String OBJECT_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{any(java.lang.String)});";
+        private static final String EXCEPTION_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
+
+        private Object cursorLocation;
+        private JavaCoordinates coordinates;
+        private Space prefix;
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, ExecutionContext ctx) {
+            J.MethodDeclaration md = super.visitMethodDeclaration(methodDeclaration, ctx);
+            if (md.getBody() == null) {
+                return md;
+            }
+            cursorLocation = md.getBody();
+            List<Statement> statements = md.getBody().getStatements();
+            J.Block newBody = md.getBody();
+            for (int i = 0; i < statements.size(); i++) {
+                Statement s = statements.get(i);
+                if (!(s instanceof J.NewClass)) {
+                    continue;
+                }
+                J.NewClass nc = (J.NewClass) s;
+                if (!(nc.getClazz() instanceof J.Identifier)) {
+                    continue;
+                }
+                J.Identifier clazz = (J.Identifier) nc.getClazz();
+                if (!clazz.getSimpleName().equals("Expectations")) {
+                    continue;
+                }
+                // empty Expectations block is considered invalid
+                assert nc.getBody() != null && !nc.getBody().getStatements().isEmpty() : "Expectations block is empty";
+
+                maybeAddImport("org.mockito.Mockito", "when");
+                maybeRemoveImport("mockit.Expectations");
+
+                // prepare the statements for moving
+                J.Block innerBlock = (J.Block) nc.getBody().getStatements().get(0);
+
+                prefix = nc.getPrefix();
+                coordinates = nc.getCoordinates().replace();
+                List<Statement> expectationStatements = innerBlock.getStatements();
+                List<Object> templateParams = new ArrayList<>();
+
+                for (Statement expectationStatement : expectationStatements) {
+                    // TODO: handle void methods (including final statement)
+
+                    // TODO: handle additional jmockit expectations features
+
+                    if (expectationStatement instanceof J.MethodInvocation && !templateParams.isEmpty()) {
+                        newBody = buildNewBody(ctx, templateParams, i);
+
+                        // reset for next statement
+                        cursorLocation = newBody;
+                        templateParams = new ArrayList<>();
+                        templateParams.add(expectationStatement);
+                    } else if (expectationStatement instanceof J.MethodInvocation) {
+                        // fresh expectation
+                        templateParams.add(expectationStatement);
+                    } else {
+                        // assignment
+                        templateParams.add(((J.Assignment) expectationStatement).getAssignment());
+                    }
+                }
+
+                if (!templateParams.isEmpty()) {
+                    newBody = buildNewBody(ctx, templateParams, i);
+                }
+            }
+
+            return md.withBody(newBody);
         }
-        template = Throwable.class.isAssignableFrom(resultClass) ? EXCEPTION_RESULT_TEMPLATE : OBJECT_RESULT_TEMPLATE;
-      } else {
-        throw new IllegalStateException("Unexpected value: " + result.getType());
-      }
-      return template;
+
+        private J.Block buildNewBody(ExecutionContext ctx, List<Object> templateParams, int newStatementIndex) {
+            Expression result = (Expression) templateParams.get(1);
+            String template = getTemplate(result);
+
+            J.Block newBody = JavaTemplate.builder(template)
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
+                    .staticImports("org.mockito.Mockito.when")
+                    .build()
+                    .apply(
+                            new Cursor(getCursor(), cursorLocation),
+                            coordinates,
+                            templateParams.toArray()
+                    );
+
+            List<Statement> newStatements = new ArrayList<>(newBody.getStatements().size());
+            for (int i = 0; i < newBody.getStatements().size(); i++) {
+                Statement s = newBody.getStatements().get(i);
+                if (i == newStatementIndex) {
+                    // next statement should go immediately after one just added
+                    coordinates = s.getCoordinates().after();
+                }
+                newStatements.add(s.withPrefix(prefix));
+            }
+            return newBody.withStatements(newStatements);
+        }
+
+        /*
+         * Based on the result type, we need to use a different template.
+         */
+        private static String getTemplate(Expression result) {
+            String template;
+            JavaType resultType = Objects.requireNonNull(result.getType());
+            if (resultType instanceof JavaType.Primitive) {
+                template = PRIMITIVE_RESULT_TEMPLATE;
+            } else if (resultType instanceof JavaType.Class) {
+                Class<?> resultClass;
+                try {
+                    resultClass = Class.forName(((JavaType.Class) resultType).getFullyQualifiedName());
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+                template = Throwable.class.isAssignableFrom(resultClass) ? EXCEPTION_RESULT_TEMPLATE : OBJECT_RESULT_TEMPLATE;
+            } else {
+                throw new IllegalStateException("Unexpected value: " + result.getType());
+            }
+            return template;
+        }
     }
-  }
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -64,7 +64,10 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
         private static final String EXCEPTION_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
         private static final Pattern EXPECTATIONS_PATTERN = Pattern.compile("mockit.Expectations");
 
+        // the LST element that is being updated when applying one of the java templates
         private Object cursorLocation;
+
+        // the coordinates where the next statement should be inserted
         private JavaCoordinates coordinates;
 
         @Override

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -66,16 +66,16 @@ class JMockitToMockitoTest implements RewriteTest {
 
               @ExtendWith(JMockitExtension.class)
               class MyTest {
-                @Mocked
-                MyObject myObject;
+                  @Mocked
+                  MyObject myObject;
 
-                void test() {
-                  new Expectations() {{
-                    myObject.getSomeField();
-                    result = null;
-                  }};
-                  assertNull(myObject.getSomeField());
-                }
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = null;
+                      }};
+                      assertNull(myObject.getSomeField());
+                  }
               }
               """,
             """
@@ -88,13 +88,13 @@ class JMockitToMockitoTest implements RewriteTest {
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
-                @Mock
-                MyObject myObject;
+                  @Mock
+                  MyObject myObject;
 
-                void test() {
-                  when(myObject.getSomeField()).thenReturn(null);
-                  assertNull(myObject.getSomeField());
-                }
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn(null);
+                      assertNull(myObject.getSomeField());
+                  }
               }
               """
           )
@@ -120,40 +120,40 @@ class JMockitToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-            
+                          
               import static org.junit.jupiter.api.Assertions.assertEquals;
-            
+                          
               @ExtendWith(JMockitExtension.class)
               class MyTest {
-                @Mocked
-                MyObject myObject;
-            
-                void test() {
-                  new Expectations() {{
-                    myObject.getSomeField();
-                    result = 10;
-                  }};
-                  assertEquals(10, myObject.getSomeField());
-                }
+                  @Mocked
+                  MyObject myObject;
+                          
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = 10;
+                      }};
+                      assertEquals(10, myObject.getSomeField());
+                  }
               }
               """,
             """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
-                @Mock
-                MyObject myObject;
+                  @Mock
+                  MyObject myObject;
 
-                void test() {
-                  when(myObject.getSomeField()).thenReturn(10);
-                  assertEquals(10, myObject.getSomeField());
-                }
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn(10);
+                      assertEquals(10, myObject.getSomeField());
+                  }
               }
               """
           )
@@ -179,44 +179,44 @@ class JMockitToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-            
+                          
               import static org.junit.jupiter.api.Assertions.assertEquals;
-            
+                          
               @ExtendWith(JMockitExtension.class)
               class MyTest {
-                @Mocked
-                MyObject myObject;
+                  @Mocked
+                  MyObject myObject;
                 
-                String expected = "expected";
+                  String expected = "expected";
                 
-                void test() {
-                  new Expectations() {{
-                    myObject.getSomeField();
-                    result = expected;
-                  }};
-                  assertEquals(expected, myObject.getSomeField());
-                }
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = expected;
+                      }};
+                      assertEquals(expected, myObject.getSomeField());
+                  }
               }
               """,
             """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-              
+                            
               @ExtendWith(MockitoExtension.class)
               class MyTest {
-                @Mock
-                MyObject myObject;
+                  @Mock
+                  MyObject myObject;
                 
-                String expected = "expected";
+                  String expected = "expected";
                 
-                void test() {
-                  when(myObject.getSomeField()).thenReturn(expected);
-                  assertEquals(expected, myObject.getSomeField());
-                }
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn(expected);
+                      assertEquals(expected, myObject.getSomeField());
+                  }
               }
               """
           )
@@ -242,40 +242,40 @@ class JMockitToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-            
+                          
               import static org.junit.jupiter.api.Assertions.assertNotNull;
-            
+                          
               @ExtendWith(JMockitExtension.class)
               class MyTest {
-                @Mocked
-                MyObject myObject;
-            
-                void test() {
-                  new Expectations() {{
-                    myObject.getSomeField();
-                    result = new Object();
-                  }};
-                  assertNotNull(myObject.getSomeField());
-                }
+                  @Mocked
+                  MyObject myObject;
+                          
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = new Object();
+                      }};
+                      assertNotNull(myObject.getSomeField());
+                  }
               }
               """,
             """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertNotNull;
               import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
-                @Mock
-                MyObject myObject;
+                  @Mock
+                  MyObject myObject;
 
-                void test() {
-                  when(myObject.getSomeField()).thenReturn(new Object());
-                  assertNotNull(myObject.getSomeField());
-                }
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn(new Object());
+                      assertNotNull(myObject.getSomeField());
+                  }
               }
               """
           )
@@ -304,16 +304,16 @@ class JMockitToMockitoTest implements RewriteTest {
 
               @ExtendWith(JMockitExtension.class)
               class MyTest {
-                @Mocked
-                MyObject myObject;
+                  @Mocked
+                  MyObject myObject;
 
-                void test() throws RuntimeException {
-                  new Expectations() {{
-                    myObject.getSomeField();
-                    result = new RuntimeException();
-                  }};
-                  myObject.getSomeField();
-                }
+                  void test() throws RuntimeException {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = new RuntimeException();
+                      }};
+                      myObject.getSomeField();
+                  }
               }
               """,
             """
@@ -325,13 +325,88 @@ class JMockitToMockitoTest implements RewriteTest {
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
-                @Mock
-                MyObject myObject;
+                  @Mock
+                  MyObject myObject;
 
-                void test() throws RuntimeException {
-                  when(myObject.getSomeField()).thenThrow(new RuntimeException());
-                  myObject.getSomeField();
-                }
+                  void test() throws RuntimeException {
+                      when(myObject.getSomeField()).thenThrow(new RuntimeException());
+                      myObject.getSomeField();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jMockitExpectationsToMockitoWhenMultipleStatements() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public int getSomeField() {
+                      return 0;
+                  }
+                  public Object getSomeObjectField() {
+                      return new Object();
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  MyObject myObject;
+
+                  @Mocked
+                  MyObject myOtherObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          result = 10;
+                          myOtherObject.getSomeObjectField();
+                          result = null;
+                      }};
+                      assertEquals(10, myObject.getSomeField());
+                      assertNull(myOtherObject.getSomeObjectField());
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+              import static org.mockito.Mockito.when;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  MyObject myObject;
+
+                  @Mock
+                  MyObject myOtherObject;
+
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn(10);
+                      when(myOtherObject.getSomeObjectField()).thenReturn(null);
+                      assertEquals(10, myObject.getSomeField());
+                      assertNull(myOtherObject.getSomeObjectField());
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -43,7 +43,7 @@ class JMockitToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void jMockitExpectationsToMockitoWhen() {
+    void jMockitExpectationsToMockitoWhenNullResult() {
         //language=java
         rewriteRun(
           java(
@@ -94,6 +94,243 @@ class JMockitToMockitoTest implements RewriteTest {
                 void test() {
                   when(myObject.getSomeField()).thenReturn(null);
                   assertNull(myObject.getSomeField());
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jMockitExpectationsToMockitoWhenIntResult() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public int getSomeField() {
+                      return 0;
+                  }
+              }
+              """
+          ),
+          java(
+            """              
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                @Mocked
+                MyObject myObject;
+            
+                void test() {
+                  new Expectations() {{
+                    myObject.getSomeField();
+                    result = 10;
+                  }};
+                  assertEquals(10, myObject.getSomeField());
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.when;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                @Mock
+                MyObject myObject;
+
+                void test() {
+                  when(myObject.getSomeField()).thenReturn(10);
+                  assertEquals(10, myObject.getSomeField());
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jMockitExpectationsToMockitoWhenVariableResult() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public String getSomeField() {
+                      return "X";
+                  }
+              }
+              """
+          ),
+          java(
+            """              
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                @Mocked
+                MyObject myObject;
+                
+                String expected = "expected";
+                
+                void test() {
+                  new Expectations() {{
+                    myObject.getSomeField();
+                    result = expected;
+                  }};
+                  assertEquals(expected, myObject.getSomeField());
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.when;
+              
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                @Mock
+                MyObject myObject;
+                
+                String expected = "expected";
+                
+                void test() {
+                  when(myObject.getSomeField()).thenReturn(expected);
+                  assertEquals(expected, myObject.getSomeField());
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jMockitExpectationsToMockitoWhenNewClassResult() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public String getSomeField() {
+                      return "X";
+                  }
+              }
+              """
+          ),
+          java(
+            """              
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+            
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                @Mocked
+                MyObject myObject;
+            
+                void test() {
+                  new Expectations() {{
+                    myObject.getSomeField();
+                    result = new Object();
+                  }};
+                  assertNotNull(myObject.getSomeField());
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+              import static org.mockito.Mockito.when;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                @Mock
+                MyObject myObject;
+
+                void test() {
+                  when(myObject.getSomeField()).thenReturn(new Object());
+                  assertNotNull(myObject.getSomeField());
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jMockitExpectationsToMockitoWhenExceptionResult() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public String getSomeField() {
+                      return "X";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                @Mocked
+                MyObject myObject;
+
+                void test() throws RuntimeException {
+                  new Expectations() {{
+                    myObject.getSomeField();
+                    result = new RuntimeException();
+                  }};
+                  myObject.getSomeField();
+                }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.mockito.Mockito.when;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                @Mock
+                MyObject myObject;
+
+                void test() throws RuntimeException {
+                  when(myObject.getSomeField()).thenThrow(new RuntimeException());
+                  myObject.getSomeField();
                 }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- Refactored the recipe to visit `J.MethodDeclaration` instead of `J.NewClass`. When attempting to substitute the `J.NewClass` with multiple `J.MethodDeclaration` LSTs, the old recipe would fail.
- Added support for multiple expectations statements.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Continuation of #415. 

This is still an incomplete implementation, but now handles multiple expectations defined within a JMockit `Expectations` block.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
