### PR TITLE
Convert lambda block to expression after adopting `assertThrows`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.search.FindImports;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markup;
+import org.openrewrite.staticanalysis.LambdaBlockToExpression;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -169,6 +170,8 @@ public class UpdateTestAnnotation extends Recipe {
                 }
                 maybeAddImport("org.junit.jupiter.api.Test");
             }
+
+            doAfterVisit(new LambdaBlockToExpression().getVisitor());
 
             return super.visitMethodDeclaration(m, ctx);
         }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -35,6 +35,7 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
           .recipe(new JUnitAssertThrowsToAssertExceptionType());
     }
 
+    @SuppressWarnings({"Convert2MethodRef", "CodeBlock2Expr"})
     @DocumentExample
     @Test
     void toAssertExceptionOfType() {
@@ -47,8 +48,11 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
               public class SimpleExpectedExceptionTest {
                   public void throwsExceptionWithSpecificType() {
                       assertThrows(NullPointerException.class, () -> {
-                          throw new NullPointerException();
+                          foo();
                       });
+                  }
+                  void foo() {
+                      throw new NullPointerException();
                   }
               }
               """,
@@ -57,9 +61,11 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
               
               public class SimpleExpectedExceptionTest {
                   public void throwsExceptionWithSpecificType() {
-                      assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
-                          throw new NullPointerException();
-                      });
+                      assertThatExceptionOfType(NullPointerException.class).isThrownBy(() ->
+                          foo());
+                  }
+                  void foo() {
+                      throw new NullPointerException();
                   }
               }
               """
@@ -127,6 +133,7 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
      * A degenerate case showing we need to make sure the <code>assertThrows</code> appears
      * immediately inside a J.Block.
      */
+    @SuppressWarnings("ThrowableNotThrown")
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/pull/331")
     void assertThrowsTernaryAssignment() {

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -106,7 +106,8 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
               
                   @Test
                   public void testEmptyPath() {
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                       assertTrue(exception.getMessage().contains("Invalid location: gs://"));
                   }
                   void foo() {
@@ -459,7 +460,8 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
               
                   @Test
                   public void testEmptyPath() {
-                      assertThrows(IOException.class, () -> foo());
+                      assertThrows(IOException.class, () ->
+                          foo());
                   }
                   void foo() throws IOException {
                       throw new IOException();

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -114,7 +114,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
             """
               import org.junit.Test;
 
-              public class MyTest {
+              class MyTest {
 
                   @Test(expected = IllegalArgumentException.class)
                   public void test() {
@@ -130,7 +130,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
 
               import static org.junit.jupiter.api.Assertions.assertThrows;
 
-              public class MyTest {
+              class MyTest {
 
                   @Test
                   public void test() {
@@ -153,9 +153,9 @@ class UpdateTestAnnotationTest implements RewriteTest {
           java(
             """
               import org.junit.Test;
-                                
+
               public class MyTest {
-                                
+
                   @Test(expected = IndexOutOfBoundsException.class)
                   public void test() {
                       int arr = new int[]{}[0];
@@ -601,7 +601,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                       // Second call shows why we wrap the entire method body in the lambda
                       foo();
                   }
-                  
+
                   void foo() throws IOException {
                       throw new IOException();
                   }
@@ -624,7 +624,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                           foo();
                       });
                   }
-                  
+
                   void foo() throws IOException {
                       throw new IOException();
                   }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -106,6 +106,45 @@ class UpdateTestAnnotationTest implements RewriteTest {
         );
     }
 
+    @Test
+    void assertThrowsSingleLineInlined() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+
+              public class MyTest {
+
+                  @Test(expected = IllegalArgumentException.class)
+                  public void test() {
+                      foo();
+                  }
+                  private void foo() {
+                      throw new IllegalArgumentException("boom");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void test() {
+                      assertThrows(IllegalArgumentException.class, () -> foo());
+                  }
+                  private void foo() {
+                      throw new IllegalArgumentException("boom");
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("ConstantConditions")
     @Test
     void assertThrowsSingleStatement() {
@@ -113,16 +152,16 @@ class UpdateTestAnnotationTest implements RewriteTest {
         rewriteRun(
           java(
             """
-                  import org.junit.Test;
-                  
-                  public class MyTest {
-                  
-                      @Test(expected = IndexOutOfBoundsException.class)
-                      public void test() {
-                          int arr = new int[]{}[0];
-                      }
+              import org.junit.Test;
+                                
+              public class MyTest {
+                                
+                  @Test(expected = IndexOutOfBoundsException.class)
+                  public void test() {
+                      int arr = new int[]{}[0];
                   }
-                  """,
+              }
+              """,
             """
               import org.junit.jupiter.api.Test;
 
@@ -562,7 +601,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                       // Second call shows why we wrap the entire method body in the lambda
                       foo();
                   }
-    
+                  
                   void foo() throws IOException {
                       throw new IOException();
                   }
@@ -585,7 +624,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
                           foo();
                       });
                   }
-    
+                  
                   void foo() throws IOException {
                       throw new IOException();
                   }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -134,7 +134,8 @@ class UpdateTestAnnotationTest implements RewriteTest {
 
                   @Test
                   public void test() {
-                      assertThrows(IllegalArgumentException.class, () -> foo());
+                      assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                   }
                   private void foo() {
                       throw new IllegalArgumentException("boom");


### PR DESCRIPTION
Test case for inlining valid single line assertthrows

## What's changed?
Inline valid single line assert throws test case

## What's your motivation?
This recipe creates intellij suggestion/warning to inline this code and I much prefer it inlined, saves 2 lines of useless code.

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Yes - maybe a separate recipe which achieves this is better, or maybe both - change this recipe, and have a separate recipe. Can do separate recipe first as it addresses at a global level.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
