### PR TITLE
feature: ArchUnit 0.x to 1.x migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/archunit.yml
+++ b/src/main/resources/META-INF/rewrite/archunit.yml
@@ -1,0 +1,49 @@
+#
+# Copyright 2023 the original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.archunit.ArchUnit0to1Migration
+displayName: ArchUnit 0.x upgrade
+description: Upgrade ArchUnit from 0.x to 1.x.
+recipeList:
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: com.tngtech.archunit
+      artifactId: archunit-junit5
+      newVersion: 1.x
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getAllClasses()
+      newMethodName: getClassesInPackageTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getAllSubpackages()
+      newMethodName: getSubpackagesInTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getClassDependenciesFromSelf()
+      newMethodName: getClassDependenciesFromThisPackageTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getClassDependenciesToSelf()
+      newMethodName: getClassDependenciesToThisPackageTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getPackageDependenciesFromSelf()
+      newMethodName: getPackageDependenciesFromThisPackageTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage getPackageDependenciesToSelf()
+      newMethodName: getPackageDependenciesToThisPackageTree
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.tngtech.archunit.core.domain.JavaPackage accept(..)
+      newMethodName: traversePackageTree
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: com.tngtech.archunit.library.plantuml
+      newPackageName: com.tngtech.archunit.library.plantuml.rules


### PR DESCRIPTION
Resolves #431

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
A new recipe to migrate most of the changes from ArchUnit 0.x to 1.x

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
To help migrate it, since ArchUnit <1.1 does not support Java 21

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
