### PR TITLE
Do not change visibility in `UpdateTestAnnotation`; use `TestsShouldNotBePublic` instead

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -116,10 +116,6 @@ public class UpdateTestAnnotation extends Recipe {
             ChangeTestAnnotation cta = new ChangeTestAnnotation();
             J.MethodDeclaration m = (J.MethodDeclaration) cta.visitNonNull(method, ctx, getCursor().getParentOrThrow());
             if (m != method) {
-                if (Boolean.FALSE.equals(TypeUtils.isOverride(m.getMethodType()))) {
-                    m = (J.MethodDeclaration) new ChangeMethodAccessLevelVisitor<ExecutionContext>(new MethodMatcher(m), null)
-                            .visitNonNull(m, ctx, getCursor().getParentOrThrow());
-                }
                 if (cta.expectedException != null) {
                     m = JavaTemplate.builder("org.junit.jupiter.api.function.Executable o = () -> #{};")
                             .contextSensitive()

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -98,7 +98,7 @@ class JUnit5MigrationTest implements RewriteTest {
               public class SampleTest {
                   @SuppressWarnings("ALL")
                   @Test
-                  void filterShouldRemoveUnusedConfig() {
+                  public void filterShouldRemoveUnusedConfig() {
                       assertThat(asList("1", "2", "3"),
                               containsInAnyOrder("3", "2", "1"));
                   }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -60,7 +60,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test_printLine() {
+                  public void test_printLine() {
                       assertDoesNotThrow(() -> {
                           int arr = new int[]{0}[0];
                       });
@@ -95,7 +95,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test() {
+                  public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
                           throw new IllegalArgumentException("boom");
                       });
@@ -131,7 +131,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test() {
+                  public void test() {
                       assertThrows(IndexOutOfBoundsException.class, () -> {
                           int arr = new int[]{}[0];
                       });
@@ -167,7 +167,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test() {
+                  public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
                           String foo = "foo";
                           throw new IllegalArgumentException("boom");
@@ -200,7 +200,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test() {
+                  public void test() {
                   }
               }
               """
@@ -253,17 +253,17 @@ class UpdateTestAnnotationTest implements RewriteTest {
                   // some comments
                   @Issue("some issue")
                   @Test
-                  void test() {
+                  public void test() {
                   }
               
                   // some comments
                   @Test
-                  void test1() {
+                  public void test1() {
                   }
               
-                  // some comments
                   @Test
-                  void test2() {
+                  // some comments
+                  public void test2() {
                   }
               }
               """
@@ -294,7 +294,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               
                   @Test
                   @Timeout(500)
-                  void test() {
+                  public void test() {
                   }
               }
               """
@@ -338,7 +338,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
               
                   @Test
-                  void test() {
+                  public void test() {
                       assertThrows(MyException.class, () -> {
                           throw new MyException("my exception");
                       });
@@ -375,70 +375,10 @@ class UpdateTestAnnotationTest implements RewriteTest {
               
                   @Test
                   @Timeout(500)
-                  void test() {
+                  public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
                           throw new IllegalArgumentException("boom");
                       });
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Issue("https://github.com/openrewrite/rewrite/issues/150")
-    @Test
-    void protectedToPackageVisibility() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Test;
-
-              public class MyTest {
-              
-                  @Test
-                  protected void test() {
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.Test;
-
-              public class MyTest {
-
-                  @Test
-                  void test() {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @SuppressWarnings("JUnitMalformedDeclaration")
-    @Test
-    void privateToPackageVisibility() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Test;
-              
-              public class MyTest {
-              
-                  @Test
-                  private void test() {
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.Test;
-              
-              public class MyTest {
-              
-                  @Test
-                  void test() {
                   }
               }
               """
@@ -532,7 +472,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               /** @see org.junit.jupiter.api.Test */
               public class MyTest {
                   @Test
-                  void test() {
+                  public void test() {
                   }
               }
               """
@@ -557,7 +497,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               
               public class MyTest {
                   @org.junit.jupiter.api.Test
-                  void feature1() {
+                  public void feature1() {
                   }
               }
               """
@@ -587,7 +527,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                             
               public class MyTest {
                   @org.junit.jupiter.api.Test
-                  void feature1() {
+                  public void feature1() {
                   }
                   
                   @Test

--- a/src/test/java/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.java
@@ -108,7 +108,7 @@ class JunitMockitoUpgradeIntegrationTest implements RewriteTest {
                   }
               
                   @Test
-                  void usingAnnotationBasedMock() {
+                  public void usingAnnotationBasedMock() {
               
                       mockedList.add("one");
                       mockedList.clear();


### PR DESCRIPTION
## What's changed?
Fixes #441

UpdateTestAnnotation does not change the visibility modifier anymore.
I updated the test as needed.
I removed the following 2 tests in UpdateTestAnnotationTest as they make no sense after the change:
	privateToPackageVisibility()
	protectedToPackageVisibility()

