### PR TITLE
Simplify toString assertion

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -348,6 +348,11 @@ recipeList:
       assertToReplace: isFalse
       dedicatedAssertion: isExhausted
       requiredType: java.util.Iterator
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: toString
+      assertToReplace: isEqualTo
+      dedicatedAssertion: hasToString
+      requiredType: java.lang.Object
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -247,7 +247,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer
 displayName: Use OkHttp 3 MockWebServer for JUnit 5
-description: Migrates OkHttp 3 `MockWebServer` to enable JUnit Jupiter Extension support
+description: Migrates OkHttp 3 `MockWebServer` to enable JUnit Jupiter Extension support.
 tags:
   - testing
   - junit
@@ -266,7 +266,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.CleanupAssertions
 displayName: Clean Up Assertions
-description: Simplifies JUnit Jupiter assertions to their most-direct equivalents
+description: Simplifies JUnit Jupiter assertions to their most-direct equivalents.
 tags:
   - testing
   - junit
@@ -286,7 +286,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.UseXMLUnitLegacy
 displayName: Use XMLUnit Legacy for JUnit 5
-description: Migrates XMLUnit 1.x to XMLUnit legacy 2.x
+description: Migrates XMLUnit 1.x to XMLUnit legacy 2.x.
 tags:
   - testing
   - junit

--- a/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
@@ -471,7 +471,7 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
                   class MyTest {
                       void testMethod(Object argument) {
                           String s = "hello world";
-                          assertThat(argument.toString()).isEqualTo(("value");
+                          assertThat(argument.toString()).isEqualTo("value");
                       }
                   }
                   """,

--- a/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
@@ -455,4 +455,40 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
             );
         }
     }
+    
+    @Nested
+    class Objects {
+        
+        void objectoToStringReplacement() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.junit.jupiter.api.Test;
+
+                  import static org.assertj.core.api.Assertions.assertThat;
+
+                  class MyTest {
+                      void testMethod(Object argument) {
+                          String s = "hello world";
+                          assertThat(argument.toString()).isEqualTo(("value");
+                      }
+                  }
+                  """,
+                  """
+                  import org.junit.jupiter.api.Test;
+
+                  import static org.assertj.core.api.Assertions.assertThat;
+
+                  class MyTest {
+                      void testMethod(Object argument) {
+                          String s = "hello world";
+                          assertThat(argument).hasToString("value");
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/MigrateChainedAssertToAssertJTest.java
@@ -458,7 +458,7 @@ class MigrateChainedAssertToAssertJTest implements RewriteTest {
     
     @Nested
     class Objects {
-        
+        @Test
         void objectoToStringReplacement() {
             rewriteRun(
               //language=java

--- a/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
@@ -18,7 +18,6 @@ package org.openrewrite.java.testing.junit5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -44,7 +43,7 @@ class CleanupAssertionsTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Assertions;
               import org.junit.jupiter.api.Test;
-                          
+
               class ExampleTest {
                   @Test
                   void test() {
@@ -105,7 +104,7 @@ class CleanupAssertionsTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Assertions;
               import org.junit.jupiter.api.Test;
-                          
+
               class ExampleTest {
                   @Test
                   void test() {
@@ -136,7 +135,7 @@ class CleanupAssertionsTest implements RewriteTest {
             """
                     import org.junit.jupiter.api.Assertions;
                     import org.junit.jupiter.api.Test;
-                                              
+
                     class A {
                         class B {}
 
@@ -151,7 +150,7 @@ class CleanupAssertionsTest implements RewriteTest {
             """
                     import org.junit.jupiter.api.Assertions;
                     import org.junit.jupiter.api.Test;
-                                              
+
                     class A {
                         class B {}
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.config.Environment;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -27,10 +26,7 @@ class UseXMLUnitLegacyTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec
-          .recipe(Environment.builder()
-            .scanRuntimeClasspath()
-            .build()
-            .activateRecipes("org.openrewrite.java.testing.junit5.UseXMLUnitLegacy"));
+          .recipeFromResources("org.openrewrite.java.testing.junit5.UseXMLUnitLegacy");
     }
 
     @Test


### PR DESCRIPTION
Instead of using:
```
assertThat(cat.toString()).isEqualTo("animal");
```

Could use:
```
assertThat(cat).hasToString("animal");
```

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
