### PR TITLE
AddMissingTestBeforeAfterAnnotations is looking for annotations in all ancestor classes

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddMissingTestBeforeAfterAnnotations.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddMissingTestBeforeAfterAnnotations.java
@@ -66,11 +66,14 @@ public class AddMissingTestBeforeAfterAnnotations extends Recipe {
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             if (!method.hasModifier(J.Modifier.Type.Static) && !method.isConstructor()) {
-                Optional<Method> superMethod = TypeUtils.findOverriddenMethod(method.getMethodType());
-                if (superMethod.isPresent()) {
+                Method currMethod = method.getMethodType();
+                Optional<Method> superMethod = TypeUtils.findOverriddenMethod(currMethod);
+                while (superMethod.isPresent()) {
                     method = maybeAddMissingAnnotation(method, superMethod.get(), LifecyleAnnotation.BEFORE_EACH, ctx);
                     method = maybeAddMissingAnnotation(method, superMethod.get(), LifecyleAnnotation.AFTER_EACH, ctx);
                     method = maybeAddMissingAnnotation(method, superMethod.get(), LifecyleAnnotation.TEST, ctx);
+                    currMethod = superMethod.get();
+                    superMethod = TypeUtils.findOverriddenMethod(currMethod);
                 }
             }
             return super.visitMethodDeclaration(method, ctx);

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddMissingTestBeforeAfterAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddMissingTestBeforeAfterAnnotationsTest.java
@@ -92,7 +92,7 @@ class AddMissingTestBeforeAfterAnnotationsTest implements RewriteTest {
           )
         );
     }
-    
+
     @Test
     void addMissingTestBeforeAfterAnnotationsIfNewFound() {
         //language=java
@@ -152,6 +152,100 @@ class AddMissingTestBeforeAfterAnnotationsTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void addMissingTestBeforeAfterAnnotationsIfExtended() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.AfterEach;
+              import org.junit.jupiter.api.BeforeEach;
+              import org.junit.jupiter.api.Test;
+              
+              public class AbstractTest {
+                  @BeforeEach
+                  public void before() {
+                  }
+
+                  @AfterEach
+                  public void after() {
+                  }
+
+                  @Test
+                  public void test() {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              public class A extends AbstractTest {
+                  public void before() {
+                  }
+
+                  public void after() {
+                  }
+
+                  public void test() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.AfterEach;
+              import org.junit.jupiter.api.BeforeEach;
+              import org.junit.jupiter.api.Test;
+              
+              public class A extends AbstractTest {
+                  @BeforeEach
+                  public void before() {
+                  }
+
+                  @AfterEach
+                  public void after() {
+                  }
+
+                  @Test
+                  public void test() {
+                  }
+              }
+              """
+          ),
+          java(
+                """
+                  public class B extends A {
+                      public void before() {
+                      }
+
+                      public void after() {
+                      }
+
+                      public void test() {
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.jupiter.api.AfterEach;
+                  import org.junit.jupiter.api.BeforeEach;
+                  import org.junit.jupiter.api.Test;
+                  
+                  public class B extends A {
+                      @BeforeEach
+                      public void before() {
+                      }
+
+                      @AfterEach
+                      public void after() {
+                      }
+
+                      @Test
+                      public void test() {
+                      }
+                  }
+                  """
+              )
+            );
     }
 
 }


### PR DESCRIPTION
This PR contains another enhancement to the AddMissingTestBeforeAfterAnnotations recipe.

see #443, #444, #445

The current implementation did not handle the case correctly where the test annotations where not on the superclass itself,
but on an ancestor class up in the hierarchy. With this fix, not only the superclass but all classes up in the hierarchy are checked.
See new test addMissingTestBeforeAfterAnnotationsIfExtended