### PR TITLE
removing UpgradeOkHttpMockWebServer from JUnit5 upgrade

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -88,7 +88,6 @@ recipeList:
   - org.openrewrite.java.testing.junit5.EnclosedToNested
   - org.openrewrite.java.testing.junit5.AddMissingNested
   - org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed
-  - org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer
   - org.openrewrite.java.testing.junit5.UseXMLUnitLegacy
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: junit
@@ -243,7 +242,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer
 displayName: Use OkHttp 3 MockWebServer for JUnit 5
-description: Migrates OkHttp 3 `MockWebServer` to the JUnit Jupiter compatible version.
+description: Migrates OkHttp 3 `MockWebServer` to enable JUnit Jupiter Extension support
 tags:
   - testing
   - junit


### PR DESCRIPTION
`mockwebserver3-junit5` is not necessary for JUnit5 compatibility; only to provide the relevant `Extension`. And given that the corresponding JUnit4 Rule seems to have been introduced in the same okhttp version (5.x), it is unlikely for existing apps on JUnit4 to have usages non-JUnit-5-compatible code (and even if they do use the MockWebServerRule, this recipe does not yet convert that to MockWebServerExtension anyway). there's also a version management concern here; moving to an "alpha" version of a dep may surprise/confuse users, and, moving *only* mockwebserver to that version (without touching other okhttp deps) may risk compatibility issues

cc @knutwannheden since this came from your commit (a while ago) https://github.com/openrewrite/rewrite-testing-frameworks/commit/1bf96d3982571b2ea7b52f29366d7ac5dd5a3979