### PR TITLE
`PowerMockitoMockStaticToMockito` duplicates variables and methods when static nested class is involved

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -446,7 +446,6 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                                 new Cursor(getCursor().getParentOrThrow(), classDecl),
                                 classDecl.getBody().getCoordinates().firstStatement(),
                                 classlessTypeName,
-                                // Not sure if replacing `.` with `_` is a structural solution, but it works for inner classes for now
                                 classlessTypeName.replace(".", "_")
                         );
 

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -43,8 +43,8 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 Preconditions.or(
-                    new UsesType<>("org.powermock..*", false),
-                    new UsesType<>("org.mockito..*", false)
+                        new UsesType<>("org.powermock..*", false),
+                        new UsesType<>("org.mockito..*", false)
                 ),
                 new PowerMockitoToMockitoVisitor()
         );
@@ -446,7 +446,8 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                                 new Cursor(getCursor().getParentOrThrow(), classDecl),
                                 classDecl.getBody().getCoordinates().firstStatement(),
                                 classlessTypeName,
-                                classlessTypeName
+                                // Not sure if replacing `.` with `_` is a structural solution, but it works for inner classes for now
+                                classlessTypeName.replace(".", "_")
                         );
 
                 J.VariableDeclarations mockField = (J.VariableDeclarations) classDecl.getBody().getStatements().get(0);

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -654,7 +654,8 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
               public class MyTest {
 
-                  private MockedStatic<A.B> mockedAB;
+                  private MockedStatic<A.B> mockedA_B;
+
                   private static final String TEST_MESSAGE = "this is a test message";
 
                   @Before
@@ -663,12 +664,12 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
                   @BeforeEach
                   void setUpStaticMocks() {
-                      mockedAB = Mockito.mockStatic(A.B.class);
+                      mockedA_B = Mockito.mockStatic(A.B.class);
                   }
 
                   @AfterEach
                   void tearDownStaticMocks() {
-                      mockedAB.closeOnDemand();
+                      mockedA_B.closeOnDemand();
                   }
 
                   @Test


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Add minimalistic testcase to show that when a static nested class is mocked, it tries to add a field declaration but the JavaTemplate breaks duplicating fields and methods.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
