### PR TITLE
Don't remove `mockStatic()` calls in resources of try-with-resources

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -189,7 +189,7 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
 
             if (MOCKED_STATIC_MATCHER.matches(mi)) {
                 determineTestGroups();
-                if (getCursor().firstEnclosing(J.Assignment.class) == null) {
+                if (!getCursor().getPath(o -> o instanceof J.Assignment || o instanceof J.Try.Resource).hasNext()) {
                     //noinspection DataFlowIssue
                     return null;
                 }

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -111,7 +111,7 @@ recipeList:
   - org.openrewrite.java.testing.mockito.CleanupMockitoImports
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
-  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
+#  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-junit-jupiter

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -111,6 +111,7 @@ recipeList:
   - org.openrewrite.java.testing.mockito.CleanupMockitoImports
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
+# https://github.com/openrewrite/rewrite-testing-frameworks/issues/360
 #  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -256,9 +256,10 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void tearDownMethodOfTestNGWithAnnotationRemainsUntouched() {
-       //language=java
+        //language=java
         rewriteRun(
           java(
             """
@@ -303,6 +304,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void tearDownMethodOfTestNGHasAnnotationWithSameArgumentsAsTheTestThatCallsMockStatic() {
         //language=java
@@ -539,7 +541,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
               public class PowerMockTestCase {}
               """
           ),
-         java(
+          java(
             """
               import org.powermock.modules.testng.PowerMockTestCase;
 
@@ -548,7 +550,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
             """
               public class MyPowerMockTestCase {}
               """)
-         );
+        );
     }
 
     @Test
@@ -562,7 +564,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
               public class PowerMockConfiguration {}
               """
           ),
-         java(
+          java(
             """
               import org.powermock.configuration.PowerMockConfiguration;
                 
@@ -575,11 +577,37 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
     }
 
     @Test
+    void mockStaticInTryWithResources() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.mockito.MockedStatic;
+              
+              import java.nio.file.Files;
+              
+              import static org.mockito.Mockito.mockStatic;
+              
+              class A {
+                @Test
+                void testTryWithResource() {
+                  try (MockedStatic<Files> mocked = mockStatic(Files.class)) {
+                    // test logic that uses mocked
+                  }
+                }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/358")
     void doesNotExplodeOnTopLevelMethodDeclaration() {
         rewriteRun(
           groovy(
-          "def myFun() { }"
-        ));
+            "def myFun() { }"
+          ));
     }
 }


### PR DESCRIPTION
This commit does not yet close the issue, as there are other cases, where this can potentially go wrong.

It also appears strange that the recipe matches on Mockito's `mockStatic()` rather than on PowerMock's `mockStatic()`. Therefore, the recipe is for now excluded from `Mockito1to3Migration`, as this is part of `JUnit4to5Migration` which is widely used.

Issue: #360
