### PR TITLE
Fixes broken testcontainer dependencies after JUnit4to5Migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -95,6 +95,12 @@ recipeList:
   - org.openrewrite.maven.ExcludeDependency:
       groupId: junit
       artifactId: junit
+  # Workaround for https://github.com/testcontainers/testcontainers-java/issues/970:
+  - org.openrewrite.maven.RemoveExclusion:
+      groupId: org.testcontainers
+      artifactId: testcontainers
+      exclusionGroupId: junit
+      exclusionArtifactId: junit
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.junit.vintage
       artifactId: junit-vintage-engine

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -181,6 +181,22 @@ class JUnit5MigrationTest implements RewriteTest {
                     </dependency>
                 </dependencies>
             </project>
+            """,
+            """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example.jackson</groupId>
+                <artifactId>test-plugins</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>testcontainers</artifactId>
+                        <version>1.18.3</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
             """
           )
         );

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -27,7 +27,6 @@ import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class JUnit5MigrationTest implements RewriteTest {
-
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -43,25 +42,26 @@ class JUnit5MigrationTest implements RewriteTest {
     @Test
     void classReference() {
         rewriteRun(
+          //language=java
           java(
             """
-            import org.junit.Test;
-            
-            public class Sample {
-                void method() {
-                    Class<Test> c = Test.class;
-                }
-            }
-            """,
+              import org.junit.Test;
+                          
+              public class Sample {
+                  void method() {
+                      Class<Test> c = Test.class;
+                  }
+              }
+              """,
             """
-            import org.junit.jupiter.api.Test;
-            
-            public class Sample {
-                void method() {
-                    Class<Test> c = Test.class;
-                }
-            }
-            """
+              import org.junit.jupiter.api.Test;
+                          
+              public class Sample {
+                  void method() {
+                      Class<Test> c = Test.class;
+                  }
+              }
+              """
           )
         );
     }
@@ -112,51 +112,52 @@ class JUnit5MigrationTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/279")
     void upgradeMavenPluginVersions() {
         rewriteRun(
+          //language=xml
           pomXml(
             """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example.jackson</groupId>
-                <artifactId>test-plugins</artifactId>
-                <version>1.0.0</version>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.20.1</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <version>2.20.1</version>
-                        </plugin>
-                    </plugins>
-                </build>
-            </project>
-            """,
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.jackson</groupId>
+                  <artifactId>test-plugins</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>2.20.1</version>
+                          </plugin>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-failsafe-plugin</artifactId>
+                              <version>2.20.1</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """,
             """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example.jackson</groupId>
-                <artifactId>test-plugins</artifactId>
-                <version>1.0.0</version>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>2.22.2</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-failsafe-plugin</artifactId>
-                            <version>2.22.2</version>
-                        </plugin>
-                    </plugins>
-                </build>
-            </project>
-            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.jackson</groupId>
+                  <artifactId>test-plugins</artifactId>
+                  <version>1.0.0</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>2.22.2</version>
+                          </plugin>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-failsafe-plugin</artifactId>
+                              <version>2.22.2</version>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
           )
         );
     }
@@ -164,42 +165,25 @@ class JUnit5MigrationTest implements RewriteTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
     void dontExcludeJunit4DependencyfromTestcontainers() {
-        rewriteRun(
-          pomXml(
-            """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example.jackson</groupId>
-                <artifactId>test-plugins</artifactId>
-                <version>1.0.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.testcontainers</groupId>
-                        <artifactId>testcontainers</artifactId>
-                        <version>1.18.3</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </project>
-            """,
-            """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>com.example.jackson</groupId>
-                <artifactId>test-plugins</artifactId>
-                <version>1.0.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.testcontainers</groupId>
-                        <artifactId>testcontainers</artifactId>
-                        <version>1.18.3</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-            </project>
-            """
-          )
-        );
+        //language=xml
+        String before = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example.jackson</groupId>
+              <artifactId>test-plugins</artifactId>
+              <version>1.0.0</version>
+              <dependencies>
+                  <dependency>
+                      <groupId>org.testcontainers</groupId>
+                      <artifactId>testcontainers</artifactId>
+                      <version>1.18.3</version>
+                      <scope>test</scope>
+                  </dependency>
+              </dependencies>
+          </project>
+          """;
+        // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
+        rewriteRun(pomXml(before, before));
     }
 
     // edge case for deprecated use of assertEquals
@@ -207,12 +191,12 @@ class JUnit5MigrationTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/384")
     @Test
     void assertEqualsWithArrayArgumentToAssertArrayEquals() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.Assert;
-              
+                            
               class MyTest {
                   void test() {
                        Assert.assertEquals(new Object[1], new Object[1]);
@@ -221,7 +205,7 @@ class JUnit5MigrationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Assertions;
-              
+                            
               class MyTest {
                   void test() {
                        Assertions.assertArrayEquals(new Object[1], new Object[1]);

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -161,6 +161,31 @@ class JUnit5MigrationTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
+    void dontExcludeJunit4DependencyfromTestcontainers() {
+        rewriteRun(
+          pomXml(
+            """
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example.jackson</groupId>
+                <artifactId>test-plugins</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>testcontainers</artifactId>
+                        <version>1.18.3</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+            </project>
+            """
+          )
+        );
+    }
+
     // edge case for deprecated use of assertEquals
     // https://junit.org/junit4/javadoc/4.13/org/junit/Assert.html#assertEquals(java.lang.Object%5B%5D,%20java.lang.Object%5B%5D)
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/384")


### PR DESCRIPTION
- Added a testcase for build errors due to missing Junit4 dependencies
- Added workaround to JUnit4to5Migration: Undo the exclusion

Fixes #429 