### PR TITLE
When upgrading mockito also upgrade potential byte buddy dependencies

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -45,11 +45,7 @@ recipeList:
       newVersion: 5.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
-      artifactId: byte-buddy
-      newVersion: 1.15.x
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: net.bytebuddy
-      artifactId: byte-buddy-agent
+      artifactId: byte-buddy*
       newVersion: 1.15.x
   - org.openrewrite.maven.RemoveDuplicateDependencies
 
@@ -69,11 +65,7 @@ recipeList:
       newVersion: 4.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
-      artifactId: byte-buddy
-      newVersion: 1.12.19
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: net.bytebuddy
-      artifactId: byte-buddy-agent
+      artifactId: byte-buddy*
       newVersion: 1.12.19
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -178,9 +170,5 @@ recipeList:
       newArtifactId: mockito-core
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
-      artifactId: byte-buddy
-      newVersion: 1.11.13
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: net.bytebuddy
-      artifactId: byte-buddy-agent
+      artifactId: byte-buddy*
       newVersion: 1.11.13

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -43,6 +43,14 @@ recipeList:
       groupId: org.mockito
       artifactId: "*"
       newVersion: 5.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.15.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.15.x
   - org.openrewrite.maven.RemoveDuplicateDependencies
 
 ---
@@ -59,6 +67,14 @@ recipeList:
       groupId: org.mockito
       artifactId: "*"
       newVersion: 4.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.12.19
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.12.19
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.mockito.Mockito1to3Migration
@@ -143,8 +159,8 @@ recipeList:
   - org.openrewrite.java.testing.mockito.CleanupMockitoImports
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
-# https://github.com/openrewrite/rewrite-testing-frameworks/issues/360
-#  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
+  # https://github.com/openrewrite/rewrite-testing-frameworks/issues/360
+  #  - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.testing.mockito.RetainStrictnessWarn
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
@@ -160,3 +176,11 @@ recipeList:
       oldGroupId: org.mockito
       oldArtifactId: mockito-all
       newArtifactId: mockito-core
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy
+      newVersion: 1.11.13
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: net.bytebuddy
+      artifactId: byte-buddy-agent
+      newVersion: 1.11.13

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
@@ -122,4 +122,61 @@ class MockitoInlineToCoreTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldUpdateByteBuddy() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>5.13.0</version>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                        <version>1.12.19</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+              </project>
+              """,
+            sourceSpecs -> sourceSpecs.after(after -> {
+                String mockitoVersion = Pattern.compile("<version>(5.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
+                String byteBuddyVersion = Pattern.compile("<version>(1.15.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
+                return """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>demo</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <version>%s</version>
+                            <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.bytebuddy</groupId>
+                            <artifactId>byte-buddy</artifactId>
+                            <version>%s</version>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(mockitoVersion, byteBuddyVersion);
+            })
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.mockito;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -29,6 +30,7 @@ class MockitoInlineToCoreTest implements RewriteTest {
         spec.recipeFromResources("org.openrewrite.java.testing.mockito.Mockito1to5Migration");
     }
 
+    @DocumentExample
     @Test
     void inlineToCore() {
         rewriteRun(
@@ -50,25 +52,22 @@ class MockitoInlineToCoreTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            sourceSpecs -> sourceSpecs.after(after -> {
-                String version = Pattern.compile("<version>(5.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
-                return """
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.mockito</groupId>
-                            <artifactId>mockito-core</artifactId>
-                            <version>%s</version>
-                            <scope>test</scope>
-                        </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(version);
-            })
+            spec -> spec.after(after -> """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>%s</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+              </project>
+              """.formatted(Pattern.compile("<version>(5.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1)))
           )
         );
     }
@@ -100,25 +99,22 @@ class MockitoInlineToCoreTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            sourceSpecs -> sourceSpecs.after(after -> {
-                String version = Pattern.compile("<version>(5.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
-                return """
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.mockito</groupId>
-                            <artifactId>mockito-core</artifactId>
-                            <version>%s</version>
-                            <scope>test</scope>
-                        </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(version);
-            })
+            spec -> spec.after(after -> """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>%s</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+              </project>
+              """.formatted(Pattern.compile("<version>(5.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1)))
           )
         );
     }
@@ -150,32 +146,30 @@ class MockitoInlineToCoreTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            sourceSpecs -> sourceSpecs.after(after -> {
-                String mockitoVersion = Pattern.compile("<version>(5.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
-                String byteBuddyVersion = Pattern.compile("<version>(1.15.+)</version>").matcher(after).results().reduce((a, b) -> b).orElseThrow().group(1);
-                return """
-                  <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>com.example</groupId>
-                    <artifactId>demo</artifactId>
-                    <version>0.0.1-SNAPSHOT</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.mockito</groupId>
-                            <artifactId>mockito-core</artifactId>
-                            <version>%s</version>
-                            <scope>test</scope>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.bytebuddy</groupId>
-                            <artifactId>byte-buddy</artifactId>
-                            <version>%s</version>
-                            <scope>test</scope>
-                        </dependency>
-                    </dependencies>
-                  </project>
-                  """.formatted(mockitoVersion, byteBuddyVersion);
-            })
+            spec -> spec.after(after -> """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.example</groupId>
+                <artifactId>demo</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>%s</version>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>net.bytebuddy</groupId>
+                        <artifactId>byte-buddy</artifactId>
+                        <version>%s</version>
+                        <scope>test</scope>
+                    </dependency>
+                </dependencies>
+              </project>
+              """.formatted(
+              Pattern.compile("<version>(5.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1),
+              Pattern.compile("<version>(1.15.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1)))
           )
         );
     }


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Also upgrade byte buddy during mockito upgrade

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
If the version of byte-buddy and byte-buddy agent mismatch the mockmaker plugin cannot be initialized

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Test coverage

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
