### PR TITLE
Replace Hamcrest CoreMatchers as well using wildcards

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestIsMatcherToAssertJ.java
@@ -39,7 +39,7 @@ public class HamcrestIsMatcherToAssertJ extends Recipe {
         return "Migrate Hamcrest `is(Object)` to AssertJ `Assertions.assertThat(..)`.";
     }
 
-    static final MethodMatcher IS_OBJECT_MATCHER = new MethodMatcher("org.hamcrest.Matchers is(..)");
+    static final MethodMatcher IS_OBJECT_MATCHER = new MethodMatcher("org.hamcrest.*Matchers is(..)");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
@@ -63,13 +63,13 @@ public class HamcrestMatcherToAssertJ extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>("org.hamcrest.Matchers " + matcher + "(..)"), new MigrateToAssertJVisitor());
+        return Preconditions.check(new UsesMethod<>("org.hamcrest.*Matchers " + matcher + "(..)"), new MigrateToAssertJVisitor());
     }
 
     private class MigrateToAssertJVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final MethodMatcher assertThatMatcher = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
-        private final MethodMatcher matchersMatcher = new MethodMatcher("org.hamcrest.Matchers " + matcher + "(..)");
-        private final MethodMatcher subMatcher = new MethodMatcher("org.hamcrest.Matchers *(org.hamcrest.Matcher)");
+        private final MethodMatcher matchersMatcher = new MethodMatcher("org.hamcrest.*Matchers " + matcher + "(..)");
+        private final MethodMatcher subMatcher = new MethodMatcher("org.hamcrest.*Matchers *(org.hamcrest.Matcher)");
 
 
         @Override
@@ -104,6 +104,7 @@ public class HamcrestMatcherToAssertJ extends Recipe {
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeAddImport("org.assertj.core.api.Assertions", "within");
             maybeRemoveImport("org.hamcrest.Matchers." + matcher);
+            maybeRemoveImport("org.hamcrest.CoreMatchers." + matcher);
             maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
@@ -62,14 +62,14 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>("org.hamcrest.Matchers " + notMatcher + "(..)"), new MigrateToAssertJVisitor());
+        return Preconditions.check(new UsesMethod<>("org.hamcrest.*Matchers " + notMatcher + "(..)"), new MigrateToAssertJVisitor());
     }
 
     private class MigrateToAssertJVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
-        private final MethodMatcher NOT_MATCHER = new MethodMatcher("org.hamcrest.Matchers not(org.hamcrest.Matcher)");
-        private final MethodMatcher MATCHERS_MATCHER = new MethodMatcher("org.hamcrest.Matchers " + notMatcher + "(..)");
-        private final MethodMatcher SUB_MATCHER = new MethodMatcher("org.hamcrest.Matchers *(org.hamcrest.Matcher)");
+        private final MethodMatcher NOT_MATCHER = new MethodMatcher("org.hamcrest.*Matchers not(org.hamcrest.Matcher)");
+        private final MethodMatcher MATCHERS_MATCHER = new MethodMatcher("org.hamcrest.*Matchers " + notMatcher + "(..)");
+        private final MethodMatcher SUB_MATCHER = new MethodMatcher("org.hamcrest.*Matchers *(org.hamcrest.Matcher)");
 
         @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
@@ -110,6 +110,8 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers.not");
             maybeRemoveImport("org.hamcrest.Matchers." + notMatcher);
+            maybeRemoveImport("org.hamcrest.CoreMatchers.not");
+            maybeRemoveImport("org.hamcrest.CoreMatchers." + notMatcher);
             maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestOfMatchersToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestOfMatchersToAssertJ.java
@@ -45,8 +45,8 @@ public class HamcrestOfMatchersToAssertJ extends Recipe {
     }
 
     private static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
-    private static final MethodMatcher ANY_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers anyOf(..)");
-    private static final MethodMatcher ALL_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers allOf(..)");
+    private static final MethodMatcher ANY_OF_MATCHER = new MethodMatcher("org.hamcrest.*Matchers anyOf(..)");
+    private static final MethodMatcher ALL_OF_MATCHER = new MethodMatcher("org.hamcrest.*Matchers allOf(..)");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -96,6 +96,8 @@ public class HamcrestOfMatchersToAssertJ extends Recipe {
 
             maybeRemoveImport("org.hamcrest.Matchers.anyOf");
             maybeRemoveImport("org.hamcrest.Matchers.allOf");
+            maybeRemoveImport("org.hamcrest.CoreMatchers.anyOf");
+            maybeRemoveImport("org.hamcrest.CoreMatchers.allOf");
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             return JavaTemplate.builder(template.toString())
                     .contextSensitive()

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveIsMatcher.java
@@ -36,7 +36,7 @@ public class RemoveIsMatcher extends Recipe {
         return "Remove Hamcrest `is(Matcher)` ahead of migration.";
     }
 
-    static final MethodMatcher IS_MATCHER = new MethodMatcher("org.hamcrest.Matchers is(org.hamcrest.Matcher)");
+    static final MethodMatcher IS_MATCHER = new MethodMatcher("org.hamcrest.*Matchers is(org.hamcrest.Matcher)");
     static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(..)");
 
     @Override
@@ -48,6 +48,7 @@ public class RemoveIsMatcher extends Recipe {
                     getCursor().putMessage("ASSERT_THAT", mi);
                 } else if (IS_MATCHER.matches(mi) && getCursor().pollNearestMessage("ASSERT_THAT") != null) {
                     maybeRemoveImport("org.hamcrest.Matchers.is");
+                    maybeRemoveImport("org.hamcrest.CoreMatchers.is");
                     return mi.getArguments().get(0).withPrefix(mi.getPrefix());
                 }
                 return super.visitMethodInvocation(mi, ctx);

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJTest.java
@@ -164,6 +164,43 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
                   """)
             );
         }
+
+        @Test
+        void coreMatchers() {
+            rewriteRun(
+              spec -> spec.recipe(new HamcrestMatcherToAssertJ("startsWith", "startsWith")),
+              //language=java
+              java(
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.hamcrest.MatcherAssert.assertThat;
+                  import static org.hamcrest.CoreMatchers.startsWith;
+                              
+                  class ATest {
+                      @Test
+                      void test() {
+                          String str1 = "Hello world!";
+                          assertThat(str1, startsWith("Hello"));
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class ATest {
+                      @Test
+                      void test() {
+                          String str1 = "Hello world!";
+                          assertThat(str1).startsWith("Hello");
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     @Nested
@@ -352,7 +389,7 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
                                 
                   import java.util.ArrayList;
                   import java.util.List;
-                  
+                                    
                   import static org.assertj.core.api.Assertions.assertThat;
                               
                   class ATest {
@@ -374,10 +411,10 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
               //language=java
               java("""
                   import org.junit.jupiter.api.Test;
-                  
+                                    
                   import static org.hamcrest.MatcherAssert.assertThat;
                   import static org.hamcrest.Matchers.closeTo;
-                  
+                                    
                   class ATest {
                       @Test
                       void replaceCloseTo() {
@@ -387,10 +424,10 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
                   """,
                 """
                   import org.junit.jupiter.api.Test;
-                  
+                                    
                   import static org.assertj.core.api.Assertions.assertThat;
                   import static org.assertj.core.api.Assertions.within;
-                  
+                                    
                   class ATest {
                       @Test
                       void replaceCloseTo() {
@@ -409,10 +446,10 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
               java("""
                   import org.junit.jupiter.api.Test;
                   import java.math.BigDecimal;
-                  
+                                    
                   import static org.hamcrest.MatcherAssert.assertThat;
                   import static org.hamcrest.Matchers.closeTo;
-                  
+                                    
                   class ATest {
                       @Test
                       void replaceCloseTo() {
@@ -426,10 +463,10 @@ class HamcrestMatcherToAssertJTest implements RewriteTest {
                 """
                   import org.junit.jupiter.api.Test;
                   import java.math.BigDecimal;
-                  
+                                    
                   import static org.assertj.core.api.Assertions.assertThat;
                   import static org.assertj.core.api.Assertions.within;
-                  
+                                    
                   class ATest {
                       @Test
                       void replaceCloseTo() {


### PR DESCRIPTION
## What's your motivation?
https://github.com/openrewrite/rewrite-testing-frameworks/issues/357#issuecomment-1809958904

## Alternatives
We could also first change the imports from CoreMatchers to Matchers, but that might have side effects not overseen here.