### PR TITLE
Prevent `ExpectedExceptionToAssertThrows` from pulling variable declarations into lambda

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.search.FindImports;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markup;
+import org.openrewrite.staticanalysis.LambdaBlockToExpression;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -168,6 +169,8 @@ public class UpdateTestAnnotation extends Recipe {
                     maybeAddImport("java.util.concurrent.TimeUnit");
                 }
                 maybeAddImport("org.junit.jupiter.api.Test");
+
+                doAfterVisit(new LambdaBlockToExpression().getVisitor());
             }
 
             return super.visitMethodDeclaration(m, ctx);

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -173,8 +173,6 @@ public class UpdateTestAnnotation extends Recipe {
                 doAfterVisit(new LambdaBlockToExpression().getVisitor());
             }
 
-            doAfterVisit(new LambdaBlockToExpression().getVisitor());
-
             return super.visitMethodDeclaration(m, ctx);
         }
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -469,4 +469,51 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void variableDeclarationsShouldNotBePulledIntoAssertThrowsLambda() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              class MyTest {
+
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMethod() {
+                      int num = 1;
+                      String message = "message";
+
+                      thrown.expect(RuntimeException.class);
+                      thrown.expectMessage("Using vars" + num + message);
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void testMethod() {
+                      int num = 1;
+                      String message = "message";
+                      Throwable exception = assertThrows(RuntimeException.class, () -> {
+                      });
+                      assertTrue(exception.getMessage().contains("Using vars" + num + message));
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -492,6 +492,11 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
 
                       thrown.expect(RuntimeException.class);
                       thrown.expectMessage("Using vars" + num + message);
+                      foo();
+                  }
+    
+                  void foo() {
+                      throw new RuntimeException("Using vars");
                   }
               }
               """,
@@ -508,8 +513,12 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                       int num = 1;
                       String message = "message";
                       Throwable exception = assertThrows(RuntimeException.class, () -> {
-                      });
-                      assertTrue(exception.getMessage().contains("Using vars" + num + message));
+                          foo();
+                      }, "Using vars" + num + message);
+                  }
+    
+                  void foo() {
+                      throw new RuntimeException("Using vars");
                   }
               }
               """


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Added a testcase to prove them problem exists

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/572
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/194