### PR TITLE
JMockit to Mockito Recipe - Rewrite JMockit Mocked Variable to Mockito statements

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
@@ -55,8 +55,6 @@ public class JMockitMockedVariableToMockito extends Recipe {
     private static class RewriteMockedVariableVisitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, @NotNull ExecutionContext ctx) {
-            System.out.println(TreeVisitingPrinter.printTree(getCursor()));
-
             List<Statement> parameters = methodDeclaration.getParameters();
             if (!parameters.isEmpty()) {
                 this.maybeRemoveImport("mockit.Mocked");

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.TreeVisitingPrinter;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockito.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.jmockit;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.TreeVisitingPrinter;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class JMockitMockedVariableToMockito extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Rewrite JMockit Mocked Variable";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Rewrites JMockit `Mocked Variable` to Mockito statements.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("mockit.Mocked", false),
+                new RewriteMockedVariableVisitor());
+    }
+
+    private static class RewriteMockedVariableVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDeclaration, @NotNull ExecutionContext ctx) {
+            System.out.println(TreeVisitingPrinter.printTree(getCursor()));
+
+            List<Statement> parameters = methodDeclaration.getParameters();
+            if (!parameters.isEmpty()) {
+                this.maybeRemoveImport("mockit.Mocked");
+                this.maybeAddImport("org.mockito.Mockito");
+
+                // Create lists to store the mocked parameters and the new type parameters
+                List<J.VariableDeclarations> mockedParameter = new ArrayList<>(parameters.size());
+                List<Statement> newTypeParameterList = new ArrayList<>(parameters.size());
+                parameters.forEach(parameter -> {
+                    if (parameter instanceof J.VariableDeclarations) {
+                        J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) parameter;
+                        // Check if the parameter has the annotation "mockit.Mocked"
+                        if (variableDeclarations.getLeadingAnnotations().stream().anyMatch(annotation -> annotation.getType() != null && annotation.getType().toString().equals("mockit.Mocked"))) {
+                            mockedParameter.add(variableDeclarations);
+                        } else {
+                            newTypeParameterList.add(variableDeclarations);
+                        }
+                    }
+                });
+
+                // Check if there are mocked parameters
+                if (!mockedParameter.isEmpty()) {
+                    // Update the method declaration with the new type parameters
+                    methodDeclaration = methodDeclaration.withParameters(newTypeParameterList);
+                    JavaTemplate addStatementsTemplate = JavaTemplate.builder("#{} #{} = Mockito.mock(#{}.class);\n")
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
+                            .imports("org.mockito.Mockito")
+                            .contextSensitive()
+                            .build();
+                    for (int i = mockedParameter.size() - 1; i >= 0; i--) {
+                        J.VariableDeclarations variableDeclarations = mockedParameter.get(i);
+                        // Apply the template and update the method declaration
+                        methodDeclaration = maybeAutoFormat(
+                                methodDeclaration, addStatementsTemplate.apply(updateCursor(methodDeclaration),
+                                        methodDeclaration.getBody().getCoordinates().firstStatement(),
+                                        variableDeclarations.getTypeExpression().toString(),
+                                        variableDeclarations.getVariables().get(0).getSimpleName(),
+                                        variableDeclarations.getTypeExpression().toString()),
+                                ctx
+                        );
+                    }
+                }
+            }
+            return methodDeclaration;
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/jmockit.yml
+++ b/src/main/resources/META-INF/rewrite/jmockit.yml
@@ -23,6 +23,7 @@ tags:
   - jmockit
 recipeList:
   - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockito
+  - org.openrewrite.java.testing.jmockit.JMockitMockedVariableToMockito
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.Mocked
       newFullyQualifiedTypeName: org.mockito.Mock

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.openrewrite.java.Assertions.java;
 
 class JMockitMockedVariableToMockitoTest implements RewriteTest {
@@ -86,8 +85,10 @@ class JMockitMockedVariableToMockitoTest implements RewriteTest {
         );
     }
 
+    @Test
     void noVariableTest() {
         rewriteRun(
+          //language=java
           java(
             """
               import mockit.Mocked;

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.jmockit;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openrewrite.java.Assertions.java;
+
+class JMockitMockedVariableToMockitoTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-jupiter-api-5.9",
+              "jmockit-1.49",
+              "mockito-core-3.12",
+              "mockito-junit-jupiter-3.12"
+            ))
+          .recipeFromResource(
+            "/META-INF/rewrite/jmockit.yml",
+            "org.openrewrite.java.testing.jmockit.JMockitToMockito"
+          );
+    }
+
+    @Test
+    void mockedVariableTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.Mocked;
+              
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+                          
+              class A {
+                  @Mocked
+                  Object mockedObject;
+              
+                  void test(@Mocked Object o, @Mocked Object o2) {
+                      assertNotNull(o);
+                      assertNotNull(o2);
+                  }
+              }
+              """,
+            """
+              import org.mockito.Mock;
+              import org.mockito.Mockito;
+              
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+                          
+              class A {
+                  @Mock
+                  Object mockedObject;
+              
+                  void test() {
+                      Object o = Mockito.mock(Object.class);
+                      Object o2 = Mockito.mock(Object.class);
+                      assertNotNull(o);
+                      assertNotNull(o2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    void noVariableTest() {
+        rewriteRun(
+          java(
+            """
+              import mockit.Mocked;
+              
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+                          
+              class A {
+                  @Mocked
+                  Object mockedObject;
+              
+                  void test() {
+                      assertNotNull(mockedObject);
+                  }
+              }
+              """,
+            """
+              import org.mockito.Mock;
+              
+              import static org.junit.jupiter.api.Assertions.assertNotNull;
+                          
+              class A {
+                  @Mock
+                  Object mockedObject;
+              
+                  void test() {
+                      assertNotNull(mockedObject);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockedVariableToMockitoTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.jmockit;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -42,6 +43,7 @@ class JMockitMockedVariableToMockitoTest implements RewriteTest {
           );
     }
 
+    @DocumentExample
     @Test
     void mockedVariableTest() {
         //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Improvements:

- Added support for JMockit Mocked Variable features(eg. `void someMethod(@Mocked Object o)`)

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
