### PR TITLE
Added to notMatchers

### DIFF
--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -275,6 +275,12 @@ recipeList:
   - org.openrewrite.java.testing.hamcrest.HamcrestNotMatcherToAssertJ:
       notMatcher: hasItem
       assertion: doesNotContain
+  - org.openrewrite.java.testing.hamcrest.HamcrestNotMatcherToAssertJ:
+      notMatcher: hasItems
+      assertion: doesNotContain
+  - org.openrewrite.java.testing.hamcrest.HamcrestNotMatcherToAssertJ:
+      notMatcher: empty
+      assertion: isNotEmpty
 
   # Add dependency if not already present
   - org.openrewrite.java.dependencies.AddDependency:


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
I've added 2 'notMatcher's to HamcrestNotMatcherToAssertJ.

## What's your motivation?
 I've added two notMatcher's that were not automatically changed in my project. By adding these two it fixed my problem.

## Anything in particular you'd like reviewers to focus on?
-

## Anyone you would like to review specifically?
-

## Have you considered any alternatives or workarounds?
-

## Any additional context
-

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
