### PR TITLE
Fix performance regression in AssertJ recipes

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertArrayEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertArrayEqualsToAssertThat.java
@@ -73,7 +73,8 @@ public class JUnitAssertArrayEqualsToAssertThat extends Recipe {
             Expression expected = args.get(0);
             Expression actual = args.get(1);
 
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
             maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME);
 
             if (args.size() == 2) {
@@ -93,7 +94,7 @@ public class JUnitAssertArrayEqualsToAssertThat extends Recipe {
                         .build()
                         .apply(getCursor(), method.getCoordinates().replace(), actual, message, expected);
             } else if (args.size() == 3) {
-                maybeAddImport("org.assertj.core.api.Assertions", "within");
+                maybeAddImport("org.assertj.core.api.Assertions", "within", false);
                 // assert is using floating points with a delta and no message.
                 return JavaTemplate.builder("assertThat(#{anyArray()}).containsExactly(#{anyArray()}, within(#{any()}));")
                         .staticImports("org.assertj.core.api.Assertions.assertThat", "org.assertj.core.api.Assertions.within")
@@ -104,7 +105,7 @@ public class JUnitAssertArrayEqualsToAssertThat extends Recipe {
 
             // The assertEquals is using a floating point with a delta argument and a message.
             Expression message = args.get(3);
-            maybeAddImport("org.assertj.core.api.Assertions", "within");
+            maybeAddImport("org.assertj.core.api.Assertions", "within", false);
 
             JavaTemplate.Builder template = TypeUtils.isString(message.getType()) ?
                     JavaTemplate.builder("assertThat(#{anyArray()}).as(#{any(String)}).containsExactly(#{anyArray()}, within(#{any()}));") :

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertFalseToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertFalseToAssertThat.java
@@ -98,7 +98,7 @@ public class JUnitAssertFalseToAssertThat extends Recipe {
             }
 
             //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false););
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
 
             // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertFalseToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertFalseToAssertThat.java
@@ -97,7 +97,10 @@ public class JUnitAssertFalseToAssertThat extends Recipe {
                         );
             }
 
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false););
+
+            // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
             return method;

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThat.java
@@ -74,7 +74,6 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
 
             if (args.size() == 2) {
                 method = JavaTemplate.builder("assertThat(#{any()}).isNotEqualTo(#{any()});")
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -93,7 +92,6 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
 
 
                 method = template
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -106,7 +104,6 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                         );
             } else if (args.size() == 3) {
                 method = JavaTemplate.builder("assertThat(#{any()}).isNotCloseTo(#{any()}, within(#{any()}));")
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat", "org.assertj.core.api.Assertions.within")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -117,7 +114,7 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                                 expected,
                                 args.get(2)
                         );
-                maybeAddImport("org.assertj.core.api.Assertions", "within");
+                maybeAddImport("org.assertj.core.api.Assertions", "within", false);
             } else {
                 Expression message = args.get(3);
 
@@ -126,7 +123,6 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                         JavaTemplate.builder("assertThat(#{any()}).as(#{any(java.util.function.Supplier)}).isNotCloseTo(#{any()}, within(#{any()}));");
 
                 method = template
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat", "org.assertj.core.api.Assertions.within")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -139,12 +135,13 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                                 args.get(2)
                         );
 
-                maybeAddImport("org.assertj.core.api.Assertions", "within");
+                maybeAddImport("org.assertj.core.api.Assertions", "within", false);
             }
 
-            //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat"
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
-            //And if there are no longer references to the JUnit assertions class, we can remove the import.
+            //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
+
+            // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
             return method;

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotNullToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotNullToAssertThat.java
@@ -71,7 +71,6 @@ public class JUnitAssertNotNullToAssertThat extends Recipe {
 
             if (args.size() == 1) {
                 method = JavaTemplate.builder("assertThat(#{any()}).isNotNull();")
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -89,7 +88,6 @@ public class JUnitAssertNotNullToAssertThat extends Recipe {
                         JavaTemplate.builder("assertThat(#{any()}).as(#{any(java.util.function.Supplier)}).isNotNull();");
 
                 method = template
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -101,8 +99,11 @@ public class JUnitAssertNotNullToAssertThat extends Recipe {
                         );
             }
 
+            //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
+
+            //And if there are no longer references to the JUnit assertions class, we can remove the import.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
 
             return method;
         }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNullToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNullToAssertThat.java
@@ -71,7 +71,6 @@ public class JUnitAssertNullToAssertThat extends Recipe {
 
             if (args.size() == 1) {
                 method = JavaTemplate.builder("assertThat(#{any()}).isNull();")
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -88,7 +87,6 @@ public class JUnitAssertNullToAssertThat extends Recipe {
                         JavaTemplate.builder("assertThat(#{any()}).as(#{any(java.util.function.Supplier)}).isNull();");
 
                 method = template
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -100,11 +98,11 @@ public class JUnitAssertNullToAssertThat extends Recipe {
                         );
             }
 
+            // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
+
             // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
-
-            // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat".
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
 
             return method;
         }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertSameToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertSameToAssertThat.java
@@ -105,7 +105,7 @@ public class JUnitAssertSameToAssertThat extends Recipe {
             maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
 
             // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
-            maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME);
+            maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
             return method;
         }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertSameToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertSameToAssertThat.java
@@ -72,7 +72,6 @@ public class JUnitAssertSameToAssertThat extends Recipe {
 
             if (args.size() == 2) {
                 method = JavaTemplate.builder("assertThat(#{any()}).isSameAs(#{any()});")
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -90,7 +89,6 @@ public class JUnitAssertSameToAssertThat extends Recipe {
                         JavaTemplate.builder("assertThat(#{any()}).as(#{any(java.util.function.Supplier)}).isSameAs(#{any()});");
 
                 method = template
-                        .contextSensitive()
                         .staticImports("org.assertj.core.api.Assertions.assertThat")
                         .javaParser(assertionsParser(ctx))
                         .build()
@@ -103,8 +101,11 @@ public class JUnitAssertSameToAssertThat extends Recipe {
                         );
             }
 
-            maybeRemoveImport("org.junit.jupiter.api.Assertions");
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            // Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
+
+            // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
+            maybeRemoveImport(JUNIT_QUALIFIED_ASSERTIONS_CLASS_NAME);
 
             return method;
         }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
@@ -85,7 +85,7 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
                                     mi.getCoordinates().replace(),
                                     mi.getArguments().get(0), executable
                             );
-                    maybeAddImport("org.assertj.core.api.AssertionsForClassTypes", "assertThatExceptionOfType");
+                    maybeAddImport("org.assertj.core.api.AssertionsForClassTypes", "assertThatExceptionOfType", false);
                     maybeRemoveImport("org.junit.jupiter.api.Assertions.assertThrows");
                     maybeRemoveImport("org.junit.jupiter.api.Assertions");
                 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertTrueToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertTrueToAssertThat.java
@@ -97,7 +97,10 @@ public class JUnitAssertTrueToAssertThat extends Recipe {
                         );
             }
 
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat", false);
+
+            // Remove import for "org.junit.jupiter.api.Assertions" if no longer used.
             maybeRemoveImport("org.junit.jupiter.api.Assertions");
 
             return method;

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitFailToAssertJFail.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitFailToAssertJFail.java
@@ -145,7 +145,8 @@ public class JUnitFailToAssertJFail extends Recipe {
                                 method.getCoordinates().replace(),
                                 arguments.toArray()
                         );
-                maybeAddImport("org.assertj.core.api.Assertions", "fail");
+                //Make sure there is a static import for "org.assertj.core.api.Assertions.assertThat" (even if not referenced)
+                maybeAddImport("org.assertj.core.api.Assertions", "fail", false);
                 return super.visitMethodInvocation(method, ctx);
             }
         }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertNotNullToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertNotNullToAssertThatTest.java
@@ -246,8 +246,9 @@ class JUnitAssertNotNullToAssertThatTest implements RewriteTest {
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/491")
     void importAddedForCustomArguments() {
+        //language=java
         rewriteRun(
-          //language=java
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(
             """
               import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## What's changed?
Since commit https://github.com/openrewrite/rewrite-testing-frameworks/commit/368384a174bd92d49880c19a879fb9e14afcfa27 , AssertJ recipes are really slower since calling `contextSensitive()` method  disable a cache on JavaTemplate.

Fixes:
- Make sure there is a static import org.assertj.core.api.Assertions.* , even if not referenced (see #491 and #479)
- reintroduced assertionsParser cache in JUnitAssertEqualsToAssertThat
