### PR TITLE
Jmockit Expectations with no times or result should be transformed to Mockito verify statement

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -968,6 +968,149 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
     }
 
     @Test
+    void whenMinTimes() {
+        //language=java
+        rewriteRun(
+          java(
+            """                                          
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                  
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait(anyLong, anyInt);
+                          minTimes = 2;
+                      }};
+                      myObject.wait(10L, 10);
+                  }
+              }
+              """,
+            """              
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                  
+                  void test() {
+                      myObject.wait(10L, 10);
+                      verify(myObject, atLeast(2)).wait(anyLong(), anyInt());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenMaxTimes() {
+        //language=java
+        rewriteRun(
+          java(
+            """                                          
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                  
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait(anyLong, anyInt);
+                          maxTimes = 5;
+                      }};
+                      myObject.wait(10L, 10);
+                  }
+              }
+              """,
+            """              
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                  
+                  void test() {
+                      myObject.wait(10L, 10);
+                      verify(myObject, atMost(5)).wait(anyLong(), anyInt());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenMinTimesMaxTimes() {
+        //language=java
+        rewriteRun(
+          java(
+            """                                          
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                  
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait(anyLong, anyInt);
+                          minTimes = 1;
+                          maxTimes = 3;
+                      }};
+                      myObject.wait(10L, 10);
+                  }
+              }
+              """,
+            """              
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                  
+                  void test() {
+                      myObject.wait(10L, 10);
+                      verify(myObject, atLeast(1)).wait(anyLong(), anyInt());
+                      verify(myObject, atMost(3)).wait(anyLong(), anyInt());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void whenSpy() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -209,19 +209,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                          
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -240,7 +240,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
@@ -275,19 +275,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                          
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField(anyString);
@@ -301,7 +301,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -335,21 +335,21 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                
+              
                   String expected = "expected";
-                
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -363,17 +363,17 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-                            
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                
+              
                   String expected = "expected";
-                
+              
                   void test() {
                       when(myObject.getSomeField()).thenReturn(expected);
                       assertEquals(expected, myObject.getSomeField());
@@ -398,19 +398,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertNotNull;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                          
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -424,7 +424,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertNotNull;
               import static org.mockito.Mockito.when;
 
@@ -579,7 +579,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import java.util.ArrayList;
               import java.util.List;
               
@@ -594,7 +594,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField((List<String>) any);
@@ -622,7 +622,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   MyObject myObject;
-                  
+              
                   void test() {
                       when(myObject.getSomeField(anyList())).thenReturn(null);
                       when(myObject.getSomeOtherField(any(Object.class))).thenReturn(null);
@@ -651,7 +651,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import java.util.ArrayList;
               import java.util.List;
               
@@ -666,7 +666,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -691,7 +691,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   MyObject myObject;
-                  
+              
                   void test() {
                       when(myObject.getSomeField()).thenReturn(null);
                       assertNull(myObject.getSomeField());
@@ -718,7 +718,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import java.util.ArrayList;
               import java.util.List;
               
@@ -733,7 +733,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                  
+              
                   void test() {
                       String bazz = "bazz";
                       new Expectations() {{
@@ -759,7 +759,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   MyObject myObject;
-                  
+              
                   void test() {
                       String bazz = "bazz";
                       when(myObject.getSomeField(eq("foo"), anyString(), eq(bazz), eq(10L))).thenReturn(null);
@@ -789,31 +789,31 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                          
+              
                   void test() {
                       String a = "a";
                       String s = "s";
-                      
+              
                       new Expectations() {{
                           myObject.getSomeField(anyString);
                           result = s;
-                          
+              
                           myObject.getString();
                           result = a;
                       }};
-                      
+              
                       assertEquals("s", myObject.getSomeField("foo"));
                       assertEquals("a", myObject.getString());
                   }
@@ -823,7 +823,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -836,11 +836,11 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   void test() {
                       String a = "a";
                       String s = "s";
-                      
+              
                       when(myObject.getSomeField(anyString())).thenReturn(s);
-                      
+              
                       when(myObject.getString()).thenReturn(a);
-                      
+              
                       assertEquals("s", myObject.getSomeField("foo"));
                       assertEquals("a", myObject.getString());
                   }
@@ -864,19 +864,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """
           ),
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                          
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                          
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                          
+              
                   void test() {
                       String a = "a";
                       new Expectations() {{
@@ -885,7 +885,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                           String b = "b";
                           result = s;
                       }};
-                      
+              
                       assertEquals("s", myObject.getSomeField("foo"));
                   }
               }
@@ -894,7 +894,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -909,7 +909,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       String s = "s";
                       String b = "b";
                       when(myObject.getSomeField(anyString())).thenReturn(s);
-                      
+              
                       assertEquals("s", myObject.getSomeField("foo"));
                   }
               }
@@ -923,17 +923,17 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """                                          
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -944,7 +944,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   }
               }
               """,
-            """              
+            """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
@@ -955,7 +955,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -986,14 +986,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Tested;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-    
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
-    
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Tested
                   MyObject myObject;
-    
+              
                   void test() {
                       new Expectations(myObject) {{
                           myObject.getSomeField();
@@ -1007,15 +1007,15 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.InjectMocks;
               import org.mockito.junit.jupiter.MockitoExtension;
-    
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-    
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @InjectMocks
                   MyObject myObject;
-    
+              
                   void test() {
                       when(myObject.getSomeField()).thenReturn("foo");
                       assertEquals("foo", myObject.getSomeField());
@@ -1060,10 +1060,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   @Mocked
                   MyObject myOtherObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.hashCode();
@@ -1106,7 +1106,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       assertNull(myOtherObject.getSomeObjectField());
                       myObject.wait(10L, 10);
                       assertEquals("foo", myOtherObject.getSomeStringField("bar", 10L));
-                      verify(myObject).wait(anyLong(), anyInt());                      
+                      verify(myObject).wait(anyLong(), anyInt());
                   }
               }
               """


### PR DESCRIPTION
Currently Jmockit Expectation statements when they do not have a times or result, when migrated to mockito disappear. However, when migrated to mockito, it should have a corresponding verify statement as per following documentation:
1. https://www.baeldung.com/jmockit-expectations section 2.4 "Then we used the default behavior (if no repetition constraint is given minTimes = 1; is used) to define that at least one invocation will be done to methodForTimes2()"
2. https://jmockit.github.io/tutorial/Mocking.html section 6.2

From my experience, when people specify this in the Expectation, it almost always corresponds to a mockito verify with no explicit times, basically saying that this statement occurs exactly once. 
In mockito usually times is used to specify the exact number of invocations and this gives more finegrained verification, whereas the JMockit Expectation the developer typically intends "exactly once" when specifying no times even though it really means at least once.

If we prefer to use at least once, I can modify it as such, but a simple verify with no times is usually what the original author of the JMockit Expectation intends.

### Checklist below done
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
