### PR TITLE
JMockit to Mockito Recipe - Bug Fixes and Improvements

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
@@ -112,7 +112,8 @@ class ArgumentMatchersRewriter {
             } else if (methodArgument instanceof J.FieldAccess) {
                 return rewriteIdentifierToArgumentMatcher(((J.FieldAccess) methodArgument).getName());
             } else {
-                throw new IllegalStateException("Unexpected method argument: " + methodArgument + ", class: " + methodArgument.getClass());
+                // unhandled type, return argument unchanged
+                return methodArgument;
             }
         }
         if (!(methodArgument instanceof J.TypeCast)) {
@@ -168,11 +169,8 @@ class ArgumentMatchersRewriter {
     }
 
     private Expression rewriteIdentifierToArgumentMatcher(J.Identifier methodArgument) {
-        if (methodArgument.getType() == null) {
-            throw new IllegalStateException("Missing type information for identifier: " + methodArgument);
-        }
         if (!(methodArgument.getType() instanceof JavaType.FullyQualified)) {
-            throw new IllegalStateException("Unexpected identifier type: " + methodArgument.getType());
+            return methodArgument;
         }
         JavaType.FullyQualified type = (JavaType.FullyQualified) methodArgument.getType();
         return rewriteFullyQualifiedArgument(methodArgument, type.getClassName(), type.getFullyQualifiedName());
@@ -190,7 +188,8 @@ class ArgumentMatchersRewriter {
             className = ((JavaType.Class) typeCastType).getClassName();
             fqn = ((JavaType.Class) typeCastType).getFullyQualifiedName();
         } else {
-            throw new IllegalStateException("Unexpected J.TypeCast type: " + typeCastType);
+            // unhandled type, return argument unchanged
+            return methodArgument;
         }
         return rewriteFullyQualifiedArgument(tc, className, fqn);
     }
@@ -230,7 +229,8 @@ class ArgumentMatchersRewriter {
                 argumentMatcher = "isNull";
                 break;
             default:
-                throw new IllegalStateException("Unexpected primitive type: " + primitiveType);
+                // unhandled type, return argument unchanged
+                return methodArgument;
         }
         String template = argumentMatcher + "()";
         return applyArgumentTemplate(methodArgument, argumentMatcher, template, new ArrayList<>());

--- a/src/main/java/org/openrewrite/java/testing/jmockit/ExpectationsBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/ExpectationsBlockRewriter.java
@@ -248,15 +248,21 @@ class ExpectationsBlockRewriter {
         StringBuilder templateBuilder = new StringBuilder("verify(#{any(" + fqn + ")}, "
                 + verificationMode
                 + "(#{any(int)})).#{}(");
+        boolean hasArgument = false;
         for (Expression argument : arguments) {
-            if (argument instanceof J.Literal) {
+            if (argument instanceof J.Empty) {
+                continue;
+            } else if (argument instanceof J.Literal) {
                 templateBuilder.append(((J.Literal) argument).getValueSource());
             } else {
                 templateBuilder.append(argument);
             }
+            hasArgument = true;
             templateBuilder.append(", ");
         }
-        templateBuilder.delete(templateBuilder.length() - 2, templateBuilder.length());
+        if (hasArgument) {
+            templateBuilder.delete(templateBuilder.length() - 2, templateBuilder.length());
+        }
         templateBuilder.append(");");
         return templateBuilder.toString();
     }
@@ -274,11 +280,11 @@ class ExpectationsBlockRewriter {
                 continue;
             }
             J.Assignment assignment = (J.Assignment) expectationStatement;
-            if (!(assignment.getVariable() instanceof J.Identifier)) {
+            J.Identifier identifier = JMockitUtils.getVariableIdentifierFromAssignment(assignment);
+            if (identifier == null) {
                 // unhandled assignment variable type
                 return null;
             }
-            J.Identifier identifier = (J.Identifier) assignment.getVariable();
             switch (identifier.getSimpleName()) {
                 case "result":
                     resultWrapper.addResult(assignment.getAssignment());

--- a/src/main/java/org/openrewrite/java/testing/jmockit/ExpectationsBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/ExpectationsBlockRewriter.java
@@ -280,12 +280,12 @@ class ExpectationsBlockRewriter {
                 continue;
             }
             J.Assignment assignment = (J.Assignment) expectationStatement;
-            J.Identifier identifier = JMockitUtils.getVariableIdentifierFromAssignment(assignment);
-            if (identifier == null) {
+            String variableName = getVariableNameFromAssignment(assignment);
+            if (variableName == null) {
                 // unhandled assignment variable type
                 return null;
             }
-            switch (identifier.getSimpleName()) {
+            switch (variableName) {
                 case "result":
                     resultWrapper.addResult(assignment.getAssignment());
                     break;
@@ -301,6 +301,19 @@ class ExpectationsBlockRewriter {
             }
         }
         return resultWrapper;
+    }
+
+    private static String getVariableNameFromAssignment(J.Assignment assignment) {
+        String name = null;
+        if (assignment.getVariable() instanceof J.Identifier) {
+            name = ((J.Identifier) assignment.getVariable()).getSimpleName();
+        } else if (assignment.getVariable() instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
+            if (fieldAccess.getTarget() instanceof J.Identifier) {
+                name = fieldAccess.getSimpleName();
+            }
+        }
+        return name;
     }
 
     private static String getPrimitiveTemplateField(JavaType.Primitive primitiveType) {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -60,14 +60,19 @@ public class JMockitExpectationsToMockito extends Recipe {
             J.Block methodBody = ssr.rewriteMethodBody();
             List<Statement> statements = methodBody.getStatements();
 
+            int bodyStatementIndex = 0;
             // iterate over each statement in the method body, find Expectations blocks and rewrite them
-            for (int bodyStatementIndex = 0; bodyStatementIndex < statements.size(); bodyStatementIndex++) {
+            while (bodyStatementIndex < statements.size()) {
                 if (!JMockitUtils.isValidExpectationsNewClassStatement(statements.get(bodyStatementIndex))) {
+                    bodyStatementIndex++;
                     continue;
                 }
                 ExpectationsBlockRewriter ebr = new ExpectationsBlockRewriter(this, ctx, methodBody,
                         ((J.NewClass) statements.get(bodyStatementIndex)), bodyStatementIndex);
                 methodBody = ebr.rewriteMethodBody();
+                // reset the iteration to the beginning of the method body since the number of statements has likely changed
+                bodyStatementIndex = 0;
+                statements = methodBody.getStatements();
             }
             return md.withBody(methodBody);
         }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -55,26 +55,21 @@ public class JMockitExpectationsToMockito extends Recipe {
             if (md.getBody() == null) {
                 return md;
             }
-            try {
-                // rewrite the statements that are not mock expectations or verifications
-                SetupStatementsRewriter ssr = new SetupStatementsRewriter(this, md.getBody());
-                J.Block methodBody = ssr.rewriteMethodBody();
-                List<Statement> statements = methodBody.getStatements();
+            // rewrite the statements that are not mock expectations or verifications
+            SetupStatementsRewriter ssr = new SetupStatementsRewriter(this, md.getBody());
+            J.Block methodBody = ssr.rewriteMethodBody();
+            List<Statement> statements = methodBody.getStatements();
 
-                // iterate over each statement in the method body, find Expectations blocks and rewrite them
-                for (int bodyStatementIndex = 0; bodyStatementIndex < statements.size(); bodyStatementIndex++) {
-                    if (!JMockitUtils.isExpectationsNewClassStatement(statements.get(bodyStatementIndex))) {
-                        continue;
-                    }
-                    ExpectationsBlockRewriter ebr = new ExpectationsBlockRewriter(this, ctx, methodBody,
-                            ((J.NewClass) statements.get(bodyStatementIndex)), bodyStatementIndex);
-                    methodBody = ebr.rewriteMethodBody();
+            // iterate over each statement in the method body, find Expectations blocks and rewrite them
+            for (int bodyStatementIndex = 0; bodyStatementIndex < statements.size(); bodyStatementIndex++) {
+                if (!JMockitUtils.isValidExpectationsNewClassStatement(statements.get(bodyStatementIndex))) {
+                    continue;
                 }
-                return md.withBody(methodBody);
-            } catch (Exception e) {
-                // if anything goes wrong, just return the original method declaration
-                return md;
+                ExpectationsBlockRewriter ebr = new ExpectationsBlockRewriter(this, ctx, methodBody,
+                        ((J.NewClass) statements.get(bodyStatementIndex)), bodyStatementIndex);
+                methodBody = ebr.rewriteMethodBody();
             }
+            return md.withBody(methodBody);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -35,18 +35,4 @@ class JMockitUtils {
         // Expectations block should be composed of a block within another block
         return nc.getBody() != null && nc.getBody().getStatements().size() == 1;
     }
-
-    static J.Identifier getVariableIdentifierFromAssignment(J.Assignment assignment) {
-        J.Identifier identifier = null;
-        if (assignment.getVariable() instanceof J.Identifier) {
-            identifier = (J.Identifier) assignment.getVariable();
-        } else if (assignment.getVariable() instanceof J.FieldAccess) {
-            J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
-            if (fieldAccess.getTarget() instanceof J.Identifier) {
-                identifier = (J.Identifier) fieldAccess.getTarget();
-            }
-        }
-        return identifier;
-    }
-
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -20,7 +20,7 @@ import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 class JMockitUtils {
-    static boolean isExpectationsNewClassStatement(Statement s) {
+    static boolean isValidExpectationsNewClassStatement(Statement s) {
         if (!(s instanceof J.NewClass)) {
             return false;
         }
@@ -32,13 +32,7 @@ class JMockitUtils {
         if (!TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType())) {
             return false;
         }
-        // empty Expectations block is considered invalid
-        assert nc.getBody() != null
-                && !nc.getBody().getStatements().isEmpty() : "Expectations block is empty";
         // Expectations block should be composed of a block within another block
-        assert nc.getBody().getStatements().size() == 1 : "Expectations block is malformed";
-
-        return true;
+        return nc.getBody() != null && nc.getBody().getStatements().size() == 1;
     }
-
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -35,4 +35,18 @@ class JMockitUtils {
         // Expectations block should be composed of a block within another block
         return nc.getBody() != null && nc.getBody().getStatements().size() == 1;
     }
+
+    static J.Identifier getVariableIdentifierFromAssignment(J.Assignment assignment) {
+        J.Identifier identifier = null;
+        if (assignment.getVariable() instanceof J.Identifier) {
+            identifier = (J.Identifier) assignment.getVariable();
+        } else if (assignment.getVariable() instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
+            if (fieldAccess.getTarget() instanceof J.Identifier) {
+                identifier = (J.Identifier) fieldAccess.getTarget();
+            }
+        }
+        return identifier;
+    }
+
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
@@ -40,15 +40,15 @@ class SetupStatementsRewriter {
         List<Statement> statements = methodBody.getStatements();
         // iterate over each statement in the method body, find Expectations blocks and rewrite them
         for (Statement s : statements) {
-            if (!JMockitUtils.isExpectationsNewClassStatement(s)) {
+            if (!JMockitUtils.isValidExpectationsNewClassStatement(s)) {
                 continue;
             }
-
             J.NewClass nc = (J.NewClass) s;
             assert nc.getBody() != null;
+            J.Block expectationsBlock = (J.Block) nc.getBody().getStatements().get(0);
+
             // statement needs to be moved directly before expectations class instantiation
             JavaCoordinates coordinates = nc.getCoordinates().before();
-            J.Block expectationsBlock = (J.Block) nc.getBody().getStatements().get(0);
             List<Statement> newExpectationsBlockStatements = new ArrayList<>();
             for (Statement expectationStatement : expectationsBlock.getStatements()) {
                 if (!isSetupStatement(expectationStatement)) {

--- a/src/main/resources/META-INF/rewrite/jmockit.yml
+++ b/src/main/resources/META-INF/rewrite/jmockit.yml
@@ -22,6 +22,7 @@ tags:
   - testing
   - jmockit
 recipeList:
+  - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockito
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.Mocked
       newFullyQualifiedTypeName: org.mockito.Mock
@@ -34,7 +35,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.integration.junit5.JMockitExtension
       newFullyQualifiedTypeName: org.mockito.junit.jupiter.MockitoExtension
-  - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockito
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-core

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -176,6 +176,11 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                           result = 10;
                       }};
                       assertEquals(10, myObject.getSomeField());
+                      new Expectations() {{
+                          myObject.getSomeField();
+                          this.result = 100;
+                      }};
+                      assertEquals(100, myObject.getSomeField());
                   }
               }
               """,
@@ -195,6 +200,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   void test() {
                       when(myObject.getSomeField()).thenReturn(10);
                       assertEquals(10, myObject.getSomeField());
+                      when(myObject.getSomeField()).thenReturn(100);
+                      assertEquals(100, myObject.getSomeField());
                   }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

**Improvements:**

- Added support for `minTimes` and `maxTimes` JMockit features.
- Several pieces of logic depended on the instance of the LST element (e.g. `J.Literal` or `J.Identifier`) rather than the `JavaType` itself. Refactored to use the more appropriate type matching.
- Argument matcher convenience methods like `anyString` or `anyLong` were not uniformly applied and in some cases `any(java.lang.String)` would be used instead. Use the convenience APIs consistently.
- The recipe had several scenarios where an exception is intentionally thrown in order to prevent processing LSTs that contain either invalid or unhandled LST structures. Change this to instead simply return the LST elements unchanged and continue processing rather than short-circuiting the entire recipe.

**Bug Fixes:**

- Multiple Expectations Blocks in a single test method causing incorrect statement ordering.
- Fix handling of `this.result = <value>` in an `Expectations` block; previously only `result = <value>` was properly handled.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Continue the recipe maturation!


## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
