### PR TITLE
JMockit to Mockito Recipe - Handle Argument Matchers and Void Methods

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -175,10 +175,10 @@ public class JMockitExpectationsToMockito extends Recipe {
                     continue;
                 }
                 String argumentMatcher = ((J.Identifier) methodArgument).getSimpleName();
-                maybeAddImport("org.mockito.ArgumentMatchers", argumentMatcher);
+                maybeAddImport("org.mockito.Mockito", argumentMatcher);
                 newArguments.add(JavaTemplate.builder(argumentMatcher + "()")
                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
-                        .staticImports("org.mockito.ArgumentMatchers." + argumentMatcher)
+                        .staticImports("org.mockito.Mockito." + argumentMatcher)
                         .build()
                         .apply(
                                 new Cursor(getCursor(), methodArgument),

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -152,19 +152,16 @@ public class JMockitExpectationsToMockito extends Recipe {
 
         private J.Block applyTemplate(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation, JavaCoordinates coordinates) {
             Expression result = null;
-            String staticImport;
+            String methodName = "doNothing";
             if (templateParams.size() > 1) {
-                maybeAddImport("org.mockito.Mockito", "when");
-                staticImport = "org.mockito.Mockito.when";
+                methodName = "when";
                 result = (Expression) templateParams.get(1);
-            } else {
-                maybeAddImport("org.mockito.Mockito", "doNothing");
-                staticImport = "org.mockito.Mockito.doNothing";
             }
+            maybeAddImport("org.mockito.Mockito", methodName);
             rewriteArgumentMatchers(ctx, templateParams);
             return JavaTemplate.builder(getMockitoStatementTemplate(result))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
-                    .staticImports(staticImport)
+                    .staticImports("org.mockito.Mockito." + methodName)
                     .build()
                     .apply(
                             new Cursor(getCursor(), cursorLocation),

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -162,7 +162,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                 staticImport = "org.mockito.Mockito.doNothing";
             }
             rewriteArgumentMatchers(ctx, templateParams);
-            return JavaTemplate.builder(getTemplate(result))
+            return JavaTemplate.builder(getMockitoStatementTemplate(result))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
                     .staticImports(staticImport)
                     .build()
@@ -203,10 +203,7 @@ public class JMockitExpectationsToMockito extends Recipe {
             return JMOCKIT_ARGUMENT_MATCHERS.contains(identifier.getSimpleName());
         }
 
-        /*
-         * Based on the result type, we need to use a different template.
-         */
-        private static String getTemplate(Expression result) {
+        private static String getMockitoStatementTemplate(Expression result) {
             if (result == null) {
                 return VOID_RESULT_TEMPLATE;
             }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -111,7 +111,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                     if (expectationStatement instanceof J.MethodInvocation) {
                         if (!templateParams.isEmpty()) {
                             // apply template to build new method body
-                            newBody = buildNewBody(ctx, templateParams, cursorLocation, coordinates);
+                            newBody = applyTemplate(ctx, templateParams, cursorLocation, coordinates);
 
                             // next statement coordinates are immediately after the statement just added
                             int newStatementIndex = bodyStatementIndex + mockitoStatementIndex;
@@ -133,14 +133,14 @@ public class JMockitExpectationsToMockito extends Recipe {
 
                 // handle the last statement
                 if (!templateParams.isEmpty()) {
-                    newBody = buildNewBody(ctx, templateParams, cursorLocation, coordinates);
+                    newBody = applyTemplate(ctx, templateParams, cursorLocation, coordinates);
                 }
             }
 
             return md.withBody(newBody);
         }
 
-        private J.Block buildNewBody(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation, JavaCoordinates coordinates) {
+        private J.Block applyTemplate(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation, JavaCoordinates coordinates) {
             Expression result = null;
             String staticImport;
             if (templateParams.size() > 1) {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -56,7 +56,6 @@ public class JMockitExpectationsToMockito extends Recipe {
         private static final String PRIMITIVE_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{});";
         private static final String OBJECT_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{any(java.lang.String)});";
         private static final String THROWABLE_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
-        private static final Pattern EXPECTATIONS_PATTERN = Pattern.compile("^mockit.Expectations$");
         private static final Set<String> JMOCKIT_ARGUMENT_MATCHERS = new HashSet<>();
         static {
             JMOCKIT_ARGUMENT_MATCHERS.add("anyString");
@@ -93,7 +92,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                     continue;
                 }
                 J.Identifier clazz = (J.Identifier) nc.getClazz();
-                if (clazz.getType() == null || !clazz.getType().isAssignableFrom(EXPECTATIONS_PATTERN)) {
+                if (!TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType())) {
                     continue;
                 }
                 // empty Expectations block is considered invalid

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -146,7 +146,8 @@ public class JMockitExpectationsToMockito extends Recipe {
             return md.withBody(newBody);
         }
 
-        private J.Block applyTemplate(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation, JavaCoordinates coordinates) {
+        private J.Block applyTemplate(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation,
+                                      JavaCoordinates coordinates) {
             Expression result = null;
             String methodName = "doNothing";
             if (templateParams.size() > 1) {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -29,11 +29,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaCoordinates;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -209,13 +205,9 @@ public class JMockitExpectationsToMockito extends Recipe {
             if (resultType instanceof JavaType.Primitive) {
                 template = PRIMITIVE_RESULT_TEMPLATE;
             } else if (resultType instanceof JavaType.Class) {
-                Class<?> resultClass;
-                try {
-                    resultClass = Class.forName(((JavaType.Class) resultType).getFullyQualifiedName());
-                } catch (ClassNotFoundException e) {
-                    throw new RuntimeException(e);
-                }
-                template = Throwable.class.isAssignableFrom(resultClass) ? THROWABLE_RESULT_TEMPLATE : OBJECT_RESULT_TEMPLATE;
+                template = TypeUtils.isAssignableTo(Throwable.class.getName(), resultType)
+                        ? THROWABLE_RESULT_TEMPLATE
+                        : OBJECT_RESULT_TEMPLATE;
             } else {
                 throw new IllegalStateException("Unexpected value: " + result.getType());
             }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -175,10 +175,10 @@ public class JMockitExpectationsToMockito extends Recipe {
                     continue;
                 }
                 String argumentMatcher = ((J.Identifier) methodArgument).getSimpleName();
-                maybeAddImport("org.mockito.Mockito", argumentMatcher);
+                maybeAddImport("org.mockito.ArgumentMatchers", argumentMatcher);
                 newArguments.add(JavaTemplate.builder(argumentMatcher + "()")
                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
-                        .staticImports("org.mockito.Mockito." + argumentMatcher)
+                        .staticImports("org.mockito.ArgumentMatchers." + argumentMatcher)
                         .build()
                         .apply(
                                 new Cursor(getCursor(), methodArgument),

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoWhen.java
@@ -62,7 +62,7 @@ public class JMockitExpectationsToMockitoWhen extends Recipe {
         private static final String PRIMITIVE_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{});";
         private static final String OBJECT_RESULT_TEMPLATE = "when(#{any()}).thenReturn(#{any(java.lang.String)});";
         private static final String EXCEPTION_RESULT_TEMPLATE = "when(#{any()}).thenThrow(#{any()});";
-        private static final Pattern EXPECTATIONS_PATTERN = Pattern.compile("mockit.Expectations");
+        private static final Pattern EXPECTATIONS_PATTERN = Pattern.compile("^mockit.Expectations$");
 
         // the LST element that is being updated when applying one of the java templates
         private Object cursorLocation;

--- a/src/main/resources/META-INF/rewrite/jmockit.yml
+++ b/src/main/resources/META-INF/rewrite/jmockit.yml
@@ -28,7 +28,7 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.integration.junit5.JMockitExtension
       newFullyQualifiedTypeName: org.mockito.junit.jupiter.MockitoExtension
-  - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockitoWhen
+  - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-core

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -461,7 +461,7 @@ class JMockitToMockitoTest implements RewriteTest {
           java(
             """
               class MyObject {
-                  public String getSomeStringField(String input, String otherInput) {
+                  public String getSomeStringField(String input, long otherInput) {
                       return "X";
                   }
                   public int getSomeIntField() {
@@ -499,13 +499,13 @@ class JMockitToMockitoTest implements RewriteTest {
                           myOtherObject.getSomeObjectField();
                           result = null;
                           myObject.doSomething();
-                          myOtherObject.getSomeStringField(anyString, anyString);
+                          myOtherObject.getSomeStringField(anyString, anyLong);
                           result = "foo";
                       }};
                       assertEquals(10, myObject.getSomeIntField());
                       assertNull(myOtherObject.getSomeObjectField());
                       myObject.doSomething();
-                      assertEquals("foo", myOtherObject.getSomeStringField("bar", "bazz"));
+                      assertEquals("foo", myOtherObject.getSomeStringField("bar", 10L));
                   }
               }
               """,
@@ -530,11 +530,11 @@ class JMockitToMockitoTest implements RewriteTest {
                       when(myObject.getSomeIntField()).thenReturn(10);
                       when(myOtherObject.getSomeObjectField()).thenReturn(null);
                       doNothing().when(myObject.doSomething());
-                      when(myOtherObject.getSomeStringField(anyString(), anyString())).thenReturn("foo");
+                      when(myOtherObject.getSomeStringField(anyString(), anyLong())).thenReturn("foo");
                       assertEquals(10, myObject.getSomeIntField());
                       assertNull(myOtherObject.getSomeObjectField());
                       myObject.doSomething();
-                      assertEquals("foo", myOtherObject.getSomeStringField("bar", "bazz"));
+                      assertEquals("foo", myOtherObject.getSomeStringField("bar", 10L));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -407,7 +407,7 @@ class JMockitToMockitoTest implements RewriteTest {
                   public Object getSomeObjectField() {
                       return new Object();
                   }
-                    public void doSomething() {}
+                  public void doSomething() {}
               }
               """
           ),

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -258,7 +258,7 @@ class JMockitToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
                             
               import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.ArgumentMatchers.anyString;
+              import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
@@ -516,10 +516,7 @@ class JMockitToMockitoTest implements RewriteTest {
 
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.ArgumentMatchers.anyLong;
-              import static org.mockito.ArgumentMatchers.anyString;
-              import static org.mockito.Mockito.doNothing;
-              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -258,7 +258,7 @@ class JMockitToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
                             
               import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.anyString;
+              import static org.mockito.ArgumentMatchers.anyString;
               import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
@@ -516,7 +516,10 @@ class JMockitToMockitoTest implements RewriteTest {
 
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.*;
+              import static org.mockito.ArgumentMatchers.anyLong;
+              import static org.mockito.ArgumentMatchers.anyString;
+              import static org.mockito.Mockito.doNothing;
+              import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
- Added handling for [Argument Matchers](https://jmockit.github.io/tutorial/Mocking.html#argumentMatching).
- Added handling for Void methods in Expectations blocks.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Continuation of #418.

This recipe is still incomplete, pending handling of `times`, `minTimes`, and `maxTimes` fields of `Expectations` blocks in a subsequent PR.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
