### PR TITLE
don't use TempDirNonFinal on method parameters

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TempDirNonFinalTest.java
@@ -95,7 +95,7 @@ class TempDirNonFinalTest implements RewriteTest {
     }
 
     @Test
-    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241")
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/241, https://github.com/openrewrite/rewrite-testing-frameworks/issues/483")
     void tempDirFileParameter() {
         //language=java
         rewriteRun(
@@ -109,7 +109,7 @@ class TempDirNonFinalTest implements RewriteTest {
               
               class MyTest {
                   @Test
-                  void fileTest(@TempDir File tempDir) {
+                  void fileTest(@TempDir final File tempDir) {
                   }
               }
               """


### PR DESCRIPTION
Fixes #483.

## What's changed?
apply TempDirNonFinal only to fields, not method parameters
Without the main code fix, the modified test fails.

## Anything in particular you'd like reviewers to focus on?
The method for detecting whether the variables are fields or method arguments has been copied from another recipe. There are multiple (different) implementations of this method all over the place, and I have no idea if the other implementations are better or not. Someone from the core team might want to introduce an actual API method for that to avoid these local duplicates.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
