### PR TITLE
ExpectedExceptionToAssertThrows should not wrap single statement

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -160,8 +160,11 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             Object expectedExceptionParam = (expectMethodInvocation == null || isExpectArgAMatcher) ?
                     "Exception.class" : expectMethodInvocation.getArguments().get(0);
 
-            String templateString = expectedExceptionParam instanceof String ? "#{}assertThrows(#{}, () -> #{});" : "#{}assertThrows(#{any()}, () -> #{});";
+            String templateString = expectedExceptionParam instanceof String ? "#{}assertThrows(#{}, () -> #{any()});" : "#{}assertThrows(#{any()}, () -> #{any()});";
 
+            Statement statement = bodyWithoutExpectedExceptionCalls.getStatements().size() == 1 &&
+                                  !(bodyWithoutExpectedExceptionCalls.getStatements().get(0) instanceof J.Throw) ?
+                    bodyWithoutExpectedExceptionCalls.getStatements().get(0) : bodyWithoutExpectedExceptionCalls;
             m = JavaTemplate.builder(templateString)
                     .contextSensitive()
                     .javaParser(javaParser(ctx))
@@ -172,7 +175,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                             m.getCoordinates().replaceBody(),
                             exceptionDeclParam,
                             expectedExceptionParam,
-                            bodyWithoutExpectedExceptionCalls
+                            statement
                     );
 
             maybeAddImport("org.junit.jupiter.api.Assertions", "assertThrows");

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -25,6 +25,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+@SuppressWarnings({"deprecation", "JUnitMalformedDeclaration", "JUnit3StyleTestMethodInJUnit4Class", "Convert2MethodRef"})
 class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
 
     @Override
@@ -105,9 +106,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
               
                   @Test
                   public void testEmptyPath() {
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-                          foo();
-                      });
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
                       assertTrue(exception.getMessage().contains("Invalid location: gs://"));
                   }
                   void foo() {


### PR DESCRIPTION
As [discussed on Slack](https://rewriteoss.slack.com/archives/C01A843MWG5/p1721792132436429) with @shivanisky .