### PR TITLE
Add unit to `@Timeout`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -151,9 +151,9 @@ public class UpdateTestAnnotation extends Recipe {
                     }
                 }
                 if (cta.timeout != null) {
-                    m = JavaTemplate.builder("@Timeout(#{any(long)})")
+                    m = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS)")
                             .javaParser(javaParser(ctx))
-                            .imports("org.junit.jupiter.api.Timeout")
+                            .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
                             .build()
                             .apply(
                                     updateCursor(m),
@@ -161,6 +161,7 @@ public class UpdateTestAnnotation extends Recipe {
                                     cta.timeout
                             );
                     maybeAddImport("org.junit.jupiter.api.Timeout");
+                    maybeAddImport("java.util.concurrent.TimeUnit");
                 }
                 maybeAddImport("org.junit.jupiter.api.Test");
             }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -272,6 +272,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/450")
     void annotationWithTimeout() {
         //language=java
         rewriteRun(
@@ -290,10 +291,12 @@ class UpdateTestAnnotationTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
               import org.junit.jupiter.api.Timeout;
               
+              import java.util.concurrent.TimeUnit;
+              
               public class MyTest {
               
                   @Test
-                  @Timeout(500)
+                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
                   public void test() {
                   }
               }
@@ -369,12 +372,14 @@ class UpdateTestAnnotationTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
               import org.junit.jupiter.api.Timeout;
               
+              import java.util.concurrent.TimeUnit;
+              
               import static org.junit.jupiter.api.Assertions.assertThrows;
               
               public class MyTest {
               
                   @Test
-                  @Timeout(500)
+                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
                   public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
                           throw new IllegalArgumentException("boom");
@@ -518,7 +523,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                   }
                   
                   @Test
-                  void feature2() {
+                  public void feature2() {
                   }
               }
               """,
@@ -531,7 +536,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                   }
                   
                   @Test
-                  void feature2() {
+                  public void feature2() {
                   }
               }
               """


### PR DESCRIPTION
Fixes #450
- #450

Quickest way to fix this is to add an explicit unit, since any division might lead to rounding errors.

We could also explore simplifying the durations as we do for AssertJ
https://github.com/openrewrite/rewrite-testing-frameworks/blob/24742fb4458d71f11103116090a3337612ca8187/src/main/java/org/openrewrite/java/testing/assertj/AdoptAssertJDurationAssertions.java#L165-L203
But that's probably best done as a separate followup recipe such that we also pick up any existing tests.
