### PR TITLE
Add Kotlin support for JUnit recipes: UpdateBeforeAfterAnnotations

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotations.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotations.java
@@ -49,15 +49,13 @@ public class UpdateBeforeAfterAnnotations extends Recipe {
     public static class UpdateBeforeAfterAnnotationsVisitor extends JavaIsoVisitor<ExecutionContext> {
 
         @Override
-        public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            //This visitor handles changing the method visibility for any method annotated with one of the four before/after
-            //annotations. It registers visitors that will sweep behind it making the type changes.
+        public J preVisit(J tree, ExecutionContext ctx) {
+            stopAfterPreVisit();
             doAfterVisit(new ChangeType("org.junit.Before", "org.junit.jupiter.api.BeforeEach", true).getVisitor());
             doAfterVisit(new ChangeType("org.junit.After", "org.junit.jupiter.api.AfterEach", true).getVisitor());
             doAfterVisit(new ChangeType("org.junit.BeforeClass", "org.junit.jupiter.api.BeforeAll", true).getVisitor());
             doAfterVisit(new ChangeType("org.junit.AfterClass", "org.junit.jupiter.api.AfterAll", true).getVisitor());
-
-            return super.visitCompilationUnit(cu, ctx);
+            return tree;
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -18,12 +18,13 @@ package org.openrewrite.java.testing.junit5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class AddParameterizedTestAnnotationTest implements RewriteTest {
     @Override
@@ -31,10 +32,11 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9", "junit-jupiter-params-5.9"))
+          .parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9", "junit-jupiter-params-5.9"))
           .recipe(new AddParameterizedTestAnnotation());
     }
 
-    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/314")
     @Test
     @DocumentExample
     void replaceTestWithParameterizedTest() {
@@ -64,6 +66,35 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   @ValueSource(ints = {1, 3, 5, -3, 15, Integer.MAX_VALUE})
                   void testIsOdd(int number) {
                       assertTrue(number % 2 != 0);
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class NumbersTest {
+                  @Test
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class NumbersTest {
+                  @ParameterizedTest
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
                   }
               }
               """
@@ -102,6 +133,35 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   }
               }
               """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class NumbersTest {
+                  @Test
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class NumbersTest {
+                  @ParameterizedTest
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
+                  }
+              }
+              """
           )
         );
     }
@@ -122,6 +182,19 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   @Test
                   void printMessage() {
                       System.out.println("message");
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+
+              class NumbersTest {
+                  @Test
+                  fun printMessage() {
+                      System.out.println("message")
                   }
               }
               """
@@ -158,6 +231,33 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   }
               }
               """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.CsvSource
+              import org.junit.jupiter.api.Test
+
+              class TestClass {
+                  @Test
+                  @CsvSource(["test@test.com"])
+                  fun processUserData(email: String) {
+                      System.out.println(email)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.CsvSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(["test@test.com"])
+                  fun processUserData(email: String) {
+                      System.out.println(email)
+                  }
+              }
+              """
           )
         );
     }
@@ -188,6 +288,33 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   @MethodSource()
                   void foo() {
                       System.out.println("bar");
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.params.provider.MethodSource
+
+              class TestClass {
+                  @Test
+                  @MethodSource
+                  fun foo() {
+                      System.out.println("bar")
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.MethodSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @MethodSource
+                  fun foo() {
+                      System.out.println("bar")
                   }
               }
               """
@@ -226,6 +353,35 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   }
               }
               """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class TestClass {
+                  @Test
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.ValueSource
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(ints = [1, 3, 5, -3, 15, Int.MAX_VALUE])
+                  fun testIsOdd(number: Int) {
+                      assertTrue(number % 2 != 0)
+                  }
+              }
+              """
           )
         );
     }
@@ -256,6 +412,33 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   @NullSource
                   void processUserData(String email) {
                       System.out.println(email);
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.NullSource
+              import org.junit.jupiter.api.Test
+
+              class TestClass {
+                  @Test
+                  @NullSource
+                  fun processUserData(email: String?) {
+                      System.out.println(email)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.NullSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @NullSource
+                  fun processUserData(email: String?) {
+                      System.out.println(email)
                   }
               }
               """
@@ -292,6 +475,33 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   }
               }
               """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.EmptySource
+              import org.junit.jupiter.api.Test
+
+              class TestClass {
+                  @Test
+                  @EmptySource
+                  fun processUserData(email: String) {
+                      System.out.println(email)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.EmptySource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @EmptySource
+                  fun processUserData(email: String) {
+                      System.out.println(email)
+                  }
+              }
+              """
           )
         );
     }
@@ -322,6 +532,33 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   @NullAndEmptySource
                   void processUserData(String email) {
                       System.out.println(email);
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.NullAndEmptySource
+              import org.junit.jupiter.api.Test
+
+              class TestClass {
+                  @Test
+                  @NullAndEmptySource
+                  fun processUserData(email: String?) {
+                      System.out.println(email)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.NullAndEmptySource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @NullAndEmptySource
+                  fun processUserData(email: String?) {
+                      System.out.println(email)
                   }
               }
               """
@@ -372,6 +609,47 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   }
               }
               """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.EnumSource
+              import org.junit.jupiter.api.Test
+
+              class TestClass {
+                  enum class time {
+                      MORNING,
+                      NOON,
+                      AFTERNOON,
+                      MIDNIGHT
+                  }
+
+                  @Test
+                  @EnumSource
+                  fun processTime(timeOfDay: time) {
+                      System.out.println("Its " + timeOfDay)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.EnumSource
+
+              class TestClass {
+                  enum class time {
+                      MORNING,
+                      NOON,
+                      AFTERNOON,
+                      MIDNIGHT
+                  }
+
+                  @ParameterizedTest
+                  @EnumSource
+                  fun processTime(timeOfDay: time) {
+                      System.out.println("Its " + timeOfDay)
+                  }
+              }
+              """
           )
         );
     }
@@ -406,6 +684,37 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                   void testWithCsvFileSourceFromFile(String country, int reference) {
                       assertNotNull(country);
                       assertNotEquals(0, reference);
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.provider.CsvFileSource
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.api.Assertions.*
+
+              class TestClass {
+                  @Test
+                  @CsvFileSource(files = ["src/test/resources/two-column.csv"], numLinesToSkip = 1)
+                  fun testWithCsvFileSourceFromFile(country: String, reference: Int) {
+                      assertNotNull(country)
+                      assertNotEquals(0, reference)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.CsvFileSource
+              import org.junit.jupiter.api.Assertions.*
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvFileSource(files = ["src/test/resources/two-column.csv"], numLinesToSkip = 1)
+                  fun testWithCsvFileSourceFromFile(country: String, reference: Int) {
+                      assertNotNull(country)
+                      assertNotEquals(0, reference)
                   }
               }
               """
@@ -460,6 +769,54 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
                       @Override
                       public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
                           return Stream.of("apple", "banana").map(Arguments::of);
+                      }
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.extension.ExtensionContext
+              import org.junit.jupiter.params.provider.Arguments
+              import org.junit.jupiter.params.provider.ArgumentsProvider
+              import org.junit.jupiter.params.provider.ArgumentsSource
+              import org.junit.jupiter.api.Test
+              import java.util.stream.Stream
+              import org.junit.jupiter.api.Assertions.*
+
+              class TestClass {
+                  @Test
+                  @ArgumentsSource(MyArgumentsProvider::class)
+                  fun testWithArgumentsSource(argument: String) {
+                      assertNotNull(argument)
+                  }
+                  class MyArgumentsProvider : ArgumentsProvider {
+                      override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+                          return Stream.of("apple", "banana").map { Arguments.of(it) }
+                      }
+                  }
+              }
+              """,
+
+            """
+              import org.junit.jupiter.api.extension.ExtensionContext
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.Arguments
+              import org.junit.jupiter.params.provider.ArgumentsProvider
+              import org.junit.jupiter.params.provider.ArgumentsSource
+              import java.util.stream.Stream
+              import org.junit.jupiter.api.Assertions.*
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ArgumentsSource(MyArgumentsProvider::class)
+                  fun testWithArgumentsSource(argument: String) {
+                      assertNotNull(argument)
+                  }
+                  class MyArgumentsProvider : ArgumentsProvider {
+                      override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
+                          return Stream.of("apple", "banana").map { Arguments.of(it) }
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateBeforeAfterAnnotationsTest.java
@@ -15,16 +15,16 @@
  */
 package org.openrewrite.java.testing.junit5;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
@@ -34,8 +34,11 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13"))
+          .parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13"))
           .recipe(new UpdateBeforeAfterAnnotations());
     }
+
 
     @DocumentExample
     @Test
@@ -45,9 +48,9 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.Before;
-              
+                            
               class Test {
-              
+                            
                   @Before
                   void before() {
                   }
@@ -55,17 +58,41 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.BeforeEach;
-              
+                            
               class Test {
-              
+                            
                   @BeforeEach
                   void before() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.Before
+
+              class Test {
+
+                  @Before
+                  fun before() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeEach
+
+              class Test {
+
+                  @BeforeEach
+                  fun before() {
                   }
               }
               """
           )
         );
     }
+
 
     @Test
     void afterToAfterEach() {
@@ -74,9 +101,9 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.After;
-              
+                            
               class Test {
-              
+                            
                   @After
                   void after() {
                   }
@@ -84,17 +111,41 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.AfterEach;
-              
+                            
               class Test {
-              
+                            
                   @AfterEach
                   void after() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.After
+
+              class Test {
+
+                  @After
+                  fun after() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.AfterEach
+
+              class Test {
+
+                  @AfterEach
+                  fun after() {
                   }
               }
               """
           )
         );
     }
+
 
     @Test
     void beforeClassToBeforeAll() {
@@ -103,9 +154,9 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.BeforeClass;
-              
+                            
               class Test {
-              
+                            
                   @BeforeClass
                   void beforeClass() {
                   }
@@ -113,17 +164,41 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.BeforeAll;
-              
+                            
               class Test {
-              
+                            
                   @BeforeAll
                   void beforeClass() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.BeforeClass
+
+              class Test {
+
+                  @BeforeClass
+                  fun beforeClass() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeAll
+
+              class Test {
+
+                  @BeforeAll
+                  fun beforeClass() {
                   }
               }
               """
           )
         );
     }
+
 
     @Test
     void afterClassToAfterAll() {
@@ -132,7 +207,7 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.AfterClass;
-              
+                            
               class Test {
                   @AfterClass
                   void afterClass() {
@@ -141,10 +216,31 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.AfterAll;
-              
+                            
               class Test {
                   @AfterAll
                   void afterClass() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.AfterClass
+
+              class Test {
+                  @AfterClass
+                  fun afterClass() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.AfterAll
+
+              class Test {
+                  @AfterAll
+                  fun afterClass() {
                   }
               }
               """
@@ -152,8 +248,6 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/openrewrite/rewrite/issues/150")
-    @Disabled
     @Test
     void convertsToPackageVisibility() {
         //language=java
@@ -161,9 +255,9 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.Before;
-              
+                            
               class Test {
-              
+                            
                   @Before // comments
                   public void before() {
                   }
@@ -171,12 +265,34 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.BeforeEach;
-              
+                            
               class Test {
-              
-                  // comments
-                  @BeforeEach
-                  void before() {
+                            
+                  @BeforeEach // comments
+                  public void before() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.Before
+
+              class Test {
+
+                  @Before // comments
+                  fun before() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeEach
+
+              class Test {
+
+                  @BeforeEach // comments
+                  fun before() {
                   }
               }
               """
@@ -184,8 +300,8 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
         );
     }
 
+
     @Test
-    @Disabled("Issue #59")
     void beforeMethodOverridesPublicAbstract() {
         //language=java
         rewriteRun(
@@ -200,9 +316,9 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
           java(
             """
               import org.junit.Before;
-              
+                            
               public class A extends AbstractTest {
-              
+                            
                   @Before
                   public void setup() {
                   }
@@ -210,11 +326,42 @@ class UpdateBeforeAfterAnnotationsTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.BeforeEach;
-              
+                            
               public class A extends AbstractTest {
-              
+                            
                   @BeforeEach
                   public void setup() {
+                  }
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              abstract class AbstractTest {
+                  abstract fun setup()
+              }
+              """
+          ),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.Before
+
+              class A : AbstractTest() {
+
+                  @Before
+                  fun setup() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeEach
+
+              class A : AbstractTest() {
+
+                  @BeforeEach
+                  fun setup() {
                   }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

- Adding support for Kotlin to the UpdateBeforeAfterAnnotations recipe.
- Adding Kotlin tests for AddParameterizedTestAnnotation
- More to come

## What's your motivation?
Would like to make the recipes to work both with Java and Kotlin.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek @knutwannheden 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
