### PR TITLE
More best pratices for AssertJ

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToBoolean.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToBoolean.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.J.MethodInvocation;
+import org.openrewrite.java.tree.JavaType.Method;
+
+import java.util.Collections;
+
+/**
+ * AssertJ has a more idiomatic way of asserting that a boolean is true. This
+ * recipe will find instances of:
+ * 
+ * -`assertThat(boolean).isEqualTo(true)` and replace them with `isTrue()`.
+ * -`assertThat(boolean).isEqualTo(false)` and replace them with `isFalse()`.
+ */
+public class IsEqualToBoolean extends Recipe {
+
+    private static final MethodMatcher IS_EQUAL_TO = new MethodMatcher(
+            "org.assertj.core.api.AbstractBooleanAssert isEqualTo(boolean)");
+
+    @Override
+    public String getDisplayName() {
+        return "Convert `assertThat(String).isEqualTo(true)` to `isTrue()` and `isEqualTo(false)` to `isFalse()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adopt idiomatic AssertJ assertion for true booleans.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesMethod<>(IS_EQUAL_TO), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                if (IS_EQUAL_TO.matches(mi)) {
+                    String methodName;
+                    if (J.Literal.isLiteralValue(mi.getArguments().get(0), true)) {
+                        methodName = "isTrue";
+                    } else {
+                        methodName = "isFalse";
+                    }
+                    Method isBooleanMethod = mi.getMethodType().withName(methodName);
+                    return mi.withName(mi.getName().withSimpleName(methodName).withType(isBooleanMethod))
+                            .withMethodType(isBooleanMethod).withArguments(Collections.emptyList());
+                }
+                return mi;
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToBoolean.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToBoolean.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 /**
  * AssertJ has a more idiomatic way of asserting that a boolean is true. This
  * recipe will find instances of:
- * 
+ * <p>
  * -`assertThat(boolean).isEqualTo(true)` and replace them with `isTrue()`.
  * -`assertThat(boolean).isEqualTo(false)` and replace them with `isFalse()`.
  */

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -25,6 +25,7 @@ recipeList:
   - org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ
   - org.openrewrite.java.testing.assertj.JUnitToAssertj
   - org.openrewrite.java.testing.assertj.StaticImports
+  - org.openrewrite.java.testing.assertj.IsEqualToBoolean
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.IsEqualToEmptyString
 
@@ -337,6 +338,16 @@ recipeList:
       assertToReplace: isSameAs
       dedicatedAssertion: containsSame
       requiredType: java.util.Optional
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: hasNext
+      assertToReplace: isTrue
+      dedicatedAssertion: hasNext
+      requiredType: java.util.Iterator
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: hasNext
+      assertToReplace: isFalse
+      dedicatedAssertion: isExhausted
+      requiredType: java.util.Iterator
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.assertj;
 
+import org.openrewrite.DocumentExample;
 import static org.openrewrite.java.Assertions.java;
 
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,10 @@ class IsEqualToBooleanTest implements RewriteTest {
         .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
                 .recipe(new IsEqualToBoolean());
     }
-    
-    @Test
+
+    @DocumentExample
+                java(
+                """
     void convertsIsEqualToTrue() {
         rewriteRun(
                 // language=java
@@ -57,7 +60,8 @@ class IsEqualToBooleanTest implements RewriteTest {
     void convertsIsEqualToFalse() {
         rewriteRun(
                 // language=java
-                java("""
+                java(
+                """
                         import static org.assertj.core.api.Assertions.assertThat;
                         class Test {
                             void test() {

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
@@ -34,6 +34,7 @@ class IsEqualToBooleanTest implements RewriteTest {
     }
 
     @DocumentExample
+    @Test
     void convertsIsEqualToTrue() {
         rewriteRun(
           // language=java
@@ -82,5 +83,4 @@ class IsEqualToBooleanTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class IsEqualToBooleanTest implements RewriteTest {
+    
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+        .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
+                .recipe(new IsEqualToBoolean());
+    }
+    
+    @Test
+    void convertsIsEqualToTrue() {
+        rewriteRun(
+                // language=java
+                java("""
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat(true).isEqualTo(true);
+                            }
+                        }
+                        """, """
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat(true).isTrue();
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void convertsIsEqualToFalse() {
+        rewriteRun(
+                // language=java
+                java("""
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat(false).isEqualTo(false);
+                            }
+                        }
+                        """, """
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat(false).isFalse();
+                            }
+                        }
+                        """));
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToBooleanTest.java
@@ -15,67 +15,72 @@
  */
 package org.openrewrite.java.testing.assertj;
 
-import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.java.Assertions.java;
+
 class IsEqualToBooleanTest implements RewriteTest {
-    
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-        .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
-                .recipe(new IsEqualToBoolean());
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
+          .recipe(new IsEqualToBoolean());
     }
 
     @DocumentExample
-                java(
-                """
     void convertsIsEqualToTrue() {
         rewriteRun(
-                // language=java
-                java("""
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat(true).isEqualTo(true);
-                            }
-                        }
-                        """, """
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat(true).isTrue();
-                            }
-                        }
-                        """));
+          // language=java
+          java(
+            """
+            import static org.assertj.core.api.Assertions.assertThat;
+            class Test {
+                void test() {
+                    assertThat(true).isEqualTo(true);
+                }
+            }
+            """,
+            """
+            import static org.assertj.core.api.Assertions.assertThat;
+            class Test {
+                void test() {
+                    assertThat(true).isTrue();
+                }
+            }
+            """
+          )
+        );
     }
 
     @Test
     void convertsIsEqualToFalse() {
         rewriteRun(
-                // language=java
-                java(
-                """
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat(false).isEqualTo(false);
-                            }
-                        }
-                        """, """
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat(false).isFalse();
-                            }
-                        }
-                        """));
+          // language=java
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+              class Test {
+                  void test() {
+                      assertThat(false).isEqualTo(false);
+                  }
+              }
+              """,
+              """
+              import static org.assertj.core.api.Assertions.assertThat;
+              class Test {
+                  void test() {
+                      assertThat(false).isFalse();
+                  }
+              }
+              """
+          )
+        );
     }
 
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class IsEqualToEmptyStringTest implements RewriteTest {
+    
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+        .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
+          .recipe(new IsEqualToEmptyString());
+    }
+    
+    @Test
+    void convertsIsEqualToEmptyString() {
+        rewriteRun(
+                // language=java
+                java("""
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat("test").isEqualTo("");
+                            }
+                        }
+                        """, """
+                        import static org.assertj.core.api.Assertions.assertThat;
+                        class Test {
+                            void test() {
+                                assertThat("test").isEmpty();
+                            }
+                        }
+                        """));
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.assertj;
 
+import org.openrewrite.DocumentExample;
 import static org.openrewrite.java.Assertions.java;
 
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,10 @@ class IsEqualToEmptyStringTest implements RewriteTest {
         .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
           .recipe(new IsEqualToEmptyString());
     }
-    
-    @Test
+
+    @DocumentExample
+                java(
+                """
     void convertsIsEqualToEmptyString() {
         rewriteRun(
                 // language=java

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.assertj;
 
+import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -33,6 +34,7 @@ class IsEqualToEmptyStringTest implements RewriteTest {
     }
 
     @DocumentExample
+    @Test
     void convertsIsEqualToEmptyString() {
         rewriteRun(
           // language=java
@@ -56,5 +58,4 @@ class IsEqualToEmptyStringTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToEmptyStringTest.java
@@ -16,44 +16,45 @@
 package org.openrewrite.java.testing.assertj;
 
 import org.openrewrite.DocumentExample;
-import static org.openrewrite.java.Assertions.java;
-
-import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.openrewrite.java.Assertions.java;
+
 class IsEqualToEmptyStringTest implements RewriteTest {
-    
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-        .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
           .recipe(new IsEqualToEmptyString());
     }
 
     @DocumentExample
-                java(
-                """
     void convertsIsEqualToEmptyString() {
         rewriteRun(
-                // language=java
-                java("""
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat("test").isEqualTo("");
-                            }
-                        }
-                        """, """
-                        import static org.assertj.core.api.Assertions.assertThat;
-                        class Test {
-                            void test() {
-                                assertThat("test").isEmpty();
-                            }
-                        }
-                        """));
+          // language=java
+          java(
+            """
+            import static org.assertj.core.api.Assertions.assertThat;
+            class Test {
+                void test() {
+                    assertThat("test").isEqualTo("");
+                }
+            }
+            """,
+            """
+            import static org.assertj.core.api.Assertions.assertThat;
+            class Test {
+                void test() {
+                    assertThat("test").isEmpty();
+                }
+            }
+            """
+          )
+        );
     }
 
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
@@ -58,9 +58,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
               java(
                 """
                   import org.junit.jupiter.api.Test;
-                                
+
                   import static org.assertj.core.api.Assertions.assertThat;
-                                
+
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -71,9 +71,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                   """,
                   """
                   import org.junit.jupiter.api.Test;
-                                
+
                   import static org.assertj.core.api.Assertions.assertThat;
-                                
+
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -107,9 +107,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             //language=java
             String template = """
               import org.junit.jupiter.api.Test;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class MyTest {
                   @Test
                   void test() {
@@ -163,9 +163,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             String template = """
               import org.junit.jupiter.api.Test;
               import java.io.File;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class MyTest {
                   @Test
                   void test() {
@@ -212,9 +212,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
               import java.nio.file.Path;
               import java.nio.file.Paths;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class MyTest {
                   @Test
                   void test() {
@@ -260,9 +260,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             //language=java
             String template = """
               import java.util.Collection;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class A {
                   void test(Collection<String> collection, Collection<String> otherCollection) {
                       String something = "";
@@ -305,9 +305,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
               import java.util.Collections;
               import java.util.Map;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class MyTest {
                   @Test
                   void test() {
@@ -345,9 +345,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                 """
                   import org.junit.jupiter.api.Test;
                   import java.util.Map;
-                                    
+    
                   import static org.assertj.core.api.Assertions.assertThat;
-                          
+
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -360,9 +360,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                 """
                   import org.junit.jupiter.api.Test;
                   import java.util.Map;
-                                    
+    
                   import static org.assertj.core.api.Assertions.assertThat;
-                          
+
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -394,9 +394,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             String template = """
               import org.junit.jupiter.api.Test;
               import java.util.Optional;
-                      
+
               import static org.assertj.core.api.Assertions.assertThat;
-                      
+
               class MyTest {
                   @Test
                   void test() {
@@ -418,7 +418,7 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
     }
 
     @Nested
-    class Iteratorz {
+    class Iterators {
         private static Stream<Arguments> collectionReplacements() {
             return Stream.of(
               Arguments.arguments("hasNext", "isTrue", "hasNext"),

--- a/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
@@ -56,31 +56,33 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             rewriteRun(
               //language=java
               java(
-                    """
-                import org.junit.jupiter.api.Test;
-                              
-                import static org.assertj.core.api.Assertions.assertThat;
-                              
-                class MyTest {
-                    @Test
-                    void testMethod() {
-                        String s = "hello world";
-                        assertThat(s.isEmpty()).isTrue();
-                    }
-                }
-                """, """
-                import org.junit.jupiter.api.Test;
-                              
-                import static org.assertj.core.api.Assertions.assertThat;
-                              
-                class MyTest {
-                    @Test
-                    void testMethod() {
-                        String s = "hello world";
-                        assertThat(s).isEmpty();
-                    }
-                }
-                """)
+                """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class MyTest {
+                      @Test
+                      void testMethod() {
+                          String s = "hello world";
+                          assertThat(s.isEmpty()).isTrue();
+                      }
+                  }
+                  """,
+                  """
+                  import org.junit.jupiter.api.Test;
+                                
+                  import static org.assertj.core.api.Assertions.assertThat;
+                                
+                  class MyTest {
+                      @Test
+                      void testMethod() {
+                          String s = "hello world";
+                          assertThat(s).isEmpty();
+                      }
+                  }
+                  """
+              )
             );
         }
 
@@ -343,9 +345,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                 """
                   import org.junit.jupiter.api.Test;
                   import java.util.Map;
-                  
+                                    
                   import static org.assertj.core.api.Assertions.assertThat;
-        
+                          
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -358,9 +360,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                 """
                   import org.junit.jupiter.api.Test;
                   import java.util.Map;
-                  
+                                    
                   import static org.assertj.core.api.Assertions.assertThat;
-        
+                          
                   class MyTest {
                       @Test
                       void testMethod() {
@@ -414,7 +416,6 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             rewriteRun(java(before, after));
         }
     }
-    
 
     @Nested
     class Iteratorz {
@@ -431,9 +432,9 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             //language=java
             String template = """
               import java.util.Iterator;
-                        
+
               import static org.assertj.core.api.Assertions.assertThat;
-                        
+
               class A {
                   void test(Iterator<String> iterator, Iterator<String> otherIterator) {
                       String something = "";
@@ -453,6 +454,5 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
               java(before, after)
             );
         }
- 
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
1 - Created a new recipe that converts `assertThat( true ).isEqualTo( true )` to `assertThat( true ).isTrue()`, same for false
2 - added new recipe to best practices on assertJ
3 - Added ChainedAssertions for Iterator hasNext

## What's your motivation?
Noticed a lot of `isEqualTo(true)` on https://github.com/OpenFeign/querydsl/ and want to get it sorted

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

Hrmm, I'm a little short of intellij, can anyone help me out of formatting this, sorry