### PR TITLE
Also swap assertNull and assertNotNull argument order

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
@@ -43,8 +43,7 @@ public class AssertionsArgumentOrder extends Recipe {
     private static final MethodMatcher jupiterAssertIterableEqualsMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertIterableEquals(..)");
 
     // `assertNull("message", result())` should be `assertNull(result(), "message")`
-    private static final MethodMatcher jupiterAssertNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertNull(Object, ..)");
-    private static final MethodMatcher jupiterAssertNotNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertNotNull(Object, ..)");
+    private static final MethodMatcher jupiterAssertNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assert*Null(Object, ..)");
 
     private static final MethodMatcher[] testNgMatcher = new MethodMatcher[]{
             new MethodMatcher("org.testng.Assert assertSame(..)"),
@@ -59,7 +58,6 @@ public class AssertionsArgumentOrder extends Recipe {
         List<MethodMatcher> matchers = new ArrayList<>(Arrays.asList(jupiterAssertionMatchers));
         matchers.add(jupiterAssertIterableEqualsMatcher);
         matchers.add(jupiterAssertNullMatcher);
-        matchers.add(jupiterAssertNotNullMatcher);
         matchers.addAll(Arrays.asList(testNgMatcher));
         //noinspection unchecked
         precondition = Preconditions.or(matchers.stream().map(UsesMethod::new).toArray(TreeVisitor[]::new));
@@ -123,7 +121,7 @@ public class AssertionsArgumentOrder extends Recipe {
         }
 
         private boolean isCorrectOrder(Expression expected, Expression actual, J.MethodInvocation mi) {
-            if (jupiterAssertNullMatcher.matches(mi) || jupiterAssertNotNullMatcher.matches(mi)) {
+            if (jupiterAssertNullMatcher.matches(mi)) {
                 return isConstant(actual, mi) || !isConstant(expected, mi);
             }
             return isConstant(expected, mi) || !isConstant(actual, mi);
@@ -165,9 +163,7 @@ public class AssertionsArgumentOrder extends Recipe {
                     return true;
                 }
             }
-            return jupiterAssertIterableEqualsMatcher.matches(mi) ||
-                   jupiterAssertNullMatcher.matches(mi) ||
-                   jupiterAssertNotNullMatcher.matches(mi);
+            return jupiterAssertIterableEqualsMatcher.matches(mi) || jupiterAssertNullMatcher.matches(mi);
         }
 
         private boolean isTestNgAssertion(J.MethodInvocation mi) {

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
@@ -43,7 +43,7 @@ public class AssertionsArgumentOrder extends Recipe {
     private static final MethodMatcher jupiterAssertIterableEqualsMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertIterableEquals(..)");
 
     // `assertNull("message", result())` should be `assertNull(result(), "message")`
-    private static final MethodMatcher jupiterAssertNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assert*Null(Object, ..)");
+    private static final MethodMatcher jupiterAssertNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assert*Null(Object, String)");
 
     private static final MethodMatcher[] testNgMatcher = new MethodMatcher[]{
             new MethodMatcher("org.testng.Assert assertSame(..)"),

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
@@ -25,7 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class AssertionsArgumentOrderTest implements RewriteTest {
+class AssertionsArgumentOrderTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipe(new AssertionsArgumentOrder())
@@ -61,6 +61,47 @@ public class AssertionsArgumentOrderTest implements RewriteTest {
                       assertEquals("result", result());
                       assertEquals("result", result(), "message");
                       assertEquals(0L, 1L);
+                  }
+                  String result() {
+                      return "result";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void junitAssertNullAndAssertNotNull() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+                          
+              class MyTest {
+                  void someMethod() {
+                      assertNull(result(), "message");
+                      assertNull("message", result());
+                      assertNotNull(result(), "message");
+                      assertNotNull("message", result());
+                  }
+                  String result() {
+                      return "result";
+                  }
+              }
+              """,
+            """
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+                          
+              class MyTest {
+                  void someMethod() {
+                      assertNull(result(), "message");
+                      assertNull(result(), "message");
+                      assertNotNull(result(), "message");
+                      assertNotNull(result(), "message");
                   }
                   String result() {
                       return "result";


### PR DESCRIPTION
## What's changed?
Also swap the order of arguments to `assertNull` and `assertNotNull`.

## What's your motivation?
Mistake easily made if migrating manually, especially at scale.