### PR TITLE
Add Kotlin support for Junit 5 recipes 1: CleanupJUnitImports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-groovy")
+    testImplementation("org.openrewrite:rewrite-kotlin:$rewriteVersion")
     testImplementation("org.openrewrite.gradle.tooling:model:$rewriteVersion")
 
     testRuntimeOnly("org.gradle:gradle-tooling-api:latest.release")

--- a/src/main/java/org/openrewrite/java/testing/junit5/CleanupJUnitImports.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CleanupJUnitImports.java
@@ -22,6 +22,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 
 public class CleanupJUnitImports extends Recipe {
     @Override
@@ -44,14 +45,17 @@ public class CleanupJUnitImports extends Recipe {
 
     public static class CleanupJUnitImportsVisitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
-        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            for (J.Import im : cu.getImports()) {
-                String packageName = im.getPackageName();
-                if (packageName.startsWith("junit") || (packageName.startsWith("org.junit") && !packageName.contains("jupiter"))) {
-                    maybeRemoveImport(im.getTypeName());
+        public J preVisit(J tree, ExecutionContext ctx) {
+            if (tree instanceof JavaSourceFile) {
+                JavaSourceFile c = (JavaSourceFile) tree;
+                for (J.Import imp : c.getImports()) {
+                    String packageName = imp.getPackageName();
+                    if (packageName.startsWith("junit") || (packageName.startsWith("org.junit") && !packageName.contains("jupiter"))) {
+                        maybeRemoveImport(imp.getTypeName());
+                    }
                 }
             }
-            return cu;
+            return super.preVisit(tree, ctx);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/CleanupJUnitImports.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CleanupJUnitImports.java
@@ -46,6 +46,7 @@ public class CleanupJUnitImports extends Recipe {
     public static class CleanupJUnitImportsVisitor extends JavaIsoVisitor<ExecutionContext> {
         @Override
         public J preVisit(J tree, ExecutionContext ctx) {
+            stopAfterPreVisit();
             if (tree instanceof JavaSourceFile) {
                 JavaSourceFile c = (JavaSourceFile) tree;
                 for (J.Import imp : c.getImports()) {
@@ -55,7 +56,7 @@ public class CleanupJUnitImports extends Recipe {
                     }
                 }
             }
-            return super.preVisit(tree, ctx);
+            return tree;
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class CleanupJUnitImportsTest implements RewriteTest {
 
@@ -30,6 +32,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13"))
+          .parser(KotlinParser.builder()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13"))
           .recipe(new CleanupJUnitImports());
     }
@@ -50,6 +54,20 @@ class CleanupJUnitImportsTest implements RewriteTest {
               """
           )
         );
+
+        //language=kotlin
+        rewriteRun(
+          kotlin(
+            """
+              import org.junit.Test
+
+              class MyTest {}
+              """,
+            """
+              class MyTest {}
+              """
+          )
+        );
     }
 
     @Test
@@ -63,6 +81,20 @@ class CleanupJUnitImportsTest implements RewriteTest {
               import java.util.HashSet;
               
               public class MyTest {
+              }
+              """
+          )
+        );
+
+        //language=kotlin
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.Arrays
+              import java.util.Collections
+              import java.util.HashSet
+
+              class MyTest {
               }
               """
           )
@@ -84,5 +116,20 @@ class CleanupJUnitImportsTest implements RewriteTest {
               """
           )
         );
+
+        //language=kotlin
+        rewriteRun(
+          kotlin(
+            """
+              import org.junit.Test
+
+              class MyTest {
+                  @Test
+                  fun foo() {}
+              }
+              """
+          )
+        );
+
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CleanupJUnitImportsTest.java
@@ -41,8 +41,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
     @DocumentExample
     @Test
     void removesUnusedImport() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.Test;
@@ -52,11 +52,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
             """
               public class MyTest {}
               """
-          )
-        );
-
-        //language=kotlin
-        rewriteRun(
+          ),
+          //language=kotlin
           kotlin(
             """
               import org.junit.Test
@@ -72,8 +69,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
 
     @Test
     void leavesOtherImportsAlone() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import java.util.Arrays;
@@ -83,11 +80,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
               public class MyTest {
               }
               """
-          )
-        );
-
-        //language=kotlin
-        rewriteRun(
+          ),
+          //language=kotlin
           kotlin(
             """
               import java.util.Arrays
@@ -103,8 +97,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
 
     @Test
     void leavesUsedJUnitImportAlone() {
-        //language=java
         rewriteRun(
+          //language=java
           java(
             """
               import org.junit.Test;
@@ -114,11 +108,8 @@ class CleanupJUnitImportsTest implements RewriteTest {
                   public void foo() {}
               }
               """
-          )
-        );
-
-        //language=kotlin
-        rewriteRun(
+          ),
+          //language=kotlin
           kotlin(
             """
               import org.junit.Test


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Some of the recipes were not working with Kotlin code bases, i would like to add this one as a first example and will change the rest of the recipes the same way after the feedback. More MRs to follow. 

The change is around the usage of visitCompilationUnit, this visitor doesn't work with Kotlin codebases , i made the change to use preVisit, and this seems to fix it.

## What's your motivation?
we would like to make the recipes work on Kotlin codebases

## Anything in particular you'd like reviewers to focus on?
Please let me know if this is the correct way, especially to add tests for both Kotlin and Java together like the way I have done.

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 

## Have you considered any alternatives or workarounds?
Nope

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
