### PR TITLE
Add Picnic AssertJ rules to AssertJ best practices

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,9 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
-    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
+    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion") {
+        exclude(module = "jakarta.xml.bind-api")
+    }
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
     compileOnly("org.projectlombok:lombok:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
-    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion") {
-        exclude(module = "jakarta.xml.bind-api")
-    }
+    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
     compileOnly("org.projectlombok:lombok:latest.release")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
+    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
     compileOnly("org.projectlombok:lombok:latest.release")

--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyString.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyString.java
@@ -27,6 +27,13 @@ import org.openrewrite.java.tree.JavaType;
 
 import java.util.Collections;
 
+/**
+ * AssertJ has a more idiomatic way of asserting that a String is empty.
+ * This recipe will find instances of `assertThat(String).isEqualTo("")` and replace them with `isEmpty()`.
+ *
+ * @deprecated Use {@link tech.picnic.errorprone.refasterrules.AssertJStringRulesRecipes.AbstractStringAssertStringIsEmptyRecipe} instead.
+ */
+@Deprecated
 public class IsEqualToEmptyString extends Recipe {
 
     private static final MethodMatcher IS_EQUAL_TO = new MethodMatcher("org.assertj.core.api.AbstractStringAssert isEqualTo(java.lang.String)");

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -381,3 +381,4 @@ recipeList:
       version: 3.x
       onlyIfUsing: org.assertj.core.api.Assertions
       acceptTransitive: true
+  - tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -28,6 +28,22 @@ recipeList:
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.IsEqualToEmptyString
 
+  - tech.picnic.errorprone.refasterrules.AssertJBigDecimalRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJBigIntegerRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJBooleanRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJByteRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJCharSequenceRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJDoubleRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJFloatRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJIntegerRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJLongRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJNumberRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJPrimitiveRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJShortRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJStringRulesRecipes
+  - tech.picnic.errorprone.refasterrules.AssertJThrowingCallableRulesRecipes
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.assertj.StaticImports

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
@@ -24,13 +24,13 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class IsEqualToEmptyStringTest implements RewriteTest {
+class AssertJBestPracticesTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
-          .recipe(new IsEqualToEmptyString());
+          .recipeFromResources("org.openrewrite.java.testing.assertj.Assertj");
     }
 
     @DocumentExample


### PR DESCRIPTION
## What's your motivation?
Leverage existing Refaster recipes to apply more small fixes for users of AssertJ

## Anything in particular you'd like reviewers to focus on?
I'd tried to remove `AbstractStringAssertStringIsEmptyRecipe` to replace `IsEqualToEmptyString`, but that's not matching, possibly due to generics. (cc @knutwannheden)

## Additional context
- #513
- #525