### PR TITLE
Add unit tests for JMockit Delegate to mockito migration. Also add test case for comments

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.testing.jmockit;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -36,6 +37,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
         setDefaultParserSettings(spec);
     }
 
+    @DocumentExample
     @Test
     void whenNoArgsVoidMethod() {
         //language=java

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.jmockit;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
+
+/**
+ * At the moment, JMockit Delegates are not migrated to mockito. What I'm seeing is that they are being trashed
+ * with the template being printed out. These tests were written to try to replicate this issue, however I was unable to.
+ * They may help anyone adding feature for Delegate migration.
+ */
+class JMockitDelegateToMockitoTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        setDefaultParserSettings(spec);
+    }
+
+    @Test
+    void whenNoArgsVoidMethod() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Delegate;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait();
+                          result = new Delegate() {
+                              public void wait() {
+                                 System.out.println("bla");
+                             }
+                          };
+                      }};
+                      myObject.wait();
+                  }
+              }
+              """,
+            """
+              import mockit.Delegate;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.mockito.Mockito.when;
+                                              
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      when(myObject.wait()).thenReturn(new Delegate() {
+                          public void wait() {
+                              System.out.println("bla");
+                          }             
+                      });
+                      myObject.wait();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenHasArgsVoidMethod() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Delegate;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait(anyLong);
+                          result = new Delegate() {
+                              void wait(long timeoutMs) {
+                                  System.out.println("bla");
+                                  System.out.println("bla");
+                             }
+                          };
+                      }};
+                      myObject.wait();
+                  }
+              }
+              """,
+            """
+              import mockit.Delegate;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.anyLong;
+              import static org.mockito.Mockito.when;
+                                              
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      when(myObject.wait(anyLong())).thenReturn(new Delegate() {
+                          void wait(long timeoutMs) {
+                              System.out.println("bla");
+                              System.out.println("bla");
+                          }           
+                      });
+                      myObject.wait();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenNoArgsNonVoidMethod() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Delegate;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.toString();
+                          result = new Delegate() {
+                              String toString() {
+                                  String a = "bla";
+                                  return a + "foo";
+                             }
+                          };
+                      }};
+                      myObject.toString();
+                  }
+              }
+              """,
+            """
+              import mockit.Delegate;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.when;
+                                              
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      when(myObject.toString()).thenReturn(new Delegate() {
+                          String toString() {
+                              String a = "bla";
+                              return a + "foo";
+                          }             
+                      });
+                      myObject.toString();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenMultipleStatementsWithAnnotation() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Delegate;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.hashCode();
+                          result = 100;
+                          myObject.toString();
+                          result = new Delegate() {
+                              @SuppressWarnings("unused")
+                              String toString() {
+                                  String a = "bla";
+                                  return a + "foo";
+                             }
+                          };
+                      }};
+                      myObject.toString();
+                  }
+              }
+              """,
+            """
+              import mockit.Delegate;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.mockito.Mockito.when;
+                                              
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      when(myObject.hashCode()).thenReturn(100);
+                      when(myObject.toString()).thenReturn(new Delegate() {
+                          @SuppressWarnings("unused")
+                          String toString() {
+                              String a = "bla";
+                              return a + "foo";
+                          }            
+                      });
+                      myObject.toString();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenClassArgumentMatcher() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          java(
+            """
+              import java.util.List;
+
+              class MyObject {
+                  public String getSomeField(List<String> input) {
+                      return "X";
+                  }
+                  public String getSomeOtherField(Object input) {
+                      return "Y";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import mockit.Delegate;
+              import mockit.Mocked;
+              import mockit.Expectations;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  MyObject myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.getSomeField((List<String>) any);
+                          result = new Delegate() {
+                              String getSomeOtherField(List<String> input) {
+                                  input.add("foo");
+                                  return input.toString();
+                             }
+                          };
+                      }};
+                      myObject.getSomeField(new ArrayList<>());
+                      myObject.getSomeOtherField(new Object());
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import mockit.Delegate;
+                             
+              import static org.mockito.Mockito.anyList;
+              import static org.mockito.Mockito.when;
+
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  MyObject myObject;
+
+                  void test() {
+                      when(myObject.getSomeField(anyList())).thenReturn(new Delegate() {
+                          String getSomeOtherField(List<String> input) {
+                              input.add("foo");
+                              return input.toString();
+                          }
+                      });
+                      myObject.getSomeField(new ArrayList<>());
+                      myObject.getSomeOtherField(new Object());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -15,10 +15,10 @@
  */
 package org.openrewrite.java.testing.jmockit;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
@@ -26,8 +26,9 @@ import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultPa
 /**
  * At the moment, JMockit Delegates are not migrated to mockito. What I'm seeing is that they are being trashed
  * with the template being printed out. These tests were written to try to replicate this issue, however I was unable to.
- * They may help anyone adding feature for Delegate migration.
+ * They may help anyone who wants to add Delegate migration.
  */
+@Disabled
 class JMockitDelegateToMockitoTest implements RewriteTest {
 
     @Override
@@ -39,7 +40,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
     void whenNoArgsVoidMethod() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import mockit.Expectations;
@@ -80,10 +80,8 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      when(myObject.wait()).thenReturn(new Delegate() {
-                          public void wait() {
+                      when(myObject.wait()).thenAnswer(invocation -> {
                               System.out.println("bla");
-                          }             
                       });
                       myObject.wait();
                   }
@@ -97,7 +95,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
     void whenHasArgsVoidMethod() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import mockit.Expectations;
@@ -143,11 +140,9 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      when(myObject.wait(anyLong())).thenReturn(new Delegate() {
-                          void wait(long timeoutMs) {
-                              System.out.println("bla");
-                              System.out.println("bla");
-                          }           
+                      when(myObject.wait(anyLong())).thenAnswer(invocation -> {
+                          System.out.println("bla");
+                          System.out.println("bla");
                       });
                       myObject.wait();
                   }
@@ -161,7 +156,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
     void whenNoArgsNonVoidMethod() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import mockit.Expectations;
@@ -206,11 +200,9 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      when(myObject.toString()).thenReturn(new Delegate() {
-                          String toString() {
-                              String a = "bla";
-                              return a + "foo";
-                          }             
+                      when(myObject.toString()).thenAnswer(invocation -> {
+                          String a = "bla";
+                          return a + "foo";
                       });
                       myObject.toString();
                   }
@@ -224,7 +216,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
     void whenMultipleStatementsWithAnnotation() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import mockit.Expectations;
@@ -273,12 +264,9 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
 
                   void test() {
                       when(myObject.hashCode()).thenReturn(100);
-                      when(myObject.toString()).thenReturn(new Delegate() {
-                          @SuppressWarnings("unused")
-                          String toString() {
-                              String a = "bla";
-                              return a + "foo";
-                          }            
+                      when(myObject.toString()).thenAnswer(invocation -> {
+                          String a = "bla";
+                          return a + "foo";
                       });
                       myObject.toString();
                   }
@@ -292,7 +280,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
     void whenClassArgumentMatcher() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
           java(
             """
               import java.util.List;
@@ -357,11 +344,10 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   MyObject myObject;
 
                   void test() {
-                      when(myObject.getSomeField(anyList())).thenReturn(new Delegate() {
-                          String getSomeOtherField(List<String> input) {
-                              input.add("foo");
-                              return input.toString();
-                          }
+                      when(myObject.getSomeField(anyList())).thenAnswer(invocation -> {
+                          List<String> input = invocation.getArgument(0);
+                          input.add("foo");
+                          return input.toString();
                       });
                       myObject.getSomeField(new ArrayList<>());
                       myObject.getSomeOtherField(new Object());

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.jmockit;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -30,6 +31,7 @@ import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultPa
  * They may help anyone who wants to add Delegate migration.
  */
 @Disabled
+@Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/522")
 class JMockitDelegateToMockitoTest implements RewriteTest {
 
     @Override
@@ -49,7 +51,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -75,7 +77,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import org.mockito.junit.jupiter.MockitoExtension;
 
               import static org.mockito.Mockito.when;
-                                              
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -105,7 +107,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -133,7 +135,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
 
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.when;
-                                              
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -164,7 +166,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               @ExtendWith(JMockitExtension.class)
@@ -194,7 +196,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
 
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-                                              
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -224,7 +226,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               @ExtendWith(JMockitExtension.class)
@@ -258,7 +260,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
 
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
-                                              
+
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
@@ -333,7 +335,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import java.util.List;
 
               import mockit.Delegate;
-                             
+
               import static org.mockito.Mockito.anyList;
               import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -60,7 +60,7 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                           myObject.wait();
                           result = new Delegate() {
                               public void wait() {
-                                 System.out.println("bla");
+                                 System.out.println("foo");
                              }
                           };
                       }};
@@ -82,9 +82,10 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      when(myObject.wait()).thenAnswer(invocation -> {
-                              System.out.println("bla");
-                      });
+                      doAnswer(invocation -> {
+                          System.out.println("foo");
+                          return null;
+                      }).when(myObject).wait();
                       myObject.wait();
                   }
               }
@@ -105,8 +106,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
                             
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
@@ -117,8 +116,8 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                           myObject.wait(anyLong);
                           result = new Delegate() {
                               void wait(long timeoutMs) {
-                                  System.out.println("bla");
-                                  System.out.println("bla");
+                                  System.out.println("foo");
+                                  System.out.println("bar");
                              }
                           };
                       }};
@@ -132,7 +131,6 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
 
-              import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.when;
                                               
@@ -142,10 +140,11 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   Object myObject;
 
                   void test() {
-                      when(myObject.wait(anyLong())).thenAnswer(invocation -> {
-                          System.out.println("bla");
-                          System.out.println("bla");
-                      });
+                      doAnswer(invocation -> {
+                          System.out.println("foo");
+                          System.out.println("bar");
+                          return null;
+                      }).when(myObject).wait(anyLong());
                       myObject.wait();
                   }
               }
@@ -178,12 +177,12 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                           myObject.toString();
                           result = new Delegate() {
                               String toString() {
-                                  String a = "bla";
-                                  return a + "foo";
+                                  String a = "foo";
+                                  return a + "bar";
                              }
                           };
                       }};
-                      myObject.toString();
+                      assertEquals("foobar", myObject.toString());
                   }
               }
               """,
@@ -203,10 +202,10 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
 
                   void test() {
                       when(myObject.toString()).thenAnswer(invocation -> {
-                          String a = "bla";
-                          return a + "foo";
+                          String a = "foo";
+                          return a + "bar";
                       });
-                      myObject.toString();
+                      assertEquals("foobar", myObject.toString());
                   }
               }
               """
@@ -241,12 +240,13 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                           result = new Delegate() {
                               @SuppressWarnings("unused")
                               String toString() {
-                                  String a = "bla";
-                                  return a + "foo";
+                                  String a = "foo";
+                                  return a + "bar";
                              }
                           };
                       }};
-                      myObject.toString();
+                      assertEquals(100, myObject.hashCode());
+                      assertEquals("foobar", myObject.toString());
                   }
               }
               """,
@@ -267,10 +267,11 @@ class JMockitDelegateToMockitoTest implements RewriteTest {
                   void test() {
                       when(myObject.hashCode()).thenReturn(100);
                       when(myObject.toString()).thenAnswer(invocation -> {
-                          String a = "bla";
-                          return a + "foo";
+                          String a = "foo";
+                          return a + "bar";
                       });
-                      myObject.toString();
+                      assertEquals(100, myObject.hashCode());
+                      assertEquals("foobar", myObject.toString());
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.jmockit;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
@@ -1475,6 +1476,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         );
     }
 
+    @Disabled // comment migration not supported yet
     @Test
     void whenComments() {
         //language=java
@@ -1533,6 +1535,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   MyObject myObject;
 
                   void test() {
+                      // comments for this line below
                       when(myObject.getSomeStringField()).thenReturn("a");
                       assertEquals("a", myObject.getSomeStringField());
                       when(myObject.getSomeStringField()).thenReturn("b");

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -42,7 +42,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               @ExtendWith(JMockitExtension.class)
@@ -189,8 +189,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;              
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
 
               @ExtendWith(JMockitExtension.class)
               class MyTest {
@@ -210,8 +210,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
-              import static org.junit.jupiter.api.Assertions.assertEquals;              
+              
+              import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
               @ExtendWith(MockitoExtension.class)
@@ -1065,7 +1065,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
@@ -1075,7 +1075,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1085,7 +1085,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   }
               }
               """,
-            """              
+            """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
@@ -1096,7 +1096,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(2)).wait(anyLong(), anyInt());
@@ -1112,7 +1112,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
@@ -1122,7 +1122,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1132,7 +1132,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   }
               }
               """,
-            """              
+            """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
@@ -1143,7 +1143,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atMost(5)).wait(anyLong(), anyInt());
@@ -1159,7 +1159,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
         //language=java
         rewriteRun(
           java(
-            """              
+            """
               import mockit.Expectations;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
@@ -1169,7 +1169,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1180,7 +1180,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   }
               }
               """,
-            """              
+            """
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
@@ -1191,7 +1191,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(1)).wait(anyLong(), anyInt());

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -1474,4 +1474,73 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenComments() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  public String getSomeStringField() {
+                      return "X";
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  MyObject myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          // comments for this line below
+                          myObject.getSomeStringField();
+                          result = "a";
+                      }};
+                      assertEquals("a", myObject.getSomeStringField());
+                      new Expectations() {{
+                          myObject.getSomeStringField();
+                          result = "b";
+                      }};
+                      assertEquals("b", myObject.getSomeStringField());
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+              import static org.mockito.Mockito.when;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  MyObject myObject;
+
+                  void test() {
+                      when(myObject.getSomeStringField()).thenReturn("a");
+                      assertEquals("a", myObject.getSomeStringField());
+                      when(myObject.getSomeStringField()).thenReturn("b");
+                      assertEquals("b", myObject.getSomeStringField());
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
At the moment, JMockit Delegates are not migrated to mockito as mentioned in issue
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/522. 

What I'm seeing is that they are being trashed with the template being printed out. These tests were written to try to replicate this issue, however I was unable to.
They may help anyone adding the feature for Delegate migration.

https://javadoc.io/doc/org.jmockit/jmockit/latest/mockit/Delegate.html

Also added one test case showing comments are not preserved.

I am wondering if it's better to have the test cases failing with the expected output and to disable them. Please let me know if that's preferred.

## Anyone you would like to review specifically?
@timtebeek @tinder-dthomson 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
