### PR TITLE
Only upgrade maven-surefire-plugin on older Maven versions

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -63,16 +63,7 @@ recipeList:
       pluginArtifactId: maven-surefire-plugin
       groupId: org.apache.maven.surefire
       artifactId: surefire-junit*
-  - org.openrewrite.maven.AddPlugin:
-      groupId: org.apache.maven.plugins
-      artifactId: maven-surefire-plugin
-      version: 3.2.5
-  - org.openrewrite.maven.AddPluginDependency:
-      pluginGroupId: org.apache.maven.plugins
-      pluginArtifactId: maven-surefire-plugin
-      groupId: org.junit.platform
-      artifactId: junit-platform-surefire-provider
-      version: 1.1.0
+  - org.openrewrite.java.testing.junit5.UpgradeSurefirePlugin
   - org.openrewrite.java.testing.junit5.UseHamcrestAssertThat
   - org.openrewrite.java.testing.junit5.MigrateAssumptions
   - org.openrewrite.java.testing.junit5.UseMockitoExtension
@@ -317,3 +308,24 @@ recipeList:
       newGroupId: org.xmlunit
       newArtifactId: xmlunit-legacy
       newVersion: 2.x
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.junit5.UpgradeSurefirePlugin
+displayName: Upgrade Surefire Plugin
+description: Upgrades the Maven Surefire Plugin to the latest version if still using an older Maven version.
+preconditions:
+  - org.openrewrite.java.search.HasBuildToolVersion:
+      type: Maven
+      version: 0.0.1-3.5.4
+recipeList:
+  - org.openrewrite.maven.AddPlugin:
+      groupId: org.apache.maven.plugins
+      artifactId: maven-surefire-plugin
+      version: 3.2.5
+  - org.openrewrite.maven.AddPluginDependency:
+      pluginGroupId: org.apache.maven.plugins
+      pluginArtifactId: maven-surefire-plugin
+      groupId: org.junit.platform
+      artifactId: junit-platform-surefire-provider
+      version: 1.1.0
+

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Tree;
@@ -74,6 +75,7 @@ class JUnit5MigrationTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/145")
     void assertThatReceiver() {

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -374,10 +374,9 @@ class JUnit5MigrationTest implements RewriteTest {
     @Test
     void bumpSurefireOnOlderMavenVersions() {
         rewriteRun(
-          java("class A {}",
-            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4"))),
-          //language=xml
+          spec -> spec.recipeFromResource("/META-INF/rewrite/junit5.yml", "org.openrewrite.java.testing.junit5.UpgradeSurefirePlugin"),
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -386,6 +385,7 @@ class JUnit5MigrationTest implements RewriteTest {
                   <version>0.0.1</version>
               </project>
               """,
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -409,7 +409,8 @@ class JUnit5MigrationTest implements RewriteTest {
                       </plugins>
                   </build>
               </project>
-              """
+              """,
+            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4"))
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -18,13 +18,13 @@ package org.openrewrite.java.testing.junit5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Tree;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.marker.BuildTool;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.List;
-import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -170,22 +170,6 @@ class JUnit5MigrationTest implements RewriteTest {
                       <scope>test</scope>
                   </dependency>
               </dependencies>
-              <build>
-                  <plugins>
-                      <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-surefire-plugin</artifactId>
-                          <version>3.2.5</version>
-                          <dependencies>
-                              <dependency>
-                                  <groupId>org.junit.platform</groupId>
-                                  <artifactId>junit-platform-surefire-provider</artifactId>
-                                  <version>1.1.0</version>
-                              </dependency>
-                          </dependencies>
-                      </plugin>
-                  </plugins>
-              </build>
           </project>
           """;
         // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
@@ -229,22 +213,6 @@ class JUnit5MigrationTest implements RewriteTest {
                       <scope>test</scope>
                   </dependency>
               </dependencies>
-              <build>
-                  <plugins>
-                      <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-surefire-plugin</artifactId>
-                          <version>3.2.5</version>
-                          <dependencies>
-                              <dependency>
-                                  <groupId>org.junit.platform</groupId>
-                                  <artifactId>junit-platform-surefire-provider</artifactId>
-                                  <version>1.1.0</version>
-                              </dependency>
-                          </dependencies>
-                      </plugin>
-                  </plugins>
-              </build>
           </project>
           """;
         // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
@@ -343,7 +311,7 @@ class JUnit5MigrationTest implements RewriteTest {
               import org.junit.jupiter.api.AfterEach;
               import org.junit.jupiter.api.BeforeEach;
               import org.junit.jupiter.api.Test;
-                            
+              
               public class A extends AbstractTest {
                   @BeforeEach
                   public void before() {
@@ -368,54 +336,81 @@ class JUnit5MigrationTest implements RewriteTest {
           spec -> spec.beforeRecipe(withToolingApi()),
           //language=groovy
           buildGradle(
-                """
-            plugins {
-                id 'java-library'
-            }
-            repositories {
-                mavenCentral()
-            }
-            dependencies {
-                testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-            }
-            tasks.withType(Test).configureEach {
-                useJUnitPlatform()
-            }
-            """),
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+              }
+              tasks.withType(Test).configureEach {
+                  useJUnitPlatform()
+              }
+              """),
           //language=xml
           pomXml(
-                """
-            <project>
-                <modelVersion>4.0.0</modelVersion>
-                <groupId>dev.ted</groupId>
-                <artifactId>testcontainer-migrate</artifactId>
-                <version>0.0.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-api</artifactId>
-                        <version>5.7.2</version>
-                        <scope>test</scope>
-                    </dependency>
-                </dependencies>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <version>3.2.5</version>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.junit.platform</groupId>
-                                    <artifactId>junit-platform-surefire-provider</artifactId>
-                                    <version>1.1.0</version>
-                                </dependency>
-                            </dependencies>
-                        </plugin>
-                    </plugins>
-                </build>
-            </project>
-            """)
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>testcontainer-migrate</artifactId>
+                  <version>0.0.1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.junit.jupiter</groupId>
+                          <artifactId>junit-jupiter-api</artifactId>
+                          <version>5.7.2</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """)
+        );
+    }
+
+    @Test
+    void bumpSurefireOnOlderMavenVersions() {
+        rewriteRun(
+          java("class A {}",
+            spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4"))),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>testcontainer-migrate</artifactId>
+                  <version>0.0.1</version>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>testcontainer-migrate</artifactId>
+                  <version>0.0.1</version>
+                  <build>
+                      <plugins>
+                          <plugin>
+                              <groupId>org.apache.maven.plugins</groupId>
+                              <artifactId>maven-surefire-plugin</artifactId>
+                              <version>3.2.5</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>org.junit.platform</groupId>
+                                      <artifactId>junit-platform-surefire-provider</artifactId>
+                                      <version>1.1.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </plugin>
+                      </plugins>
+                  </build>
+              </project>
+              """
+          )
         );
     }
 }


### PR DESCRIPTION
## What's changed?
Add a precondition to only upgrade maven-surefire-plugin on older versions of Maven.

## What's your motivation?
Prevent adding noise when already using a recent Maven release.

## Any additional context
- https://github.com/openrewrite/rewrite/pull/4206