### PR TITLE
Add recipes for negative variants of startsWith, endsWith, and matches

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -111,14 +111,29 @@ recipeList:
       dedicatedAssertion: startsWith
       requiredType: java.lang.String
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: startsWith
+      assertToReplace: isFalse
+      dedicatedAssertion: doesNotStartWith
+      requiredType: java.lang.String
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
       chainedAssertion: endsWith
       assertToReplace: isTrue
       dedicatedAssertion: endsWith
       requiredType: java.lang.String
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: endsWith
+      assertToReplace: isFalse
+      dedicatedAssertion: doesNotEndWith
+      requiredType: java.lang.String
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
       chainedAssertion: matches
       assertToReplace: isTrue
       dedicatedAssertion: matches
+      requiredType: java.lang.String
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
+      chainedAssertion: matches
+      assertToReplace: isFalse
+      dedicatedAssertion: doesNotMatch
       requiredType: java.lang.String
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion:
       chainedAssertion: trim

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionsTest.java
@@ -85,8 +85,11 @@ class SimplifyChainedAssertJAssertionsTest implements RewriteTest {
               Arguments.arguments("equalsIgnoreCase", "isTrue", "isEqualToIgnoringCase", "expected", ""),
               Arguments.arguments("contains", "isTrue", "contains", "expected", ""),
               Arguments.arguments("startsWith", "isTrue", "startsWith", "expected", ""),
+              Arguments.arguments("startsWith", "isFalse", "doesNotStartWith", "expected", ""),
               Arguments.arguments("endsWith", "isTrue", "endsWith", "expected", ""),
+              Arguments.arguments("endsWith", "isFalse", "doesNotEndWith", "expected", ""),
               Arguments.arguments("matches", "isTrue", "matches", "expected", ""),
+              Arguments.arguments("matches", "isFalse", "doesNotMatch", "expected", ""),
               Arguments.arguments("trim", "isEmpty", "isBlank", "", ""),
               Arguments.arguments("length", "isEqualTo", "hasSize", "", "length"),
               Arguments.arguments("isEmpty", "isFalse", "isNotEmpty", "", "")


### PR DESCRIPTION
## What's changed?
- Part of #571 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
