### PR TITLE
Do not reduce visibility on extended classes

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
@@ -17,25 +17,27 @@ package org.openrewrite.java.testing.cleanup;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
-import org.openrewrite.Recipe;
+import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.ChangeMethodAccessLevelVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Flag;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class TestsShouldNotBePublic extends Recipe {
+public class TestsShouldNotBePublic extends ScanningRecipe<TestsShouldNotBePublic.Accumulator> {
 
     @Option(displayName = "Remove protected modifiers",
             description = "Also remove protected modifiers from test methods",
@@ -60,16 +62,37 @@ public class TestsShouldNotBePublic extends Recipe {
     }
 
     @Override
-    public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new TestsNotPublicVisitor(Boolean.TRUE.equals(removeProtectedModifiers));
+    public Accumulator getInitialValue(ExecutionContext ctx) {
+        return new Accumulator();
     }
 
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Accumulator acc) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext executionContext) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, executionContext);
+                if (cd.getExtends() != null) {
+                    acc.extendedClasses.add(String.valueOf(cd.getExtends().getType()));
+                }
+                return cd;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        return new TestsNotPublicVisitor(Boolean.TRUE.equals(removeProtectedModifiers), acc);
+    }
+
+    public static class Accumulator {
+        Set<String> extendedClasses = new HashSet<>();
+    }
+
+    @RequiredArgsConstructor
     private static final class TestsNotPublicVisitor extends JavaIsoVisitor<ExecutionContext> {
         private final Boolean orProtected;
-
-        private TestsNotPublicVisitor(Boolean orProtected) {
-            this.orProtected = orProtected;
-        }
+        private final Accumulator acc;
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
@@ -77,8 +100,8 @@ public class TestsShouldNotBePublic extends Recipe {
 
             if (c.getKind() != J.ClassDeclaration.Kind.Type.Interface
                     && c.getModifiers().stream().anyMatch(mod -> mod.getType() == J.Modifier.Type.Public)
-                    && c.getModifiers().stream().noneMatch(mod -> mod.getType() == J.Modifier.Type.Abstract)) {
-
+                    && c.getModifiers().stream().noneMatch(mod -> mod.getType() == J.Modifier.Type.Abstract)
+                    && !acc.extendedClasses.contains(String.valueOf(c.getType()))) {
                 boolean hasTestMethods = c.getBody().getStatements().stream()
                         .filter(org.openrewrite.java.tree.J.MethodDeclaration.class::isInstance)
                         .map(J.MethodDeclaration.class::cast)

--- a/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.cleanup;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -488,6 +489,44 @@ class TestsShouldNotBePublicTest implements RewriteTest {
                   Collection<DynamicTest> testFactoryMethod() {
                       return null;
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/309")
+    void baseclassForTestsNeedsToStayPublic() {
+        //language=java
+        rewriteRun(
+          spec -> spec.recipe(new TestsShouldNotBePublic(true)),
+          java(
+            // base class for tests should stay public
+            """
+              package com.hello;
+
+              import org.junit.jupiter.api.BeforeEach;
+
+              public class MyTestBase {
+                @BeforeEach
+                void setUp() {
+                }
+              }
+              """
+          ),
+          java(
+            // test class extends base class from another package
+            """
+              package com.world;
+
+              import com.hello.MyTestBase;
+              import org.junit.jupiter.api.Test;
+
+              class MyTest extends MyTestBase {
+                @Test
+                void isWorking() {
+                }
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Turn `TestsShouldNotBePublic` into a `ScanningRecipe` that finds any extended classes, and excludes those from the recipe run.

## What's your motivation?
Fixes #309
- #309

## Anything in particular you'd like reviewers to focus on?
The approach of accumulating all extended classes is rather crude, but works. Didn't immediately see a good way to limit this further, as there's no guarantees as to features of classes that extend a common test base class, nor features that such a base class would have.