### PR TITLE
Quick attempt at idomatic AssertJ assertions through Refaster

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-java")
     implementation("org.openrewrite:rewrite-gradle")
     implementation("org.openrewrite:rewrite-maven")
+    implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")
     runtimeOnly("org.openrewrite:rewrite-java-17")
@@ -40,7 +41,13 @@ dependencies {
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
 
+    annotationProcessor("org.openrewrite:rewrite-templating:$rewriteVersion")
+    compileOnly("com.google.errorprone:error_prone_core:2.19.1") {
+        exclude("com.google.auto.service", "auto-service-annotations")
+    }
+
     implementation("org.testcontainers:testcontainers:latest.release")
+    implementation("org.assertj:assertj-core:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-groovy")
@@ -61,5 +68,4 @@ dependencies {
     testRuntimeOnly("org.testcontainers:nginx:latest.release")
 
 //    testImplementation("org.hamcrest:hamcrest:latest.release")
-//    testImplementation("org.assertj:assertj-core:latest.release")
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/IdiomaticAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IdiomaticAssertions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.Primitive;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IdiomaticAssertions {
+    @RecipeDescriptor(
+            name = "Replace redundant `String` method calls with self",
+            description = "Replace redundant `substring(..)` and `toString()` method calls with the `String` self."
+    )
+    public static class AssertThatIsEqualToZero {
+        @BeforeTemplate
+        void before(@Primitive Integer actual) {
+            assertThat(actual).isEqualTo(0);
+        }
+
+        @AfterTemplate
+        void after(@Primitive Integer actual) {
+            assertThat(actual).isZero();
+        }
+    }
+}

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -28,6 +28,7 @@ recipeList:
   - org.openrewrite.java.testing.assertj.IsEqualToBoolean
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.IsEqualToEmptyString
+  - org.openrewrite.java.testing.assertj.IdiomaticAssertionsRecipes
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/testing/assertj/IdiomaticAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IdiomaticAssertionsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class IdiomaticAssertionsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3.24"))
+          .recipe(new IdiomaticAssertionsRecipes());
+    }
+
+    @Test
+    @DocumentExample
+    void intIsEqualToZero() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+              class Test {
+                  void test(int i) {
+                      assertThat(i).isEqualTo(0);
+                      assertThat(i).isNotEqualTo(0);
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+              class Test {
+                  void test(int i) {
+                      assertThat(i).isZero();
+                      assertThat(i).isNotZero();
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
* Added rewrite-templating for Refaster recipe support
* A recipe that aims to rewrite `assertThat(actual).isEqualTo(0)` to assertThat(actual).isZero()`
 
## What's your motivation?
Get more idiomatic AssertJ assertions developed more easily, from having a first example here.

## Anything in particular you'd like reviewers to focus on?
Currently fails as the before template isn't matched
```java
                final JavaTemplate before = JavaTemplate
                        .builder("org.assertj.core.api.Assertions.assertThat(#{actual:any(int)}).isEqualTo(0);")
                        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                        .build();
```
![image](https://github.com/openrewrite/rewrite-testing-frameworks/assets/1027334/159d76f4-3482-4192-9ffe-9cc35599b9af)

`org.assertj.core.api.AbstractIntegerAssert<Generic{SELF extends }>{name=isEqualTo,return=Generic{?},parameters=[int]}`

## Have you considered any alternatives or workarounds?
Explicit recipe would work for this case, but is less easily developed and maintained, whereas we expect more similar recipes to be welcome here.

## Any additional context
- https://github.com/openrewrite/rewrite-templating/issues/47