### PR TITLE
Recipe to make tests throw at most a single Exception

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrows.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.cleanup;
+
+import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.NameCaseConvention;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J.MethodDeclaration;
+import org.openrewrite.marker.Markers;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class SimplifyTestThrows extends Recipe {
+
+    private static final String FQN_JAVA_LANG_EXCEPTION = "java.lang.Exception";
+
+    @Override
+    public String getDisplayName() {
+        return "Simplify `throws` statements of tests";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace all thrown exception classes of test method signatures by `Exception`.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofMinutes(1);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.or(
+                        new UsesType<>("org.junit.jupiter.api.Test", false),
+                        new UsesType<>("org.junit.jupiter.api.TestTemplate", false),
+                        new UsesType<>("org.junit.jupiter.api.RepeatedTest", false),
+                        new UsesType<>("org.junit.jupiter.params.ParameterizedTest", false),
+                        new UsesType<>("org.junit.jupiter.api.TestFactory", false)
+                ),
+                new SimplifyTestThrowsVisitor());
+    }
+
+    private static class SimplifyTestThrowsVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        @Override
+        public MethodDeclaration visitMethodDeclaration(MethodDeclaration method,
+                                                        ExecutionContext ctx) {
+            MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+            // reject invalid methods
+            if (TypeUtils.isOverride(m.getMethodType())
+                    || !hasJUnit5MethodAnnotation(method)
+                    || throwsIsMinimal(method)) {
+                return m;
+            }
+
+            // remove imports of the old exceptions
+            m.getThrows().forEach(t -> {
+                JavaType.FullyQualified type = TypeUtils.asFullyQualified(t.getType());
+                if (type != null) {
+                    maybeRemoveImport(type);
+                }
+            });
+
+            // overwrite the throws declarations
+            J.Identifier exceptionIdentifier = new J.Identifier(Tree.randomId(),
+                    Space.format(" "),
+                    Markers.EMPTY,
+                    emptyList(),
+                    "Exception",
+                    JavaType.ShallowClass.build(FQN_JAVA_LANG_EXCEPTION),
+                    null);
+            return m.withThrows(singletonList(exceptionIdentifier));
+        }
+
+        private boolean throwsIsMinimal(MethodDeclaration method) {
+            @Nullable List<NameTree> th = method.getThrows();
+            if (th == null || th.isEmpty()) {
+                return true;
+            }
+            if (th.size() > 1) {
+                return false;
+            }
+            @Nullable JavaType exType = th.get(0).getType();
+            return TypeUtils.isOfClassType(exType, FQN_JAVA_LANG_EXCEPTION);
+        }
+
+        private static boolean hasJUnit5MethodAnnotation(MethodDeclaration method) {
+            for (J.Annotation a : method.getLeadingAnnotations()) {
+                if (TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.Test")
+                        || TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.TestTemplate")
+                        || TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.RepeatedTest")
+                        || TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.params.ParameterizedTest")
+                        || TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.TestFactory")) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrows.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrowsTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SimplifyTestThrowsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "junit-jupiter-api-5.9", "junit-jupiter-params-5.9"))
+          .recipe(new SimplifyTestThrows());
+    }
+
+    @DocumentExample
+    @Test
+    void simplifyExceptions() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void throwsMultiple() throws IOException, ArrayIndexOutOfBoundsException, ClassCastException {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void throwsMultiple() throws Exception {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void normalMethodNoChanges() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.io.IOException;
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  void noTest() throws IOException {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noThrowsDeclaration() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+    
+              class ATest {
+                  @Test
+                  void noThrows() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usesGeneralExceptionAlready() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+    
+              class ATest {
+                  @Test
+                  void throwsEx() throws Exception {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/SimplifyTestThrowsTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.testing.cleanup;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -26,7 +25,6 @@ import org.openrewrite.test.RewriteTest;
 import static org.openrewrite.java.Assertions.java;
 
 class SimplifyTestThrowsTest implements RewriteTest {
-
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -117,5 +115,4 @@ class SimplifyTestThrowsTest implements RewriteTest {
           )
         );
     }
-
 }


### PR DESCRIPTION
## What's changed?
New recipe for replacing exception subclasses in test method signatures by java.lang.Exception, to improve readability. I'm not sure if there is any static code analysis guideline demanding this. I _am_ sure that there are different opinions by developers whether to declare `void test throws MyVerySpecialException` or just `...Exception`. Nevertheless I do need this recipe at work, and maybe it's useful for others, too.

## Anything in particular you'd like reviewers to focus on?
You may want to look at the DocumentExample in the test to see the main idea. Feel free to suggest a different name or description.
The "is this a test" detection has been copied from another recipe. I'm not sure if it would be useful to have some helper classes there to unify that.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
