### PR TITLE
`JUnitAssertEqualsToAssertThat` skipped adding `assertThat` import for custom classes

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
@@ -49,17 +49,6 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
     }
 
     public static class AssertEqualsToAssertThatVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private JavaParser.Builder<?, ?> assertionsParser;
-
-        private JavaParser.Builder<?, ?> assertionsParser(ExecutionContext ctx) {
-            if (assertionsParser == null) {
-                assertionsParser = JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "assertj-core-3.24");
-            }
-            return assertionsParser;
-        }
-
-
         private static final MethodMatcher JUNIT_ASSERT_EQUALS = new MethodMatcher("org.junit.jupiter.api.Assertions" + " assertEquals(..)");
 
         @Override
@@ -79,7 +68,7 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
             if (args.size() == 2) {
                 return JavaTemplate.builder("assertThat(#{any()}).isEqualTo(#{any()});")
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
-                        .javaParser(assertionsParser(ctx))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
                         .build()
                         .apply(getCursor(), method.getCoordinates().replace(), actual, expected);
             } else if (args.size() == 3 && !isFloatingPointType(args.get(2))) {
@@ -90,7 +79,7 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
                 return template
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .imports("java.util.function.Supplier")
-                        .javaParser(assertionsParser(ctx))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
                         .build()
                         .apply(
                                 getCursor(),
@@ -103,7 +92,7 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
                 maybeAddImport("org.assertj.core.api.Assertions", "within");
                 return JavaTemplate.builder("assertThat(#{any()}).isCloseTo(#{any()}, within(#{any()}));")
                         .staticImports("org.assertj.core.api.Assertions.assertThat", "org.assertj.core.api.Assertions.within")
-                        .javaParser(assertionsParser(ctx))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
                         .build()
                         .apply(getCursor(), method.getCoordinates().replace(), actual, expected, args.get(2));
 
@@ -119,7 +108,7 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
             return template
                     .staticImports("org.assertj.core.api.Assertions.assertThat", "org.assertj.core.api.Assertions.within")
                     .imports("java.util.function.Supplier")
-                    .javaParser(assertionsParser(ctx))
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3.24"))
                     .build()
                     .apply(
                             getCursor(),

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
@@ -72,7 +72,8 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
             Expression expected = args.get(0);
             Expression actual = args.get(1);
 
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            //always add the import (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
             if (args.size() == 2) {

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
@@ -360,45 +360,40 @@ class JUnitAssertEqualsToAssertThatTest implements RewriteTest {
     }
 
     @Test
-    @Issue("479")
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/479")
     void shouldImportWhenCustomClassIsUsed() {
         //language=java
         rewriteRun(
+          // The JavaParer in JavaTemplate only has AssertJ on the classpath, and for now is not .contextSenstive()
           spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(
             """
-              package org.example;
-              
               import org.junit.jupiter.api.Assertions;
               import org.junit.jupiter.api.Test;
               
               class ATest {
-              
-                @Test void testEquals() {
+                @Test
+                void testEquals() {
                   Assertions.assertEquals(new OwnClass(), new OwnClass());
                 }
               
                 public record OwnClass(String a) {
-              
                   public OwnClass() {this("1");}
                 }
               }
               """,
               """
-              package org.example;
-               
               import org.junit.jupiter.api.Test;
               
               import static org.assertj.core.api.Assertions.assertThat;
                 
               class ATest {
-               
-                @Test void testEquals() {
+                @Test
+                void testEquals() {
                     assertThat(new OwnClass()).isEqualTo(new OwnClass());
                 }
                
                 public record OwnClass(String a) {
-               
                   public OwnClass() {this("1");}
                 }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.assertj;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -352,6 +353,54 @@ class JUnitAssertEqualsToAssertThatTest implements RewriteTest {
                   private File notification() {
                       return new File("someFile");
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("479")
+    void shouldImportWhenCustomClassIsUsed() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              package org.example;
+              
+              import org.junit.jupiter.api.Assertions;
+              import org.junit.jupiter.api.Test;
+              
+              class ATest {
+              
+                @Test void testEquals() {
+                  Assertions.assertEquals(new OwnClass(), new OwnClass());
+                }
+              
+                public record OwnClass(String a) {
+              
+                  public OwnClass() {this("1");}
+                }
+              }
+              """,
+            """
+              package org.example;
+               
+               import static org.assertj.core.api.Assertions.assertThat;
+               
+               import org.junit.jupiter.api.Test;
+               
+               class ATest {
+               
+                 @Test void testEquals() {
+                   assertThat(new OwnClass()).isEqualTo(new OwnClass());
+                 }
+               
+                 public record OwnClass(String a) {
+               
+                   public OwnClass() {this("1");}
+                 }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
@@ -384,23 +384,23 @@ class JUnitAssertEqualsToAssertThatTest implements RewriteTest {
                 }
               }
               """,
-            """
+              """
               package org.example;
                
-               import static org.assertj.core.api.Assertions.assertThat;
+              import org.junit.jupiter.api.Test;
+              
+              import static org.assertj.core.api.Assertions.assertThat;
+                
+              class ATest {
                
-               import org.junit.jupiter.api.Test;
+                @Test void testEquals() {
+                    assertThat(new OwnClass()).isEqualTo(new OwnClass());
+                }
                
-               class ATest {
+                public record OwnClass(String a) {
                
-                 @Test void testEquals() {
-                   assertThat(new OwnClass()).isEqualTo(new OwnClass());
-                 }
-               
-                 public record OwnClass(String a) {
-               
-                   public OwnClass() {this("1");}
-                 }
+                  public OwnClass() {this("1");}
+                }
               }
               """
           )


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
fixing #479 

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
