### PR TITLE
Drop Java 17 requirement through rewrite-third-party

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
-    implementation("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
     compileOnly("org.projectlombok:lombok:latest.release")

--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyString.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyString.java
@@ -30,10 +30,7 @@ import java.util.Collections;
 /**
  * AssertJ has a more idiomatic way of asserting that a String is empty.
  * This recipe will find instances of `assertThat(String).isEqualTo("")` and replace them with `isEmpty()`.
- *
- * @deprecated Use {@link tech.picnic.errorprone.refasterrules.AssertJStringRulesRecipes.AbstractStringAssertStringIsEmptyRecipe} instead.
  */
-@Deprecated
 public class IsEqualToEmptyString extends Recipe {
 
     private static final MethodMatcher IS_EQUAL_TO = new MethodMatcher("org.assertj.core.api.AbstractStringAssert isEqualTo(java.lang.String)");

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -28,22 +28,6 @@ recipeList:
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.IsEqualToEmptyString
 
-  - tech.picnic.errorprone.refasterrules.AssertJBigDecimalRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJBigIntegerRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJBooleanRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJByteRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJCharSequenceRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJDoubleRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJFloatRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJIntegerRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJLongRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJNumberRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJPrimitiveRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJShortRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJStringRulesRecipes
-  - tech.picnic.errorprone.refasterrules.AssertJThrowingCallableRulesRecipes
-
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.assertj.StaticImports
@@ -381,4 +365,3 @@ recipeList:
       version: 3.x
       onlyIfUsing: org.assertj.core.api.Assertions
       acceptTransitive: true
-  - tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes


### PR DESCRIPTION
## What's changed?
Drop rewrite-third-party dependency.

## What's your motivation?
Brought in a Java 17 requirement due to classes being compiled with Java 17, whereas we want to continue to support Java 8.

## Any additional context
- https://github.com/openrewrite/rewrite-third-party/issues/11