### PR TITLE
JMockit to Mockito Recipe - `eq` Support, Better Type Propagation, and Error Handling

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockito.java
@@ -64,15 +64,17 @@ public class JMockitExpectationsToMockito extends Recipe {
             // iterate over each statement in the method body, find Expectations blocks and rewrite them
             while (bodyStatementIndex < statements.size()) {
                 if (!JMockitUtils.isValidExpectationsNewClassStatement(statements.get(bodyStatementIndex))) {
-                    bodyStatementIndex++;
+                    bodyStatementIndex += 1;
                     continue;
                 }
                 ExpectationsBlockRewriter ebr = new ExpectationsBlockRewriter(this, ctx, methodBody,
                         ((J.NewClass) statements.get(bodyStatementIndex)), bodyStatementIndex);
                 methodBody = ebr.rewriteMethodBody();
-                // reset the iteration to the beginning of the method body since the number of statements has likely changed
-                bodyStatementIndex = 0;
                 statements = methodBody.getStatements();
+                // if the expectations rewrite failed, skip the next statement
+                if (ebr.isExpectationsRewriteFailed()) {
+                    bodyStatementIndex += 1;
+                }
             }
             return md.withBody(methodBody);
         }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -520,6 +520,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   public String getSomeField(List<String> input) {
                       return "X";
                   }
+                  public String getSomeOtherField(Object input) {
+                      return "Y";
+                  }
               }
               """
           ),
@@ -544,8 +547,11 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       new Expectations() {{
                           myObject.getSomeField((List<String>) any);
                           result = null;
+                          myObject.getSomeOtherField((Object) any);
+                          result = null;
                       }};
                       assertNull(myObject.getSomeField(new ArrayList<>()));
+                      assertNull(myObject.getSomeOtherField(new Object()));
                   }
               }
               """,
@@ -558,8 +564,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
               
               import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.anyList;
-              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.*;
               
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -568,7 +573,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   
                   void test() {
                       when(myObject.getSomeField(anyList())).thenReturn(null);
+                      when(myObject.getSomeOtherField(any(Object.class))).thenReturn(null);
                       assertNull(myObject.getSomeField(new ArrayList<>()));
+                      assertNull(myObject.getSomeOtherField(new Object()));
                   }
               }
               """
@@ -636,7 +643,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   
                   void test() {
                       String bazz = "bazz";
-                      when(myObject.getSomeField(anyString(), anyString(), anyString(), anyLong())).thenReturn(null);
+                      when(myObject.getSomeField(eq("foo"), anyString(), eq(bazz), eq(10L))).thenReturn(null);
                       assertNull(myObject.getSomeField("foo", "bar", bazz, 10L));
                   }
               }
@@ -834,6 +841,65 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
                       verify(myObject, times(2)).wait(anyLong(), anyInt());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenSpy() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public String getSomeField() {
+                      return "X";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Tested;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+    
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+    
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Tested
+                  MyObject myObject;
+    
+                  void test() {
+                      new Expectations(myObject) {{
+                          myObject.getSomeField();
+                          result = "foo";
+                      }};
+                      assertEquals("foo", myObject.getSomeField());
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.InjectMocks;
+              import org.mockito.junit.jupiter.MockitoExtension;
+    
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.when;
+    
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @InjectMocks
+                  MyObject myObject;
+    
+                  void test() {
+                      when(myObject.getSomeField()).thenReturn("foo");
+                      assertEquals("foo", myObject.getSomeField());
                   }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
This PR includes these major changes:

- Expectations with raw values mixed with argument matchers should use `eq`
- Preserve the type information of Mockito `any(Class)` invocation arguments
- Fix infinite loop when rewriting `Expectations` block fails
- Major refactor of `ArgumentMatchersRewriter` to simplify logic and add clarity 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Continue improving the recipe, make it easier to understand.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
