### PR TITLE
Migrate JMockit Verifications to Mockito

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
@@ -60,6 +60,7 @@ class ArgumentMatchersRewriter {
     }
 
     private static final Map<JavaType.Primitive, String> PRIMITIVE_TO_MOCKITO_ARGUMENT_MATCHER = new HashMap<>();
+
     static {
         PRIMITIVE_TO_MOCKITO_ARGUMENT_MATCHER.put(JavaType.Primitive.Int, "anyInt");
         PRIMITIVE_TO_MOCKITO_ARGUMENT_MATCHER.put(JavaType.Primitive.Long, "anyLong");
@@ -81,7 +82,7 @@ class ArgumentMatchersRewriter {
         this.expectationsBlock = expectationsBlock;
     }
 
-    J.Block rewriteExpectationsBlock() {
+    J.Block rewriteJMockitBlock() {
         List<Statement> newStatements = new ArrayList<>(expectationsBlock.getStatements().size());
         for (Statement expectationStatement : expectationsBlock.getStatements()) {
             // for each statement, check if it's a method invocation and replace any argument matchers

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
@@ -161,7 +161,7 @@ class JMockitBlockRewriter {
         templateParams.add(invocation);
         templateParams.addAll(results);
 
-        methodBody = getMockitoTemplate(template, templateParams, nextStatementCoordinates);
+        methodBody = rewriteTemplate(template, templateParams, nextStatementCoordinates);
         if (!nextStatementCoordinates.isReplacement()) {
             numStatementsAdded += 1;
         }
@@ -207,10 +207,10 @@ class JMockitBlockRewriter {
         templateParams.add(invocation.getName().getSimpleName());
 
         String verifyTemplate = getVerifyTemplate(invocation.getArguments(), fqn, verificationMode, templateParams);
-        methodBody = getMockitoTemplate(verifyTemplate, templateParams, methodBody.getCoordinates().lastStatement());
+        methodBody = rewriteTemplate(verifyTemplate, templateParams, methodBody.getCoordinates().lastStatement());
     }
 
-    private J.Block getMockitoTemplate(String verifyTemplate, List<Object> templateParams, JavaCoordinates rewriteCoords) {
+    private J.Block rewriteTemplate(String verifyTemplate, List<Object> templateParams, JavaCoordinates rewriteCoords) {
         return JavaTemplate.builder(verifyTemplate)
                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-3.12"))
                 .staticImports("org.mockito.Mockito.*")

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
@@ -274,8 +274,7 @@ class JMockitBlockRewriter {
         return templateBuilder.toString();
     }
 
-    private static void appendToTemplate(StringBuilder templateBuilder, boolean buildingResults, String
-            templatePrefix,
+    private static void appendToTemplate(StringBuilder templateBuilder, boolean buildingResults, String templatePrefix,
                                          String templateField) {
         if (!buildingResults) {
             templateBuilder.append(templatePrefix);

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
@@ -160,11 +160,7 @@ class JMockitBlockRewriter {
 
         methodBody = rewriteTemplate(template, templateParams, nextStatementCoordinates);
         numStatementsAdded++;
-
-        // the next statement coordinates are directly after the most recently written statement, and subtracting the
-        // removed jmockit block
-        nextStatementCoordinates = methodBody.getStatements().get(bodyStatementIndex + numStatementsAdded - 1)
-                .getCoordinates().after();
+        setNextCoordinatesAfterLastStatementAdded();
     }
 
     private void removeBlock() {
@@ -178,7 +174,7 @@ class JMockitBlockRewriter {
         if (bodyStatementIndex == 0) {
             nextStatementCoordinates = methodBody.getCoordinates().firstStatement();
         } else {
-            nextStatementCoordinates = methodBody.getStatements().get(bodyStatementIndex - 1).getCoordinates().after();
+            setNextCoordinatesAfterLastStatementAdded();
         }
     }
 
@@ -205,7 +201,6 @@ class JMockitBlockRewriter {
         if (this.blockType == Verifications) {
             // for Verifications, replace the Verifications block
             verifyCoordinates = nextStatementCoordinates;
-            numStatementsAdded++;
         } else {
             // for Expectations put the verify at the end of the method
             verifyCoordinates = methodBody.getCoordinates().lastStatement();
@@ -213,8 +208,15 @@ class JMockitBlockRewriter {
 
         methodBody = rewriteTemplate(verifyTemplate, templateParams, verifyCoordinates);
         if (this.blockType == Verifications) {
-            nextStatementCoordinates = this.methodBody.getStatements().get(bodyStatementIndex + numStatementsAdded - 1).getCoordinates().after();
+            numStatementsAdded++;
+            setNextCoordinatesAfterLastStatementAdded();
         }
+    }
+
+    private void setNextCoordinatesAfterLastStatementAdded() {
+        // the next statement coordinates are directly after the most recently written statement, calculated by
+        // subtracting the removed jmockit block
+        this.nextStatementCoordinates = this.methodBody.getStatements().get(bodyStatementIndex + numStatementsAdded - 1).getCoordinates().after();
     }
 
     private J.Block rewriteTemplate(String verifyTemplate, List<Object> templateParams, JavaCoordinates rewriteCoords) {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockToMockito.java
@@ -70,12 +70,12 @@ public class JMockitBlockToMockito extends Recipe {
                 Statement s = statements.get(bodyStatementIndex);
                 Optional<JMockitBlockType> blockType = JMockitUtils.getJMockitBlock(s);
                 if (blockType.isPresent()) {
-                    JMockitBlockRewriter ebr = new JMockitBlockRewriter(this, ctx, methodBody,
+                    JMockitBlockRewriter blockRewriter = new JMockitBlockRewriter(this, ctx, methodBody,
                             ((J.NewClass) s), bodyStatementIndex, blockType.get());
-                    methodBody = ebr.rewriteMethodBody();
+                    methodBody = blockRewriter.rewriteMethodBody();
                     statements = methodBody.getStatements();
                     // if the expectations rewrite failed, skip the next statement
-                    if (ebr.isExpectationsRewriteFailed()) {
+                    if (blockRewriter.isRewriteFailed()) {
                         bodyStatementIndex++;
                     }
                 } else {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.jmockit;
 
 enum JMockitBlockType {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -1,0 +1,16 @@
+package org.openrewrite.java.testing.jmockit;
+
+enum JMockitBlockType {
+
+    Expectations("mockit.Expectations"), Verifications("mockit.Verifications"); // Add NonStrictExpectations later
+
+    private final String fqn;
+
+    JMockitBlockType(String fqn) {
+        this.fqn = fqn;
+    }
+
+    String getFqn() {
+        return fqn;
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -15,17 +15,15 @@
  */
 package org.openrewrite.java.testing.jmockit;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 enum JMockitBlockType {
 
-    Expectations("mockit.Expectations"), Verifications("mockit.Verifications"); // Add NonStrictExpectations later
+    Expectations("mockit.Expectations"),
+    Verifications("mockit.Verifications"); // Add NonStrictExpectations later
 
     private final String fqn;
-
-    JMockitBlockType(String fqn) {
-        this.fqn = fqn;
-    }
-
-    String getFqn() {
-        return fqn;
-    }
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -35,15 +35,16 @@ class JMockitUtils {
         }
         J.Identifier clazz = (J.Identifier) nc.getClazz();
 
+        // JMockit block should be composed of a block within another block
+        if (nc.getBody() == null || nc.getBody().getStatements().size() != 1) {
+            return empty();
+        }
+
         for (JMockitBlockType blockType : JMockitBlockType.values()) {
             if (TypeUtils.isAssignableTo(blockType.getFqn(), clazz.getType())) {
-                // JMockit block should be composed of a block within another block
-                if (nc.getBody() != null && nc.getBody().getStatements().size() == 1) {
-                    return Optional.of(blockType);
-                }
+                return Optional.of(blockType);
             }
         }
         return empty();
     }
-
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -19,20 +19,31 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+
 class JMockitUtils {
-    static boolean isValidExpectationsNewClassStatement(Statement s) {
+
+    static Optional<JMockitBlockType> getJMockitBlock(Statement s) {
         if (!(s instanceof J.NewClass)) {
-            return false;
+            return empty();
         }
         J.NewClass nc = (J.NewClass) s;
         if (!(nc.getClazz() instanceof J.Identifier)) {
-            return false;
+            return empty();
         }
         J.Identifier clazz = (J.Identifier) nc.getClazz();
-        if (!TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType())) {
-            return false;
+
+        for (JMockitBlockType blockType : JMockitBlockType.values()) {
+            if (TypeUtils.isAssignableTo(blockType.getFqn(), clazz.getType())) {
+                // JMockit block should be composed of a block within another block
+                if (nc.getBody() != null && nc.getBody().getStatements().size() == 1) {
+                    return Optional.of(blockType);
+                }
+            }
         }
-        // Expectations block should be composed of a block within another block
-        return nc.getBody() != null && nc.getBody().getStatements().size() == 1;
+        return empty();
     }
+
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
@@ -36,7 +36,7 @@ class SetupStatementsRewriter {
 
     J.Block rewriteMethodBody() {
         List<Statement> statements = methodBody.getStatements();
-        // iterate over each statement in the method body, find Expectations blocks and rewrite them
+        // iterate over each statement in the method body, find JMockit blocks and rewrite them
         for (Statement s : statements) {
             if (!JMockitUtils.getJMockitBlock(s).isPresent()) {
                 continue;

--- a/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
@@ -38,7 +38,7 @@ class SetupStatementsRewriter {
         List<Statement> statements = methodBody.getStatements();
         // iterate over each statement in the method body, find Expectations blocks and rewrite them
         for (Statement s : statements) {
-            if (!JMockitUtils.isValidExpectationsNewClassStatement(s)) {
+            if (!JMockitUtils.getJMockitBlock(s).isPresent()) {
                 continue;
             }
             J.NewClass nc = (J.NewClass) s;

--- a/src/main/resources/META-INF/rewrite/jmockit.yml
+++ b/src/main/resources/META-INF/rewrite/jmockit.yml
@@ -22,7 +22,7 @@ tags:
   - testing
   - jmockit
 recipeList:
-  - org.openrewrite.java.testing.jmockit.JMockitExpectationsToMockito
+  - org.openrewrite.java.testing.jmockit.JMockitBlockToMockito
   - org.openrewrite.java.testing.jmockit.JMockitAnnotatedArgumentToMockito
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.Mocked

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -71,7 +71,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
@@ -118,7 +118,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.verify;
 
               @ExtendWith(MockitoExtension.class)
@@ -155,7 +155,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
 
               @ExtendWith(JMockitExtension.class)
@@ -176,7 +176,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.when;
 
@@ -214,14 +214,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -240,7 +240,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
@@ -280,14 +280,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField(anyString);
@@ -301,7 +301,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -340,16 +340,16 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   String expected = "expected";
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -363,17 +363,17 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                            
+
                   String expected = "expected";
-                            
+
                   void test() {
                       when(myObject.getSomeField()).thenReturn(expected);
                       assertEquals(expected, myObject.getSomeField());
@@ -403,14 +403,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNotNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -424,7 +424,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNotNull;
               import static org.mockito.Mockito.when;
 
@@ -518,7 +518,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               @ExtendWith(JMockitExtension.class)
@@ -567,7 +567,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           java(
             """
               import java.util.List;
-                            
+
               class MyObject {
                   public String getSomeField(List<String> input) {
                       return "X";
@@ -582,19 +582,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField((List<String>) any);
@@ -610,19 +610,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                            
+
                   void test() {
                       when(myObject.getSomeField(anyList())).thenReturn(null);
                       when(myObject.getSomeOtherField(any(Object.class))).thenReturn(null);
@@ -642,7 +642,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           java(
             """
               import java.util.List;
-                            
+
               class MyObject {
                   public String getSomeField() {
                       return "X";
@@ -654,19 +654,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeField();
@@ -679,19 +679,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.when;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                            
+
                   void test() {
                       when(myObject.getSomeField()).thenReturn(null);
                       assertNull(myObject.getSomeField());
@@ -709,7 +709,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           java(
             """
               import java.util.List;
-                            
+
               class MyObject {
                   public String getSomeField(String s, String s2, String s3, long l1) {
                       return "X";
@@ -721,19 +721,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       String bazz = "bazz";
                       new Expectations() {{
@@ -747,19 +747,19 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                            
+
                   void test() {
                       String bazz = "bazz";
                       when(myObject.getSomeField(eq("foo"), anyString(), eq(bazz), eq(10L))).thenReturn(null);
@@ -778,7 +778,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           java(
             """
               class MyObject {
-                            
+
                   public String getSomeField(String s) {
                       return "X";
                   }
@@ -794,26 +794,26 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       String a = "a";
                       String s = "s";
-                            
+
                       new Expectations() {{
                           myObject.getSomeField(anyString);
                           result = s;
-                            
+
                           myObject.getString();
                           result = a;
                       }};
-                            
+
                       assertEquals("s", myObject.getSomeField("foo"));
                       assertEquals("a", myObject.getString());
                   }
@@ -823,7 +823,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -838,7 +838,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       String s = "s";
                       when(myObject.getSomeField(anyString())).thenReturn(s);
                       when(myObject.getString()).thenReturn(a);
-                            
+
                       assertEquals("s", myObject.getSomeField("foo"));
                       assertEquals("a", myObject.getString());
                   }
@@ -867,14 +867,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       String a = "a";
                       new Expectations() {{
@@ -883,7 +883,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                           String b = "b";
                           result = s;
                       }};
-                            
+
                       assertEquals("s", myObject.getSomeField("foo"));
                   }
               }
@@ -892,7 +892,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
               import static org.mockito.Mockito.when;
@@ -907,7 +907,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       String s = "s";
                       String b = "b";
                       when(myObject.getSomeField(anyString())).thenReturn(s);
-                            
+
                       assertEquals("s", myObject.getSomeField("foo"));
                   }
               }
@@ -926,12 +926,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -947,14 +947,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -972,12 +972,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """                                          
+            """              
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -996,9 +996,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -1019,12 +1019,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """                                          
+            """              
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -1043,9 +1043,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -1066,12 +1066,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """                                          
+            """              
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -1091,9 +1091,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -1129,14 +1129,14 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Tested;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Tested
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations(myObject) {{
                           myObject.getSomeField();
@@ -1150,15 +1150,15 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.InjectMocks;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @InjectMocks
                   MyObject myObject;
-                            
+
                   void test() {
                       when(myObject.getSomeField()).thenReturn("foo");
                       assertEquals("foo", myObject.getSomeField());
@@ -1195,18 +1195,18 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   @Mocked
                   MyObject myOtherObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.hashCode();
@@ -1276,15 +1276,15 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.getSomeStringField();
@@ -1335,15 +1335,15 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong);

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -1375,7 +1375,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       myObject.wait(1L);
                       myObject.wait();
                       verify(myObject).wait(anyLong());
-                      verify(myObject).wait();                
+                      verify(myObject).wait();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -836,9 +836,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   void test() {
                       String a = "a";
                       String s = "s";
-                            
                       when(myObject.getSomeField(anyString())).thenReturn(s);
-                            
                       when(myObject.getString()).thenReturn(a);
                             
                       assertEquals("s", myObject.getSomeField("foo"));
@@ -1377,7 +1375,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       myObject.wait(1L);
                       myObject.wait();
                       verify(myObject).wait(anyLong());
-                      verify(myObject).wait();                  
+                      verify(myObject).wait();                
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -160,21 +160,19 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.List;
                             
-              import mockit.Verifications;
               import mockit.Mocked;
+              import mockit.Verifications;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+                                                        
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
                             
                   void test() {
-                      assertNull(myObject.getSomeField(new ArrayList<>()));
-                      assertNull(myObject.getSomeOtherField(new Object()));
+                      myObject.getSomeField(new ArrayList<>());
+                      myObject.getSomeOtherField(new Object());
                       new Verifications() {{
                           myObject.getSomeField((List<String>) any);
                           myObject.getSomeOtherField((Object) any);
@@ -189,19 +187,15 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.any;
-              import static org.mockito.Mockito.anyList;
-                            
+                                                        
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
                             
                   void test() {
-                      assertNull(myObject.getSomeField(new ArrayList<>()));
-                      assertNull(myObject.getSomeOtherField(new Object()));
+                      myObject.getSomeField(new ArrayList<>());
+                      myObject.getSomeOtherField(new Object());
                       verify(myObject).getSomeField(anyList());
                       verify(myObject).getSomeOtherField(any(Object.class));
                   }
@@ -217,17 +211,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import java.util.List;
-                            
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
               import java.util.ArrayList;
               import java.util.List;
                             
@@ -235,16 +218,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+                            
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
-                  MyObject myObject;
+                  Object myObject;
                             
                   void test() {
-                      myObject.getSomeField();
+                      myObject.wait();
+                      myObject.wait();
                       new Verifications() {{
-                          myObject.getSomeField();
+                          myObject.wait();
+                          times = 2;
                       }};
                   }
               }
@@ -253,20 +238,21 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.List;
                             
+              import static org.mockito.Mockito.times;
+              import static org.mockito.Mockito.verify;
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.mockito.Mockito.verify;
-                            
+                                                        
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
-                  MyObject myObject;
+                  Object myObject;
                             
                   void test() {
-                      myObject.getSomeField();
-                      verify(myObject).getSomeField();
+                      myObject.wait();
+                      myObject.wait();
+                      verify(myObject, times(2)).wait();
                   }
               }
               """
@@ -363,8 +349,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
                             
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -373,14 +357,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   void test() {
                       String a = "a";
                       String s = "s";
-                      assertEquals("s", myObject.getSomeField("foo"));
-                      assertEquals("a", myObject.getString());
+                      myObject.getSomeField("foo");
+                      myObject.getString();
                       new Verifications() {{
-                          myObject.getSomeField(anyString);
-                          result = s;
-                            
+                          myObject.getSomeField(anyString);                            
                           myObject.getString();
-                          result = a;
                       }};
                   }
               }
@@ -390,7 +371,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
                             
-              import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
@@ -401,8 +381,8 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   void test() {
                       String a = "a";
                       String s = "s";                           
-                      assertEquals("s", myObject.getSomeField("foo"));
-                      assertEquals("a", myObject.getString());
+                      myObject.getSomeField("foo");
+                      myObject.getString();
                       verify(myObject).getSomeField(anyString());            
                       verify(myObject).getString();
                   }
@@ -427,28 +407,22 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           ),
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
+                                                        
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
                             
                   void test() {
-                      String a = "a";
-                      new Expectations() {{
+                      String a = "a";                            
+                      myObject.getSomeField("foo");
+                      new Verifications() {{
                           myObject.getSomeField(anyString);
-                          String s = "s";
-                          String b = "b";
-                          result = s;
-                      }};
-                            
-                      assertEquals("s", myObject.getSomeField("foo"));
+                      }};                      
                   }
               }
               """,
@@ -459,7 +433,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                             
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyString;
-              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.verify;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -468,11 +442,8 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
 
                   void test() {
                       String a = "a";
-                      String s = "s";
-                      String b = "b";
-                      when(myObject.getSomeField(anyString())).thenReturn(s);
-                            
-                      assertEquals("s", myObject.getSomeField("foo"));
+                      myObject.getSomeField("foo");
+                      verify(myObject).getSomeField(anyString());
                   }
               }
               """
@@ -486,7 +457,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -497,13 +468,13 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
                             
                   void test() {
-                      new Expectations() {{
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                           times = 3;
-                      }};
-                      myObject.wait(10L, 10);
-                      myObject.wait(10L, 10);
-                      myObject.wait(10L, 10);
+                      }};                      
                   }
               }
               """,
@@ -537,7 +508,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
         rewriteRun(
           java(
             """                                          
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -548,11 +519,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
                   
                   void test() {
-                      new Expectations() {{
+                      myObject.wait(10L, 10);
+                      new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                           minTimes = 2;
                       }};
-                      myObject.wait(10L, 10);
                   }
               }
               """,
@@ -584,7 +555,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
         rewriteRun(
           java(
             """                                          
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -595,11 +566,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
                   
                   void test() {
-                      new Expectations() {{
+                      myObject.wait(10L, 10);
+                      new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                           maxTimes = 5;
                       }};
-                      myObject.wait(10L, 10);
                   }
               }
               """,
@@ -631,7 +602,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
         rewriteRun(
           java(
             """                                          
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -642,12 +613,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
                   
                   void test() {
-                      new Expectations() {{
+                      myObject.wait(10L, 10);
+                      new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                           minTimes = 1;
                           maxTimes = 3;
                       }};
-                      myObject.wait(10L, 10);
                   }
               }
               """,
@@ -667,65 +638,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(1)).wait(anyLong(), anyInt());
                       verify(myObject, atMost(3)).wait(anyLong(), anyInt());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenSpy() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Tested;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Tested
-                  MyObject myObject;
-                            
-                  void test() {
-                      new Expectations(myObject) {{
-                          myObject.getSomeField();
-                          result = "foo";
-                      }};
-                      assertEquals("foo", myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.InjectMocks;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.when;
-                            
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @InjectMocks
-                  MyObject myObject;
-                            
-                  void test() {
-                      when(myObject.getSomeField()).thenReturn("foo");
-                      assertEquals("foo", myObject.getSomeField());
                   }
               }
               """
@@ -755,13 +667,10 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           ),
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
                             
               @ExtendWith(JMockitExtension.class)
               class MyTest {
@@ -772,19 +681,16 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   MyObject myOtherObject;
                             
                   void test() {
-                      new Expectations() {{
+                      myObject.hashCode();
+                      myOtherObject.getSomeObjectField();
+                      myObject.wait(10L, 10);
+                      myOtherObject.getSomeStringField("bar", 10L);
+                      new Verifications() {{
                           myObject.hashCode();
-                          result = 10;
                           myOtherObject.getSomeObjectField();
-                          result = null;
                           myObject.wait(anyLong, anyInt);
                           myOtherObject.getSomeStringField(anyString, anyLong);
-                          result = "foo";
-                      }};
-                      assertEquals(10, myObject.hashCode());
-                      assertNull(myOtherObject.getSomeObjectField());
-                      myObject.wait(10L, 10);
-                      assertEquals("foo", myOtherObject.getSomeStringField("bar", 10L));
+                      }};                      
                   }
               }
               """,
@@ -793,8 +699,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
 
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
@@ -806,14 +710,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   MyObject myOtherObject;
 
                   void test() {
-                      when(myObject.hashCode()).thenReturn(10);
-                      when(myOtherObject.getSomeObjectField()).thenReturn(null);
-                      when(myOtherObject.getSomeStringField(anyString(), anyLong())).thenReturn("foo");
-                      assertEquals(10, myObject.hashCode());
-                      assertNull(myOtherObject.getSomeObjectField());
+                      myObject.hashCode();
+                      myOtherObject.getSomeObjectField();
                       myObject.wait(10L, 10);
-                      assertEquals("foo", myOtherObject.getSomeStringField("bar", 10L));
+                      myOtherObject.getSomeStringField("bar", 10L);
+                      verify(myObject).hashCode();
+                      verify(myOtherObject).getSomeObjectField();
                       verify(myObject).wait(anyLong(), anyInt());
+                      verify(myOtherObject).getSomeStringField(anyString(), anyLong());
                   }
               }
               """
@@ -822,86 +726,16 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenMultipleExpectations() {
+        //TODO Preferably Verifications should be replaced inline and not appended to end of the method
+    void whenMultipleVerifications() {
         //language=java
         rewriteRun(
           java(
             """
-              class MyObject {
-                  public String getSomeStringField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-                            
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeStringField();
-                          result = "a";
-                      }};
-                      assertEquals("a", myObject.getSomeStringField());
-                      new Expectations() {{
-                          myObject.getSomeStringField();
-                          result = "b";
-                      }};
-                      assertEquals("b", myObject.getSomeStringField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() {
-                      when(myObject.getSomeStringField()).thenReturn("a");
-                      assertEquals("a", myObject.getSomeStringField());
-                      when(myObject.getSomeStringField()).thenReturn("b");
-                      assertEquals("b", myObject.getSomeStringField());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenMultipleExpectationsNoResults() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
                             
               @ExtendWith(JMockitExtension.class)
               class MyTest {
@@ -909,14 +743,16 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
                             
                   void test() {
-                      new Expectations() {{
-                          myObject.wait(anyLong);
-                      }};
-                      myObject.wait(1L);
-                      new Expectations() {{
+                      myObject.wait();
+                      new Verifications() {{
                           myObject.wait();
                       }};
-                      myObject.wait();
+                      myObject.wait(1L);
+                      myObject.wait(2L);
+                      new Verifications() {{
+                          myObject.wait(anyLong);
+                          times = 2;
+                      }};
                   }
               }
               """,
@@ -925,10 +761,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
 
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.anyLong;
-              import static org.mockito.Mockito.verify;
+              import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -936,10 +769,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      myObject.wait(1L);
                       myObject.wait();
-                      verify(myObject).wait(anyLong());
-                      verify(myObject).wait();                  
+                      myObject.wait(1L);
+                      myObject.wait(2L);
+                      verify(myObject).wait();
+                      verify(myObject, times(2)).wait(anyLong());
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -71,7 +72,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
@@ -118,7 +119,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.verify;
 
               @ExtendWith(MockitoExtension.class)
@@ -145,17 +146,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait();
                       myObject.wait();
@@ -169,18 +170,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import static org.mockito.Mockito.times;
               import static org.mockito.Mockito.verify;
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                                                        
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait();
                       myObject.wait();
@@ -196,10 +197,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
     void whenClassArgumentMatcher() {
         //language=java
         rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import java.util.List;
-                            
+
               class MyObject {
                   public String getSomeField(List<String> input) {
                       return "X";
@@ -214,17 +216,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Mocked;
               import mockit.Verifications;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                                                        
+
               @ExtendWith(JMockitExtension.class)
-              class MyTest {                                     
+              class MyTest {
                   @Mocked
                   MyObject myObject;
-                            
+
                   void test() {
                       myObject.getSomeField(new ArrayList<>());
                       myObject.getSomeOtherField(new Object());
@@ -238,16 +240,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                                                        
+
+              import static org.mockito.Mockito.*;
+
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                                                                                    
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-                            
+
                   void test() {
                       myObject.getSomeField(new ArrayList<>());
                       myObject.getSomeOtherField(new Object());
@@ -269,17 +273,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -291,9 +295,9 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
@@ -302,7 +306,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject).wait(anyLong(), eq(10));
@@ -323,12 +327,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       String a = "a";
                       String s = "s";
@@ -345,7 +349,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.verify;
 
@@ -383,7 +387,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       String a = "a";
                       myObject.wait(1L);
@@ -397,7 +401,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.verify;
 
@@ -427,12 +431,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -448,14 +452,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -478,7 +482,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -497,9 +501,9 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -525,7 +529,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -544,9 +548,9 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -572,7 +576,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -592,9 +596,9 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
-                            
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -626,10 +630,10 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   @Mocked
                   Object myOtherObject;
-                            
+
                   void test() {
                       myObject.hashCode();
                       myOtherObject.wait();
@@ -648,7 +652,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+
               import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
@@ -685,18 +689,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                            
+
                   void test() {
                       myObject.wait();
                       new Verifications() {{
-                      
+
                           myObject.wait();
-                          
+
                           myObject.wait(anyLong, anyInt);
                       }};
                       myObject.wait(1L);

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class JMockitExpectationsToMockitoTest implements RewriteTest {
+class JMockitVerificationsToMockitoTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
@@ -44,12 +44,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void whenNoResultNoTimes() {
+    void whenNoTimes() {
         //language=java
         rewriteRun(
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,10 +60,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      new Expectations() {{
+                      myObject.wait(10L, 10);             
+                      new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                       }};
-                      myObject.wait(10L, 10);
                   }
               }
               """,
@@ -91,12 +91,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void whenNoResultNoTimesNoArgs() {
+    void whenNoTimesNoArgs() {
         //language=java
         rewriteRun(
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,10 +107,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      new Expectations() {{
-                          myObject.wait();
-                      }};
                       myObject.wait(10L, 10);
+                      new Verifications() {{
+                          myObject.wait();
+                      }};                      
                   }
               }
               """,
@@ -136,429 +136,6 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         );
     }
 
-    @Test
-    void whenNullResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
-
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          result = null;
-                      }};
-                      assertNull(myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() {
-                      when(myObject.getSomeField()).thenReturn(null);
-                      assertNull(myObject.getSomeField());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenIntResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public int getSomeField() {
-                      return 0;
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-                            
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          result = 10;
-                      }};
-                      assertEquals(10, myObject.getSomeField());
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          this.result = 100;
-                      }};
-                      assertEquals(100, myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() {
-                      when(myObject.getSomeField()).thenReturn(10);
-                      assertEquals(10, myObject.getSomeField());
-                      when(myObject.getSomeField()).thenReturn(100);
-                      assertEquals(100, myObject.getSomeField());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenStringResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField(String s) {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-                            
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeField(anyString);
-                          result = "foo";
-                      }};
-                      assertEquals("foo", myObject.getSomeField("bar"));
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.anyString;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() {
-                      when(myObject.getSomeField(anyString())).thenReturn("foo");
-                      assertEquals("foo", myObject.getSomeField("bar"));
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenVariableResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-                            
-                  String expected = "expected";
-                            
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          result = expected;
-                      }};
-                      assertEquals(expected, myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.when;
-                            
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-                            
-                  String expected = "expected";
-                            
-                  void test() {
-                      when(myObject.getSomeField()).thenReturn(expected);
-                      assertEquals(expected, myObject.getSomeField());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenNewClassResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public Object getSomeField() {
-                      return null;
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNotNull;
-                            
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-                            
-                  void test() {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          result = new Object();
-                      }};
-                      assertNotNull(myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNotNull;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() {
-                      when(myObject.getSomeField()).thenReturn(new Object());
-                      assertNotNull(myObject.getSomeField());
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenExceptionResult() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-
-                  void test() throws RuntimeException {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          result = new RuntimeException();
-                      }};
-                      myObject.getSomeField();
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() throws RuntimeException {
-                      when(myObject.getSomeField()).thenThrow(new RuntimeException());
-                      myObject.getSomeField();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void whenReturns() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class MyObject {
-                  public String getSomeField() {
-                      return "X";
-                  }
-              }
-              """
-          ),
-          java(
-            """
-              import mockit.Expectations;
-              import mockit.Mocked;
-              import mockit.integration.junit5.JMockitExtension;
-              import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-
-              @ExtendWith(JMockitExtension.class)
-              class MyTest {
-                  @Mocked
-                  MyObject myObject;
-
-                  void test() throws RuntimeException {
-                      new Expectations() {{
-                          myObject.getSomeField();
-                          returns("foo", "bar");
-                      }};
-                      assertEquals("foo", myObject.getSomeField());
-                      assertEquals("bar", myObject.getSomeField());
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.when;
-
-              @ExtendWith(MockitoExtension.class)
-              class MyTest {
-                  @Mock
-                  MyObject myObject;
-
-                  void test() throws RuntimeException {
-                      when(myObject.getSomeField()).thenReturn("foo", "bar");
-                      assertEquals("foo", myObject.getSomeField());
-                      assertEquals("bar", myObject.getSomeField());
-                  }
-              }
-              """
-          )
-        );
-    }
 
     @Test
     void whenClassArgumentMatcher() {
@@ -583,7 +160,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.List;
                             
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -596,14 +173,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   MyObject myObject;
                             
                   void test() {
-                      new Expectations() {{
-                          myObject.getSomeField((List<String>) any);
-                          result = null;
-                          myObject.getSomeOtherField((Object) any);
-                          result = null;
-                      }};
                       assertNull(myObject.getSomeField(new ArrayList<>()));
                       assertNull(myObject.getSomeOtherField(new Object()));
+                      new Verifications() {{
+                          myObject.getSomeField((List<String>) any);
+                          myObject.getSomeOtherField((Object) any);
+                      }};                      
                   }
               }
               """,
@@ -616,7 +191,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
                             
               import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.*;
+              import static org.mockito.Mockito.any;
+              import static org.mockito.Mockito.anyList;
                             
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -624,10 +200,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   MyObject myObject;
                             
                   void test() {
-                      when(myObject.getSomeField(anyList())).thenReturn(null);
-                      when(myObject.getSomeOtherField(any(Object.class))).thenReturn(null);
                       assertNull(myObject.getSomeField(new ArrayList<>()));
                       assertNull(myObject.getSomeOtherField(new Object()));
+                      verify(myObject).getSomeField(anyList());
+                      verify(myObject).getSomeOtherField(any(Object.class));
                   }
               }
               """
@@ -636,7 +212,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenNoArguments() {
+    void whenTimesNoArgs() {
         //language=java
         rewriteRun(
           java(
@@ -655,24 +231,21 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.List;
                             
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
                             
                   void test() {
-                      new Expectations() {{
+                      myObject.getSomeField();
+                      new Verifications() {{
                           myObject.getSomeField();
-                          result = null;
                       }};
-                      assertNull(myObject.getSomeField());
                   }
               }
               """,
@@ -684,8 +257,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
                             
-              import static org.junit.jupiter.api.Assertions.assertNull;
-              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.verify;
                             
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -693,8 +265,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   MyObject myObject;
                             
                   void test() {
-                      when(myObject.getSomeField()).thenReturn(null);
-                      assertNull(myObject.getSomeField());
+                      myObject.getSomeField();
+                      verify(myObject).getSomeField();
                   }
               }
               """
@@ -722,12 +294,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import java.util.ArrayList;
               import java.util.List;
                             
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertNull;
                             
               @ExtendWith(JMockitExtension.class)
               class MyTest {
@@ -736,11 +306,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                             
                   void test() {
                       String bazz = "bazz";
-                      new Expectations() {{
+                      myObject.getSomeField("foo", "bar", bazz, 10L);
+                      new Verifications() {{
                           myObject.getSomeField("foo", anyString, bazz, 10L);
-                          result = null;
-                      }};
-                      assertNull(myObject.getSomeField("foo", "bar", bazz, 10L));
+                      }};                      
                   }
               }
               """,
@@ -752,7 +321,6 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
                             
-              import static org.junit.jupiter.api.Assertions.assertNull;
               import static org.mockito.Mockito.*;
                             
               @ExtendWith(MockitoExtension.class)
@@ -762,8 +330,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                             
                   void test() {
                       String bazz = "bazz";
-                      when(myObject.getSomeField(eq("foo"), anyString(), eq(bazz), eq(10L))).thenReturn(null);
-                      assertNull(myObject.getSomeField("foo", "bar", bazz, 10L));
+                      myObject.getSomeField("foo", "bar", bazz, 10L);
+                      verify(myObject).getSomeField(eq("foo"), anyString(), eq(bazz), eq(10L));
                   }
               }
               """
@@ -790,7 +358,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           ),
           java(
             """
-              import mockit.Expectations;
+              import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
@@ -805,17 +373,15 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   void test() {
                       String a = "a";
                       String s = "s";
-                            
-                      new Expectations() {{
+                      assertEquals("s", myObject.getSomeField("foo"));
+                      assertEquals("a", myObject.getString());
+                      new Verifications() {{
                           myObject.getSomeField(anyString);
                           result = s;
                             
                           myObject.getString();
                           result = a;
                       }};
-                            
-                      assertEquals("s", myObject.getSomeField("foo"));
-                      assertEquals("a", myObject.getString());
                   }
               }
               """,
@@ -825,8 +391,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
                             
               import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.mockito.Mockito.anyString;
-              import static org.mockito.Mockito.when;
+              import static org.mockito.Mockito.*;
 
               @ExtendWith(MockitoExtension.class)
               class MyTest {
@@ -835,14 +400,11 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
 
                   void test() {
                       String a = "a";
-                      String s = "s";
-                            
-                      when(myObject.getSomeField(anyString())).thenReturn(s);
-                            
-                      when(myObject.getString()).thenReturn(a);
-                            
+                      String s = "s";                           
                       assertEquals("s", myObject.getSomeField("foo"));
                       assertEquals("a", myObject.getString());
+                      verify(myObject).getSomeField(anyString());            
+                      verify(myObject).getString();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -726,7 +726,6 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-        //TODO Preferably Verifications should be replaced inline and not appended to end of the method
     void whenMultipleVerifications() {
         //language=java
         rewriteRun(
@@ -770,9 +769,9 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
 
                   void test() {
                       myObject.wait();
+                      verify(myObject).wait();
                       myObject.wait(1L);
                       myObject.wait(2L);
-                      verify(myObject).wait();
                       verify(myObject, times(2)).wait(anyLong());
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -238,9 +238,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-                            
-              import static org.mockito.Mockito.*;
-                            
+                                                        
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -743,8 +743,10 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                             
                   void test() {
                       myObject.wait();
-                      new Verifications() {{
+                      new Verifications() {{             
+                      
                           myObject.wait();
+                          
                           myObject.wait(anyLong, anyInt);
                       }};
                       myObject.wait(1L);

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -60,7 +60,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      myObject.wait(10L, 10);             
+                      myObject.wait(10L, 10);
                       new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                       }};
@@ -110,7 +110,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       myObject.wait(10L, 10);
                       new Verifications() {{
                           myObject.wait();
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -176,7 +176,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       new Verifications() {{
                           myObject.getSomeField((List<String>) any);
                           myObject.getSomeOtherField((Object) any);
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -295,7 +295,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       myObject.getSomeField("foo", "bar", bazz, 10L);
                       new Verifications() {{
                           myObject.getSomeField("foo", anyString, bazz, 10L);
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -360,7 +360,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       myObject.getSomeField("foo");
                       myObject.getString();
                       new Verifications() {{
-                          myObject.getSomeField(anyString);                            
+                          myObject.getSomeField(anyString);
                           myObject.getString();
                       }};
                   }
@@ -380,10 +380,10 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
 
                   void test() {
                       String a = "a";
-                      String s = "s";                           
+                      String s = "s";
                       myObject.getSomeField("foo");
                       myObject.getString();
-                      verify(myObject).getSomeField(anyString());            
+                      verify(myObject).getSomeField(anyString());
                       verify(myObject).getString();
                   }
               }
@@ -418,11 +418,11 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   MyObject myObject;
                             
                   void test() {
-                      String a = "a";                            
+                      String a = "a";
                       myObject.getSomeField("foo");
                       new Verifications() {{
                           myObject.getSomeField(anyString);
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -474,7 +474,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       new Verifications() {{
                           myObject.wait(anyLong, anyInt);
                           times = 3;
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -690,7 +690,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                           myOtherObject.getSomeObjectField();
                           myObject.wait(anyLong, anyInt);
                           myOtherObject.getSomeStringField(anyString, anyLong);
-                      }};                      
+                      }};
                   }
               }
               """,
@@ -743,7 +743,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                             
                   void test() {
                       myObject.wait();
-                      new Verifications() {{             
+                      new Verifications() {{
                       
                           myObject.wait();
                           

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -726,7 +726,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenMultipleVerifications() {
+    void whenMultipleVerificationsAndMultipleStatements() {
         //language=java
         rewriteRun(
           java(
@@ -745,6 +745,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                       myObject.wait();
                       new Verifications() {{
                           myObject.wait();
+                          myObject.wait(anyLong, anyInt);
                       }};
                       myObject.wait(1L);
                       myObject.wait(2L);
@@ -770,6 +771,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   void test() {
                       myObject.wait();
                       verify(myObject).wait();
+                      verify(myObject).wait(anyLong(), anyInt());
                       myObject.wait(1L);
                       myObject.wait(2L);
                       verify(myObject, times(2)).wait(anyLong());


### PR DESCRIPTION
Tests are failing, need to fix and also add tests once they pass. The import for verify is not being added. I don't know why this is not working as it is working for the when statements and the same code is being used.

https://jmockit.github.io/tutorial/Mocking.html#verification
https://www.javadoc.io/doc/org.jmockit/jmockit/1.45/mockit/Verifications.html

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
