### PR TITLE
JMockit to Mockito Recipe - Handle Typed Class Argument Matching and Collections

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -123,7 +123,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                     if (expectationStatement instanceof J.MethodInvocation) {
                         if (!templateParams.isEmpty()) {
                             // apply template to build new method body
-                            newBody = applyTemplate(ctx, templateParams, cursorLocation, coordinates);
+                            newBody = rewriteMethodBody(ctx, templateParams, cursorLocation, coordinates);
 
                             // next statement coordinates are immediately after the statement just added
                             int newStatementIndex = bodyStatementIndex + mockitoStatementIndex;
@@ -145,15 +145,15 @@ public class JMockitExpectationsToMockito extends Recipe {
 
                 // handle the last statement
                 if (!templateParams.isEmpty()) {
-                    newBody = applyTemplate(ctx, templateParams, cursorLocation, coordinates);
+                    newBody = rewriteMethodBody(ctx, templateParams, cursorLocation, coordinates);
                 }
             }
 
             return md.withBody(newBody);
         }
 
-        private J.Block applyTemplate(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation,
-                                      JavaCoordinates coordinates) {
+        private J.Block rewriteMethodBody(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation,
+                                          JavaCoordinates coordinates) {
             Expression result = null;
             String methodName = "doNothing";
             if (templateParams.size() > 1) {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -229,8 +229,9 @@ public class JMockitExpectationsToMockito extends Recipe {
             templateParams.set(0, invocation.withArguments(newArguments));
         }
 
-        private Expression rewriteMethodArgument(ExecutionContext ctx, String argumentMatcher, String template, Object cursorLocation,
-                                                 JavaCoordinates coordinates, List<Object> templateParams) {
+        private Expression rewriteMethodArgument(ExecutionContext ctx, String argumentMatcher, String template,
+                                                 Object cursorLocation, JavaCoordinates coordinates,
+                                                 List<Object> templateParams) {
             maybeAddImport("org.mockito.Mockito", argumentMatcher);
             return JavaTemplate.builder(template)
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -173,8 +173,8 @@ public class JMockitExpectationsToMockito extends Recipe {
                     );
         }
 
-        private void rewriteArgumentMatchers(ExecutionContext ctx, List<Object> templateParams) {
-            J.MethodInvocation invocation = (J.MethodInvocation) templateParams.get(0);
+        private void rewriteArgumentMatchers(ExecutionContext ctx, List<Object> bodyTemplateParams) {
+            J.MethodInvocation invocation = (J.MethodInvocation) bodyTemplateParams.get(0);
             List<Expression> newArguments = new ArrayList<>(invocation.getArguments().size());
             for (Expression methodArgument : invocation.getArguments()) {
                 if (!isArgumentMatcher(methodArgument)) {
@@ -226,7 +226,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                 newArguments.add(rewriteMethodArgument(ctx, argumentMatcher, template, methodArgument,
                         methodArgument.getCoordinates().replace(), argumentTemplateParams));
             }
-            templateParams.set(0, invocation.withArguments(newArguments));
+            bodyTemplateParams.set(0, invocation.withArguments(newArguments));
         }
 
         private Expression rewriteMethodArgument(ExecutionContext ctx, String argumentMatcher, String template,

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -167,7 +167,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                 methodName = "when";
                 result = (Expression) templateParams.get(1);
             } else {
-                throw new IllegalStateException("Unexpected number of template params");
+                throw new IllegalStateException("Unexpected number of template params: " + templateParams.size());
             }
             maybeAddImport("org.mockito.Mockito", methodName);
             rewriteArgumentMatchers(ctx, templateParams);
@@ -211,8 +211,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                     className = ((JavaType.FullyQualified) typeCastType).getClassName();
                     fqn = ((JavaType.FullyQualified) typeCastType).getFullyQualifiedName();
                 } else {
-                    newArguments.add(methodArgument);
-                    continue;
+                    throw new IllegalStateException("Unexpected J.TypeCast type: " + typeCastType);
                 }
                 if (MOCKITO_COLLECTION_MATCHERS.containsKey(fqn)) {
                     // mockito has specific argument matchers for collections
@@ -275,7 +274,7 @@ public class JMockitExpectationsToMockito extends Recipe {
                         ? THROWABLE_RESULT_TEMPLATE
                         : OBJECT_RESULT_TEMPLATE;
             } else {
-                throw new IllegalStateException("Unexpected value: " + result.getType());
+                throw new IllegalStateException("Unexpected expression type for template: " + result.getType());
             }
             return template;
         }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -186,9 +186,8 @@ public class JMockitExpectationsToMockito extends Recipe {
                 if (!(methodArgument instanceof J.TypeCast)) {
                     argumentMatcher = ((J.Identifier) methodArgument).getSimpleName();
                     template = argumentMatcher + "()";
-                    newArguments.add(rewriteMethodArgument(ctx, ((J.Identifier) methodArgument).getSimpleName(),
-                            template, methodArgument, methodArgument.getCoordinates().replace(),
-                            argumentTemplateParams));
+                    newArguments.add(rewriteMethodArgument(ctx, argumentMatcher, template, methodArgument,
+                            methodArgument.getCoordinates().replace(), argumentTemplateParams));
                     continue;
                 }
                 J.TypeCast tc = (J.TypeCast) methodArgument;

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -160,10 +160,14 @@ public class JMockitExpectationsToMockito extends Recipe {
         private J.Block rewriteMethodBody(ExecutionContext ctx, List<Object> templateParams, Object cursorLocation,
                                           JavaCoordinates coordinates) {
             Expression result = null;
-            String methodName = "doNothing";
-            if (templateParams.size() > 1) {
+            String methodName;
+            if (templateParams.size() == 1) {
+                methodName = "doNothing";
+            } else if (templateParams.size() == 2) {
                 methodName = "when";
                 result = (Expression) templateParams.get(1);
+            } else {
+                throw new IllegalStateException("Unexpected number of template params");
             }
             maybeAddImport("org.mockito.Mockito", methodName);
             rewriteArgumentMatchers(ctx, templateParams);

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitToMockitoTest.java
@@ -504,7 +504,7 @@ class JMockitToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
               
               import static org.junit.jupiter.api.Assertions.assertNotNull;
-              import static org.mockito.Mockito.any;
+              import static org.mockito.Mockito.anyList;
               import static org.mockito.Mockito.when;
               
               @ExtendWith(MockitoExtension.class)
@@ -513,7 +513,7 @@ class JMockitToMockitoTest implements RewriteTest {
                   MyObject myObject;
                   
                   void test() {
-                      when(myObject.getSomeField(any(List.class))).thenReturn(null);
+                      when(myObject.getSomeField(anyList())).thenReturn(null);
                       assertNotNull(myObject.getSomeField(new ArrayList<>()));
                   }
               }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Continuation of #419.

Handle JMockit typed argument matchers like `mockInstance.anyMethod((List<String>) any)`.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
