### PR TITLE
Add a NoMissingTypes Precondition to CleanupMockitoImports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     testRuntimeOnly("net.datafaker:datafaker:latest.release") {
         exclude(group = "org.yaml", module = "snakeyaml")
     }
+    testRuntimeOnly("org.mockito.kotlin:mockito-kotlin:latest.release")
     testRuntimeOnly("org.testcontainers:testcontainers:latest.release")
     testRuntimeOnly("org.testcontainers:nginx:latest.release")
 

--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -21,6 +21,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.NoMissingTypes;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -47,7 +48,12 @@ public class CleanupMockitoImports extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>("org.mockito.*", false), new CleanupMockitoImportsVisitor());
+        return Preconditions.check(
+                Preconditions.and(
+                        new NoMissingTypes(),
+                        new UsesType<>("org.mockito.*", false)
+                ),
+                new CleanupMockitoImportsVisitor());
     }
 
     private static class CleanupMockitoImportsVisitor extends JavaIsoVisitor<ExecutionContext> {

--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -21,7 +21,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.NoMissingTypes;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
@@ -49,10 +48,7 @@ public class CleanupMockitoImports extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                Preconditions.and(
-                        new NoMissingTypes(),
-                        new UsesType<>("org.mockito.*", false)
-                ),
+                new UsesType<>("org.mockito.*", false),
                 new CleanupMockitoImportsVisitor());
     }
 
@@ -110,12 +106,18 @@ public class CleanupMockitoImports extends Recipe {
 
                 for (J.Import _import : sf.getImports()) {
                     if (_import.getPackageName().startsWith("org.mockito")) {
-                        if (_import.isStatic()) {
+                        boolean isMockitoKotlinImport = _import.getPackageName().startsWith("org.mockito.kotlin");
+                        if (_import.isStatic() || isMockitoKotlinImport) {
                             String staticName = _import.getQualid().getSimpleName();
                             if ("*".equals(staticName) && !possibleMockitoMethod(unknownTypeMethodInvocationNames)) {
                                 maybeRemoveImport(_import.getPackageName() + "." + _import.getClassName());
                             } else if (!"*".equals(staticName) && !unknownTypeMethodInvocationNames.contains(staticName)) {
-                                maybeRemoveImport(_import.getPackageName() + "." + _import.getClassName() + "." + staticName);
+                                String fullyQualifiedName = _import.getPackageName();
+                                if (!isMockitoKotlinImport) {
+                                    fullyQualifiedName += "." + _import.getClassName();
+                                }
+                                fullyQualifiedName += "." + staticName;
+                                maybeRemoveImport(fullyQualifiedName);
                             }
                         } else if (qualifiedMethodInvocationNames.isEmpty()) {
                             maybeRemoveImport(_import.getPackageName() + "." + _import.getClassName());
@@ -152,8 +154,8 @@ public class CleanupMockitoImports extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, List<String> qualifiedMethods) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, qualifiedMethods);
                 if (MOCKITO_METHOD_NAMES.contains(mi.getSimpleName())
-                        && mi.getSelect() != null
-                        && TypeUtils.isAssignableTo("org.mockito.Mockito", mi.getSelect().getType())) {
+                    && mi.getSelect() != null
+                    && TypeUtils.isAssignableTo("org.mockito.Mockito", mi.getSelect().getType())) {
                     qualifiedMethods.add(mi.getSimpleName());
                 }
                 return mi;

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -276,6 +277,32 @@ class CleanupMockitoImportsTest implements RewriteTest {
               """,
             """
               public class MockitoArgumentMatchersTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveImportsIfMissingTypeInformation() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import org.mockito.kotlin.times;
+              import static org.mockito.Mockito.when;
+
+              class MyObjectTest {
+                MyObject myObject;
+                            
+                void test() {
+                  when(myObject.getSomeField()).thenReturn("testValue");
+                  verify(myObject, times(1)).getSomeField(); 
+                }
+              }
+              class MyObject {
+                String getSomeField() { return null; }
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Add a NoMissingTypes Precondition to CleanupMockitoImports, to prevent changes if types are missing

## What's your motivation?
Fix issue where `org.mockito.kotlin` imports were being removed although they were in use.
Following suggestion by @timtebeek in Slack channel.

## Anything in particular you'd like reviewers to focus on?
Possibly the unit test should use a Kotlin code block and not a Java one? not sure about this.

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
