### PR TITLE
Move Junit 5 assertThrows to last statement in lamdba

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -43,8 +43,8 @@ public class AssertThrowsOnLastStatement extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Applies Junit 5 assertThrows on last statement in lambda block only, in rare cases may cause compilation " +
-                "errors if lambda uses non final variables.";
+        return "Applies Junit 5 assertThrows on last statement in lambda block only, in extremely rare cases may cause " +
+                "compilation errors if lambda uses non final variables.";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -100,6 +100,8 @@ public class AssertThrowsOnLastStatement extends Recipe {
                         return methodStatement;
                     }
 
+                    // TODO Check to see if last line in lambda does not use a non-final variable
+
                     // move all the statements from the body into before the method invocation, except last one
                     return ListUtils.map(lambdaStatements, (idx, lambdaStatement) -> {
                         if (idx < lambdaStatements.size() - 1) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -31,6 +31,8 @@ import org.openrewrite.staticanalysis.LambdaBlockToExpression;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
+
 
 public class AssertThrowsOnLastStatement extends Recipe {
 
@@ -41,7 +43,8 @@ public class AssertThrowsOnLastStatement extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Applies Junit 5 assertThrows on last statement in lambda block only.";
+        return "Applies Junit 5 assertThrows on last statement in lambda block only, in rare cases may cause compilation " +
+                "errors if lambda uses non final variables.";
     }
 
     @Override
@@ -119,7 +122,7 @@ public class AssertThrowsOnLastStatement extends Recipe {
                                 ListUtils.map(arguments, (argIdx, argument) -> {
                                     if (argIdx == 1) {
                                         // Only retain the last statement in the lambda block
-                                        return lambda.withBody(body.withStatements(Collections.singletonList(lambdaStatement)));
+                                        return lambda.withBody(body.withStatements(singletonList(lambdaStatement)));
                                     }
                                     return argument;
                                 })
@@ -130,7 +133,7 @@ public class AssertThrowsOnLastStatement extends Recipe {
                         }
 
                         J.VariableDeclarations.NamedVariable newAssertThrowsVar = assertThrowsVar.withInitializer(newAssertThrows);
-                        return assertThrowsWithVarDec.withVariables(Collections.singletonList(newAssertThrowsVar));
+                        return assertThrowsWithVarDec.withVariables(singletonList(newAssertThrowsVar));
                     });
 
                 })));

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaCoordinates;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.staticanalysis.LambdaBlockToExpression;
+
+import java.util.List;
+
+
+public class AssertThrowsOnLastStatement extends Recipe {
+
+    private static final String ASSERTIONS_FQN = "org.junit.jupiter.api.Assertions";
+
+    @Override
+    public String getDisplayName() {
+        return "Applies Junit 5 assertThrows on last statement in lamdba block only";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Applies Junit 5 assertThrows on last statement in lambda block only.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // TODO change to uses method below?
+        return Preconditions.check(new UsesType<>(ASSERTIONS_FQN, false), new AssertThrowsOnLastStatementVisitor());
+    }
+
+    private static class AssertThrowsOnLastStatementVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private JavaParser.@Nullable Builder<?, ?> javaParser;
+
+        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
+            if (javaParser == null) {
+                javaParser = JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5.9");
+            }
+            return javaParser;
+
+        }
+
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(methodDecl, ctx);
+            List<Statement> methodStatements = m.getBody().getStatements();
+
+            for (Statement methodStatement : methodStatements) {
+                J statementToCheck = methodStatement;
+                if (methodStatement instanceof J.VariableDeclarations) {
+                    J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) methodStatement;
+                    List<J.VariableDeclarations.NamedVariable> variables = variableDeclarations.getVariables();
+                    if (variables.isEmpty())
+                        continue;
+                    statementToCheck = variables.get(0).getInitializer();
+                }
+
+                if (!(statementToCheck instanceof J.MethodInvocation))
+                    continue;
+
+                J.MethodInvocation methodInvocation = (J.MethodInvocation) statementToCheck;
+                if (methodInvocation.getMethodType() == null || !methodInvocation.getName().getSimpleName().equals("assertThrows"))
+                    continue;
+
+                if (!ASSERTIONS_FQN.equals(methodInvocation.getMethodType().getDeclaringType().getFullyQualifiedName()))
+                    continue;
+
+                List<Expression> arguments = methodInvocation.getArguments();
+                if (arguments.size() <= 1)
+                    continue;
+
+                Expression arg = arguments.get(1);
+                if (!(arg instanceof J.Lambda))
+                    continue;
+
+                J.Lambda lambda = (J.Lambda) arg;
+                if (!(lambda.getBody() instanceof J.Block))
+                    continue;
+
+                J.Block body = (J.Block) lambda.getBody();
+                if (body == null)
+                    continue;
+
+                List<Statement> lambdaStatements = body.getStatements();
+                if (lambdaStatements.size() <= 1)
+                    continue;
+
+                // move all the statements from the body into before the method invocation, except last one
+                JavaCoordinates beforeCoords = methodStatement.getCoordinates().before();
+                int lastStatementIdx = lambdaStatements.size() - 1;
+                Statement last = lambdaStatements.get(lastStatementIdx);
+                lambdaStatements.remove(lastStatementIdx);
+                for (Statement statement : lambdaStatements) {
+                    // add the new statements before the assertThrows
+                }
+            }
+
+            super.doAfterVisit(new LambdaBlockToExpression().getVisitor());
+            return m;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -74,40 +74,49 @@ public class AssertThrowsOnLastStatement extends Recipe {
                 if (methodStatement instanceof J.VariableDeclarations) {
                     J.VariableDeclarations variableDeclarations = (J.VariableDeclarations) methodStatement;
                     List<J.VariableDeclarations.NamedVariable> variables = variableDeclarations.getVariables();
-                    if (variables.isEmpty())
+                    if (variables.isEmpty()) {
                         continue;
+                    }
                     statementToCheck = variables.get(0).getInitializer();
                 }
 
-                if (!(statementToCheck instanceof J.MethodInvocation))
+                if (!(statementToCheck instanceof J.MethodInvocation)) {
                     continue;
+                }
 
                 J.MethodInvocation methodInvocation = (J.MethodInvocation) statementToCheck;
-                if (methodInvocation.getMethodType() == null || !methodInvocation.getName().getSimpleName().equals("assertThrows"))
+                if (methodInvocation.getMethodType() == null || !methodInvocation.getName().getSimpleName().equals("assertThrows")) {
                     continue;
+                }
 
-                if (!ASSERTIONS_FQN.equals(methodInvocation.getMethodType().getDeclaringType().getFullyQualifiedName()))
+                if (!ASSERTIONS_FQN.equals(methodInvocation.getMethodType().getDeclaringType().getFullyQualifiedName())) {
                     continue;
+                }
 
                 List<Expression> arguments = methodInvocation.getArguments();
-                if (arguments.size() <= 1)
+                if (arguments.size() <= 1) {
                     continue;
+                }
 
                 Expression arg = arguments.get(1);
-                if (!(arg instanceof J.Lambda))
+                if (!(arg instanceof J.Lambda)) {
                     continue;
+                }
 
                 J.Lambda lambda = (J.Lambda) arg;
-                if (!(lambda.getBody() instanceof J.Block))
+                if (!(lambda.getBody() instanceof J.Block)) {
                     continue;
+                }
 
                 J.Block body = (J.Block) lambda.getBody();
-                if (body == null)
+                if (body == null) {
                     continue;
+                }
 
                 List<Statement> lambdaStatements = body.getStatements();
-                if (lambdaStatements.size() <= 1)
+                if (lambdaStatements.size() <= 1) {
                     continue;
+                }
 
                 // move all the statements from the body into before the method invocation, except last one
                 JavaCoordinates beforeCoords = methodStatement.getCoordinates().before();

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2021 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class AssertThrowsOnLastStatementTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9.2"))
+          .recipe(new AssertThrowsOnLastStatement());
+    }
+
+    @DocumentExample
+    @Test
+    void applyToLastStatementWithDeclaringVariableThreeLines() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                          System.out.println("foo");
+                          foo();
+                      });
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      foo();
+                      System.out.println("foo");
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyToLastStatementNoDeclaringVariableTwoLines() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      assertThrows(IllegalArgumentException.class, () -> {
+                          System.out.println("foo");
+                          foo();
+                      });
+                  }
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      System.out.println("foo");
+                      assertThrows(IllegalArgumentException.class, () -> foo());
+                  }
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void makeNoChagesAsOneLine() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -187,6 +187,51 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
     }
 
     @Test
+    void applyToLastStatementHasMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      assertThrows(IllegalArgumentException.class, () -> {
+                          System.out.println("foo");
+                          foo();
+                      }, "message");
+                  }
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      System.out.println("foo");
+                      assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                      }, "message");
+                  }
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void makeNoChangesAsOneLine() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+// TODO possible to remove the curly braces for lamdba and inline?
 class AssertThrowsOnLastStatementTest implements RewriteTest {
 
     @Override
@@ -43,12 +44,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-              
+                            
               class MyTest {
-              
+                            
                   @Test
                   public void test() {
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -64,17 +65,19 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-              
+                            
               class MyTest {
-              
+                            
                   @Test
                   public void test() {
                       foo();
                       System.out.println("foo");
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                      });
                       assertEquals("Error message", exception.getMessage());
                   }
                   void foo() {
@@ -86,17 +89,70 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
     }
 
     @Test
-    void applyToLastStatementNoDeclaringVariableTwoLines() {
+    void applyToLastStatementWithDeclaringVariableThreeLinesHasLineBefore() {
         //language=java
         rewriteRun(
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-              
+                            
               class MyTest {
-              
+                            
+                  @Test
+                  public void test() {             
+                      System.out.println("bla");
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                          System.out.println("foo");
+                          foo();
+                      });
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
+                  @Test
+                  public void test() {
+                      System.out.println("bla");
+                      foo();
+                      System.out.println("foo");
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                      });
+                      assertEquals("Error message", exception.getMessage());
+                  }
+                  void foo() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void applyToLastStatementNoDeclaringVariableTwoLinesNoLinesAfter() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+                            
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+                            
+              class MyTest {
+                            
                   @Test
                   public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
@@ -110,16 +166,17 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertThrows;
-              
+                            
               class MyTest {
-              
+                            
                   @Test
                   public void test() {
                       System.out.println("foo");
-                      assertThrows(IllegalArgumentException.class, () ->
-                          foo());
+                      assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                      });
                   }
                   void foo() {
                   }
@@ -136,12 +193,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-              
+                            
               class MyTest {
-              
+                            
                   @Test
                   public void test() {
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -30,7 +30,7 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .logCompilationWarningsAndErrors(true)
+            //.logCompilationWarningsAndErrors(true)
             .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
           .recipe(new AssertThrowsOnLastStatement());
     }
@@ -93,7 +93,6 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
               
-              import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
               
               class MyTest {
@@ -119,7 +118,8 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
                   @Test
                   public void test() {
                       System.out.println("foo");
-                      assertThrows(IllegalArgumentException.class, () -> foo());
+                      assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                   }
                   void foo() {
                   }
@@ -130,27 +130,10 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
     }
 
     @Test
-    void makeNoChagesAsOneLine() {
+    void makeNoChangesAsOneLine() {
         //language=java
         rewriteRun(
           java(
-            """
-              import org.junit.jupiter.api.Test;
-              
-              import static org.junit.jupiter.api.Assertions.assertEquals;
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-              
-              class MyTest {
-              
-                  @Test
-                  public void test() {
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
-                      assertEquals("Error message", exception.getMessage());
-                  }
-                  void foo() {
-                  }
-              }
-              """,
             """
               import org.junit.jupiter.api.Test;
               

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -24,7 +24,6 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-// TODO possible to remove the curly braces for lamdba and inline?
 class AssertThrowsOnLastStatementTest implements RewriteTest {
 
     @Override
@@ -75,9 +74,8 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
                   public void test() {
                       foo();
                       System.out.println("foo");
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-                          foo();
-                      });
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                       assertEquals("Error message", exception.getMessage());
                   }
                   void foo() {
@@ -102,7 +100,7 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               class MyTest {
                             
                   @Test
-                  public void test() {             
+                  public void test() {
                       System.out.println("bla");
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
                           foo();
@@ -128,9 +126,8 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
                       System.out.println("bla");
                       foo();
                       System.out.println("foo");
-                      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-                          foo();
-                      });
+                      Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                       assertEquals("Error message", exception.getMessage());
                   }
                   void foo() {
@@ -174,9 +171,8 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
                   @Test
                   public void test() {
                       System.out.println("foo");
-                      assertThrows(IllegalArgumentException.class, () -> {
-                          foo();
-                      });
+                      assertThrows(IllegalArgumentException.class, () ->
+                          foo());
                   }
                   void foo() {
                   }

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -31,7 +31,7 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .logCompilationWarningsAndErrors(true)
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9.2"))
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
           .recipe(new AssertThrowsOnLastStatement());
     }
 
@@ -43,12 +43,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -64,12 +64,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       foo();
@@ -92,12 +92,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
@@ -111,11 +111,11 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       System.out.println("foo");
@@ -136,12 +136,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
           java(
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());
@@ -153,12 +153,12 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertThrows;
-                            
+              
               class MyTest {
-                            
+              
                   @Test
                   public void test() {
                       Throwable exception = assertThrows(IllegalArgumentException.class, () -> foo());


### PR DESCRIPTION
## What's changed?
In multi line assertThrows move assertThrows to last statement only

## What's your motivation?
Currently the Junit 4 to 5 recipe migrates the @Test junit 4 annotation to wrap the entire method to assertThrows when typically we want it on the last statement.
 
## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
Yes - may be modifying the existing recipe is better? Rather than providing an extra recipe to move existing assertThrows with multi line lamdbas to the last statement only, but we can hook this recipe in optionally, so ... maybe not. Maybe that can be an optional argument in the existing recipe - move applyAssertThrowsToLast and the user can set it to true if they are ok to take a hit of compilation errors in favour of better usage of junit 5 features and correctness.

## Any additional context
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/194

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
