### PR TITLE
Refactor `Mockito.when` on static (non mock) to try with resource

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -56,13 +56,13 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                         List<Statement> statementsAfterWhen = new ArrayList<>();
                         for (Statement stmt : m.getBody().getStatements()) {
                             if (stmt instanceof J.MethodInvocation &&
-                                MOCKITO_WHEN.matches(((J.MethodInvocation)stmt).getSelect())) {
-                                J.MethodInvocation when = (J.MethodInvocation)((J.MethodInvocation) stmt).getSelect();
-                                if (when.getArguments().get(0) instanceof J.MethodInvocation && ((J.MethodInvocation)when.getArguments().get(0)).getMethodType().getFlags().contains(Flag.Static)){
+                                MOCKITO_WHEN.matches(((J.MethodInvocation) stmt).getSelect())) {
+                                J.MethodInvocation when = (J.MethodInvocation) ((J.MethodInvocation) stmt).getSelect();
+                                if (when.getArguments().get(0) instanceof J.MethodInvocation && ((J.MethodInvocation) when.getArguments().get(0)).getMethodType().getFlags().contains(Flag.Static)) {
                                     JavaType.FullyQualified arg_fq = TypeUtils.asFullyQualified(when.getArguments().get(0).getType());
                                     String template = String.format("try(MockedStatic<%s> mock%s = mockStatic(%s.class)){\n" +
                                                                     "mock%s.when(%s::%s).thenReturn(%s);\n" +
-                                                                    "}", arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), ((J.MethodInvocation)when.getArguments().get(0)).getSimpleName(), ((J.MethodInvocation) stmt).getArguments().get(0));
+                                                                    "}", arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), ((J.MethodInvocation) when.getArguments().get(0)).getSimpleName(), ((J.MethodInvocation) stmt).getArguments().get(0));
                                     m = JavaTemplate.builder(template)
                                             .contextSensitive()
                                             .javaParser(JavaParser.fromJavaVersion())

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockitoWhenOnStaticToMockStatic extends Recipe {
+
+    private static final MethodMatcher MOCKITO_WHEN = new MethodMatcher("org.mockito.Mockito when(..)");
+
+    @Override
+    public String getDisplayName() {
+        return "";
+    }
+
+    @Override
+    public String getDescription() {
+        return ".";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("org.mockito.Mockito", true),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                        J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+                        boolean rewrittenWhen = false;
+                        List<Statement> statementsBeforeWhen = new ArrayList<>();
+                        List<Statement> statementsAfterWhen = new ArrayList<>();
+                        for (Statement stmt : m.getBody().getStatements()) {
+                            if (stmt instanceof J.MethodInvocation &&
+                                MOCKITO_WHEN.matches(((J.MethodInvocation)stmt).getSelect())) {
+                                J.MethodInvocation when = (J.MethodInvocation)((J.MethodInvocation) stmt).getSelect();
+                                if (when.getArguments().get(0) instanceof J.MethodInvocation && ((J.MethodInvocation)when.getArguments().get(0)).getMethodType().getFlags().contains(Flag.Static)){
+                                    JavaType.FullyQualified arg_fq = TypeUtils.asFullyQualified(when.getArguments().get(0).getType());
+                                    String template = String.format("try(MockedStatic<%s> mock%s = mockStatic(%s.class)){\n" +
+                                                                    "mock%s.when(%s::%s).thenReturn(%s);\n" +
+                                                                    "}", arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), arg_fq.getClassName(), ((J.MethodInvocation)when.getArguments().get(0)).getSimpleName(), ((J.MethodInvocation) stmt).getArguments().get(0));
+                                    m = JavaTemplate.builder(template)
+                                            .contextSensitive()
+                                            .javaParser(JavaParser.fromJavaVersion())
+                                            .staticImports("org.mockito.Mockito.mockStatic")
+                                            .build()
+                                            .apply(getCursor(), stmt.getCoordinates().replace());
+                                    rewrittenWhen = true;
+                                    maybeAddImport("org.mockito.Mockito", "mockStatic");
+                                    continue;
+                                }
+                            }
+                            if (rewrittenWhen) {
+                                statementsAfterWhen.add(stmt);
+                            } else {
+                                statementsBeforeWhen.add(stmt);
+                            }
+                        }
+                        if (rewrittenWhen) {
+                            J.Try try_catch = (J.Try) m.getBody().getStatements().get(statementsBeforeWhen.size());
+                            return maybeAutoFormat(method, m.withBody(m.getBody().withStatements(ListUtils.concat(statementsBeforeWhen, try_catch.withBody(try_catch.getBody().withStatements(ListUtils.concatAll(try_catch.getBody().getStatements(), statementsAfterWhen)))))), ctx);
+                        } else {
+                            return m;
+                        }
+                    }
+                });
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -65,7 +65,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
                     private List<Statement> getStatements(List<Statement> originalStatements, J.MethodDeclaration m) {
                         AtomicBoolean restInTry = new AtomicBoolean(false);
-                        List<Statement> newStatements = ListUtils.flatMap(originalStatements, (index, statement) -> {
+                        return ListUtils.flatMap(originalStatements, (index, statement) -> {
                             if (restInTry.get()) {
                                 // Rest of the statements have ended up in the try block
                                 return Collections.emptyList();
@@ -108,7 +108,6 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                             }
                             return statement;
                         });
-                        return newStatements;
                     }
                 });
     }

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -15,7 +15,10 @@
  */
 package org.openrewrite.java.testing.mockito;
 
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesMethod;

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -81,16 +81,15 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                     maybeAddImport("org.mockito.MockedStatic", false);
                                     maybeAddImport("org.mockito.Mockito", "mockStatic");
                                     String template = String.format(
-                                            "try(MockedStatic<#{}> %1$s = mockStatic(#{}.class)) {\n" +
-                                            "    %1$s.when(#{any()}).thenReturn(#{any()});\n" +
-                                            "}", mockName);
+                                            "try(MockedStatic<%1$s> %2$s = mockStatic(%1$s.class)) {\n" +
+                                            "    %2$s.when(#{any()}).thenReturn(#{any()});\n" +
+                                            "}", clazz.getSimpleName(), mockName);
                                     J.Try try_ = (J.Try) ((J.MethodDeclaration) JavaTemplate.builder(template)
                                             .contextSensitive()
                                             .imports("org.mockito.MockedStatic")
                                             .staticImports("org.mockito.Mockito.mockStatic")
                                             .build()
                                             .apply(getCursor(), m.getCoordinates().replaceBody(),
-                                                    clazz.getType(), clazz.getType(),
                                                     whenArg, ((J.MethodInvocation) statement).getArguments().get(0)))
                                             .getBody().getStatements().get(0);
 

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -49,66 +49,67 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(
-                new UsesMethod<>(MOCKITO_WHEN),
-                new JavaIsoVisitor<ExecutionContext>() {
-                    @Override
-                    public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                        J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-                        if (m.getBody() == null) {
-                            return m;
-                        }
+        return Preconditions.check(new UsesMethod<>(MOCKITO_WHEN), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+                if (m.getBody() == null) {
+                    return m;
+                }
 
-                        List<Statement> newStatements = getStatements(m.getBody().getStatements(), m);
-                        return maybeAutoFormat(m, m.withBody(m.getBody().withStatements(newStatements)), ctx);
+                List<Statement> newStatements = maybeWrapStatementsInTryWithResourcesMockedStatic(m, m.getBody().getStatements());
+                return maybeAutoFormat(m, m.withBody(m.getBody().withStatements(newStatements)), ctx);
+            }
+
+            private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.MethodDeclaration m, List<Statement> originalStatements) {
+                AtomicBoolean restInTry = new AtomicBoolean(false);
+                return ListUtils.flatMap(originalStatements, (index, statement) -> {
+                    if (restInTry.get()) {
+                        // Rest of the statements have ended up in the try block
+                        return Collections.emptyList();
                     }
 
-                    private List<Statement> getStatements(List<Statement> originalStatements, J.MethodDeclaration m) {
-                        AtomicBoolean restInTry = new AtomicBoolean(false);
-                        return ListUtils.flatMap(originalStatements, (index, statement) -> {
-                            if (restInTry.get()) {
-                                // Rest of the statements have ended up in the try block
-                                return Collections.emptyList();
-                            }
+                    if (statement instanceof J.MethodInvocation &&
+                        MOCKITO_WHEN.matches(((J.MethodInvocation) statement).getSelect())) {
+                        J.MethodInvocation when = (J.MethodInvocation) ((J.MethodInvocation) statement).getSelect();
+                        if (when != null && when.getArguments().get(0) instanceof J.MethodInvocation) {
+                            J.MethodInvocation whenArg = (J.MethodInvocation) when.getArguments().get(0);
+                            if (whenArg.getMethodType() != null && whenArg.getMethodType().hasFlags(Flag.Static)) {
+                                J.Identifier clazz = (J.Identifier) whenArg.getSelect();
+                                if (clazz != null && clazz.getType() != null) {
+                                    String mockName = VariableNameUtils.generateVariableName("mock" + clazz.getSimpleName(), updateCursor(m), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
+                                    maybeAddImport("org.mockito.MockedStatic", false);
+                                    maybeAddImport("org.mockito.Mockito", "mockStatic");
+                                    String template = String.format(
+                                            "try(MockedStatic<#{}> %1$s = mockStatic(#{}.class)) {\n" +
+                                            "    %1$s.when(#{any()}).thenReturn(#{any()});\n" +
+                                            "}", mockName);
+                                    J.Try try_ = (J.Try) ((J.MethodDeclaration) JavaTemplate.builder(template)
+                                            .contextSensitive()
+                                            .imports("org.mockito.MockedStatic")
+                                            .staticImports("org.mockito.Mockito.mockStatic")
+                                            .build()
+                                            .apply(getCursor(), m.getCoordinates().replaceBody(),
+                                                    clazz.getType(), clazz.getType(),
+                                                    whenArg, ((J.MethodInvocation) statement).getArguments().get(0)))
+                                            .getBody().getStatements().get(0);
 
-                            if (statement instanceof J.MethodInvocation &&
-                                MOCKITO_WHEN.matches(((J.MethodInvocation) statement).getSelect())) {
-                                J.MethodInvocation when = (J.MethodInvocation) ((J.MethodInvocation) statement).getSelect();
-                                if (when != null && when.getArguments().get(0) instanceof J.MethodInvocation) {
-                                    J.MethodInvocation whenArg = (J.MethodInvocation) when.getArguments().get(0);
-                                    if (whenArg.getMethodType() != null && whenArg.getMethodType().getFlags().contains(Flag.Static)) {
-                                        J.Identifier clazz = (J.Identifier) whenArg.getSelect();
-                                        if (clazz != null && clazz.getType() != null) {
-                                            String mockName = VariableNameUtils.generateVariableName("mock" + clazz.getSimpleName(), updateCursor(m), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
-                                            maybeAddImport("org.mockito.MockedStatic", false);
-                                            maybeAddImport("org.mockito.Mockito", "mockStatic");
-                                            String template = String.format(
-                                                    "try(MockedStatic<#{}> %1$s = mockStatic(#{}.class)) {\n" +
-                                                    "    %1$s.when(#{any()}).thenReturn(#{any()});\n" +
-                                                    "}", mockName);
-                                            J.Try try_ = (J.Try) ((J.MethodDeclaration) JavaTemplate.builder(template)
-                                                    .contextSensitive()
-                                                    .imports("org.mockito.MockedStatic")
-                                                    .staticImports("org.mockito.Mockito.mockStatic")
-                                                    .build()
-                                                    .apply(getCursor(), m.getCoordinates().replaceBody(),
-                                                            clazz.getType(), clazz.getType(),
-                                                            whenArg, ((J.MethodInvocation) statement).getArguments().get(0)))
-                                                    .getBody().getStatements().get(0);
+                                    restInTry.set(true);
 
-                                            restInTry.set(true);
-
-                                            return try_.withBody(try_.getBody().withStatements(ListUtils.concatAll(
+                                    return try_.withBody(try_.getBody().withStatements(ListUtils.concatAll(
                                                     try_.getBody().getStatements(),
-                                                    getStatements(originalStatements.subList(index + 1, originalStatements.size()), m.withBody(m.getBody().withStatements(ListUtils.concat(m.getBody().getStatements(), try_)))))))
-                                                    .withPrefix(statement.getPrefix());
-                                        }
-                                    }
+                                                    maybeWrapStatementsInTryWithResourcesMockedStatic(
+                                                            m.withBody(m.getBody().withStatements(ListUtils.concat(m.getBody().getStatements(), try_))),
+                                                            originalStatements.subList(index + 1, originalStatements.size())
+                                                    ))))
+                                            .withPrefix(statement.getPrefix());
                                 }
                             }
-                            return statement;
-                        });
+                        }
                     }
+                    return statement;
                 });
+            }
+        });
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -61,9 +61,9 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                 return maybeAutoFormat(m, m.withBody(m.getBody().withStatements(newStatements)), ctx);
             }
 
-            private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.MethodDeclaration m, List<Statement> originalStatements) {
+            private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.MethodDeclaration m, List<Statement> remainingStatements) {
                 AtomicBoolean restInTry = new AtomicBoolean(false);
-                return ListUtils.flatMap(originalStatements, (index, statement) -> {
+                return ListUtils.flatMap(remainingStatements, (index, statement) -> {
                     if (restInTry.get()) {
                         // Rest of the statements have ended up in the try block
                         return Collections.emptyList();
@@ -96,11 +96,12 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
                                     restInTry.set(true);
 
+                                    List<Statement> precedingStatements = remainingStatements.subList(0, index);
                                     return try_.withBody(try_.getBody().withStatements(ListUtils.concatAll(
                                                     try_.getBody().getStatements(),
                                                     maybeWrapStatementsInTryWithResourcesMockedStatic(
-                                                            m.withBody(m.getBody().withStatements(ListUtils.concat(m.getBody().getStatements(), try_))),
-                                                            originalStatements.subList(index + 1, originalStatements.size())
+                                                            m.withBody(m.getBody().withStatements(ListUtils.concat(precedingStatements, try_))),
+                                                            remainingStatements.subList(index + 1, remainingStatements.size())
                                                     ))))
                                             .withPrefix(statement.getPrefix());
                                 }

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -67,6 +67,7 @@ recipeList:
       groupId: net.bytebuddy
       artifactId: byte-buddy*
       newVersion: 1.12.19
+  - org.openrewrite.java.testing.mockito.MockitoWhenOnStaticToMockStatic
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.mockito.Mockito1to3Migration

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -59,6 +59,7 @@ tags:
   - mockito
 recipeList:
   - org.openrewrite.java.testing.mockito.Mockito1to3Migration
+  - org.openrewrite.java.testing.mockito.MockitoWhenOnStaticToMockStatic
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.mockito
       artifactId: "*"
@@ -67,7 +68,6 @@ recipeList:
       groupId: net.bytebuddy
       artifactId: byte-buddy*
       newVersion: 1.12.19
-  - org.openrewrite.java.testing.mockito.MockitoWhenOnStaticToMockStatic
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.mockito.Mockito1to3Migration

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -59,10 +59,10 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
           java(
             """
               import com.foo.A;
-              
+
               import static org.junit.Assert.assertEquals;
               import static org.mockito.Mockito.*;
-              
+
               class Test {
                   void test() {
                       when(A.getNumber()).thenReturn(-1);
@@ -73,10 +73,10 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
             """
               import com.foo.A;
               import org.mockito.MockedStatic;
-              
+
               import static org.junit.Assert.assertEquals;
               import static org.mockito.Mockito.*;
-              
+
               class Test {
                   void test() {
                       try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
@@ -109,15 +109,15 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
           java(
             """
               import com.foo.A;
-              
+
               import static org.junit.Assert.assertEquals;
               import static org.mockito.Mockito.*;
-              
+
               class Test {
                   void test() {
                       when(A.getNumber()).thenReturn(-1);
                       assertEquals(A.getNumber(), -1);
-              
+
                       when(A.getNumber()).thenReturn(-2);
                       assertEquals(A.getNumber(), -2);
                   }
@@ -126,18 +126,18 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
             """
               import com.foo.A;
               import org.mockito.MockedStatic;
-              
+
               import static org.junit.Assert.assertEquals;
               import static org.mockito.Mockito.*;
-              
+
               class Test {
                   void test() {
                       try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
                           mockA.when(A.getNumber()).thenReturn(-1);
                           assertEquals(A.getNumber(), -1);
-            
-                          try (MockedStatic<com.foo.A> mockA2 = mockStatic(com.foo.A.class)) {
-                              mockA2.when(A.getNumber()).thenReturn(-2);
+
+                          try (MockedStatic<com.foo.A> mockA1 = mockStatic(com.foo.A.class)) {
+                              mockA1.when(A.getNumber()).thenReturn(-2);
                               assertEquals(A.getNumber(), -2);
                           }
                       }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -47,31 +47,31 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
           spec -> spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).identifiers(false).build()),
           java(
             """
-            package a.b;
-            
-            public class A {
-            
-                public A() {
-                }
-            
-                public static A getA() {
-                    return new A();
-                }
-            }
-            """,
+              package a.b;
+
+              public class A {
+
+                  public A() {
+                  }
+
+                  public static A getA() {
+                      return new A();
+                  }
+              }
+              """,
             SourceSpec::skip
           ),
           java(
             """
             import a.b.A;
-            
+
             import static org.junit.Assert.assertEquals;
             import static org.mockito.Mockito.*;
-            
+
             class Test {
-            
+
                 private A aMock = mock(A.class);
-            
+
                 void test() {
                     when(A.getA()).thenReturn(aMock);
                     assertEquals(A.getA(), aMock);
@@ -84,11 +84,11 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
 
             import static org.junit.Assert.assertEquals;
             import static org.mockito.Mockito.*;
-            
+
             class Test {
-            
+
                 private A aMock = mock(A.class);
-            
+
                 void test() {
                     try (MockedStatic<a.b.A> mockA = mockStatic(a.b.A.class)) {
                         mockA.when(A.getA()).thenReturn(aMock);

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.SourceSpec;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
+class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -49,8 +49,8 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
             """
               package com.foo;
               public class A {
-                  public static A getA() {
-                      return new A();
+                  public static Integer getNumber() {
+                      return 42;
                   }
               }
               """,
@@ -68,8 +68,8 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
                   private A aMock = mock(A.class);
               
                   void test() {
-                      when(A.getA()).thenReturn(aMock);
-                      assertEquals(A.getA(), aMock);
+                      when(A.getNumber()).thenReturn(-1);
+                      assertEquals(A.getNumber(), -1);
                   }
               }
               """,
@@ -86,8 +86,8 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
               
                   void test() {
                       try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
-                          mockA.when(A.getA()).thenReturn(aMock);
-                          assertEquals(A.getA(), aMock);
+                          mockA.when(A.getNumber()).thenReturn(-1);
+                          assertEquals(A.getNumber(), -1);
                       }
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -44,7 +44,7 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
     void shouldRefactorMockito_When() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).identifiers(false).build()),
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().identifiers(false).build()),
           java(
             """
               package com.foo;
@@ -79,7 +79,7 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
 
               class Test {
                   void test() {
-                      try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
+                      try (MockedStatic<A> mockA = mockStatic(A.class)) {
                           mockA.when(A.getNumber()).thenReturn(-1);
                           assertEquals(A.getNumber(), -1);
                       }
@@ -94,7 +94,7 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
     void shouldHandleMultipleStaticMocks() {
         //language=java
         rewriteRun(
-          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).identifiers(false).build()),
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().identifiers(false).build()),
           java(
             """
               package com.foo;
@@ -132,11 +132,11 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
 
               class Test {
                   void test() {
-                      try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
+                      try (MockedStatic<A> mockA = mockStatic(A.class)) {
                           mockA.when(A.getNumber()).thenReturn(-1);
                           assertEquals(A.getNumber(), -1);
 
-                          try (MockedStatic<com.foo.A> mockA1 = mockStatic(com.foo.A.class)) {
+                          try (MockedStatic<A> mockA1 = mockStatic(A.class)) {
                               mockA1.when(A.getNumber()).thenReturn(-2);
                               assertEquals(A.getNumber(), -2);
                           }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-4.13",
+              "junit-jupiter-api-5.9",
+              "mockito-core-3.12",
+              "mockito-junit-jupiter-3.12"
+            ))
+          .recipe(new MockitoWhenOnStaticToMockStatic());
+    }
+
+    @Test
+    void shouldRefactorMockito_When() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+            package a.b;
+            
+            public class A {
+            
+                public A() {
+                }
+            
+                public static A getA() {
+                    return new A();
+                }
+            }
+            """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+            import a.b.A;
+            
+            import static org.junit.Assert.assertEquals;
+            import static org.mockito.Mockito.*;
+            
+            class Test {
+            
+                private A aMock = mock(A.class);
+            
+                void test() {
+                    when(A.getA()).thenReturn(aMock);
+                    assertEquals(A.getA(), aMock);
+                }
+            }
+            """,
+            """
+            import a.b.A;
+
+            import static org.junit.Assert.assertEquals;
+            import static org.mockito.Mockito.*;
+            
+            class Test {
+            
+                private A aMock = mock(A.class);
+            
+                void test() {
+                    try (MockedStatic<A> mockA = mockStatic(A.class)) {
+                        mockA.when(A::getA).thenReturn(aMock);
+                        assertEquals(A.getA(), aMock);
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -78,6 +78,7 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
             """,
             """
             import a.b.A;
+            import org.mockito.MockedStatic;
 
             import static org.junit.Assert.assertEquals;
             import static org.mockito.Mockito.*;
@@ -87,8 +88,8 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
                 private A aMock = mock(A.class);
             
                 void test() {
-                    try (MockedStatic<A> mockA = mockStatic(A.class)) {
-                        mockA.when(A::getA).thenReturn(aMock);
+                    try (MockedStatic<a.b.A> mockA = mockStatic(a.b.A.class)) {
+                        mockA.when(A.getA()).thenReturn(aMock);
                         assertEquals(A.getA(), aMock);
                     }
                 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -43,6 +44,7 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
     void shouldRefactorMockito_When() {
         //language=java
         rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).identifiers(false).build()),
           java(
             """
             package a.b;

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -95,4 +95,47 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldHandleMultipleStaticMocks() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().methodInvocations(false).identifiers(false).build()),
+          java(
+            """
+              package com.foo;
+              public class A {
+                  public static A getA() {
+                      return new A();
+                  }
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import com.foo.A;
+              
+              import static org.junit.Assert.assertEquals;
+              import static org.mockito.Mockito.*;
+              
+              class Test {
+              
+                  private A aMock = mock(A.class);
+              
+                  void test() {
+                      when(A.getA()).thenReturn(aMock);
+                      assertEquals(A.getA(), aMock);
+              
+                      when(A.getA()).thenReturn(aMock);
+                      assertEquals(A.getA(), aMock);
+                  }
+              }
+              """,
+            """
+              class TODO {}
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -64,9 +64,6 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
               import static org.mockito.Mockito.*;
               
               class Test {
-              
-                  private A aMock = mock(A.class);
-              
                   void test() {
                       when(A.getNumber()).thenReturn(-1);
                       assertEquals(A.getNumber(), -1);
@@ -81,9 +78,6 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
               import static org.mockito.Mockito.*;
               
               class Test {
-              
-                  private A aMock = mock(A.class);
-              
                   void test() {
                       try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
                           mockA.when(A.getNumber()).thenReturn(-1);
@@ -105,8 +99,8 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
             """
               package com.foo;
               public class A {
-                  public static A getA() {
-                      return new A();
+                  public static Integer getNumber() {
+                      return 42;
                   }
               }
               """,
@@ -120,20 +114,35 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
               import static org.mockito.Mockito.*;
               
               class Test {
-              
-                  private A aMock = mock(A.class);
-              
                   void test() {
-                      when(A.getA()).thenReturn(aMock);
-                      assertEquals(A.getA(), aMock);
+                      when(A.getNumber()).thenReturn(-1);
+                      assertEquals(A.getNumber(), -1);
               
-                      when(A.getA()).thenReturn(aMock);
-                      assertEquals(A.getA(), aMock);
+                      when(A.getNumber()).thenReturn(-2);
+                      assertEquals(A.getNumber(), -2);
                   }
               }
               """,
             """
-              class TODO {}
+              import com.foo.A;
+              import org.mockito.MockedStatic;
+              
+              import static org.junit.Assert.assertEquals;
+              import static org.mockito.Mockito.*;
+              
+              class Test {
+                  void test() {
+                      try (MockedStatic<com.foo.A> mockA = mockStatic(com.foo.A.class)) {
+                          mockA.when(A.getNumber()).thenReturn(-1);
+                          assertEquals(A.getNumber(), -1);
+            
+                          try (MockedStatic<com.foo.A> mockA2 = mockStatic(com.foo.A.class)) {
+                              mockA2.when(A.getNumber()).thenReturn(-2);
+                              assertEquals(A.getNumber(), -2);
+                          }
+                      }
+                  }
+              }
               """
           )
         );


### PR DESCRIPTION
## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
`Mockito.when` on static (non mock) is no longer allowed with Mockito 4

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
