### PR TITLE
Bugfix/multiple curly braces in one verification block

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -36,10 +36,10 @@ class JMockitUtils {
         J.Identifier clazz = (J.Identifier) nc.getClazz();
 
         // JMockit block should be composed of a block within another block
-        if (nc.getBody() == null
-                || (nc.getBody().getStatements().size() != 1 &&
-                        !TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType()) &&
-                        !TypeUtils.isAssignableTo("mockit.Verifications", clazz.getType()))) {
+        if (nc.getBody() == null ||
+            (nc.getBody().getStatements().size() != 1 &&
+             !TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType()) &&
+             !TypeUtils.isAssignableTo("mockit.Verifications", clazz.getType()))) {
             return empty();
         }
 

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -36,8 +36,10 @@ class JMockitUtils {
         J.Identifier clazz = (J.Identifier) nc.getClazz();
 
         // JMockit block should be composed of a block within another block
-        if (nc.getBody() == null || (nc.getBody().getStatements().size() != 1 &&
-                !TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType()))) {
+        if (nc.getBody() == null
+                || (nc.getBody().getStatements().size() != 1 &&
+                        !TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType()) &&
+                        !TypeUtils.isAssignableTo("mockit.Verifications", clazz.getType()))) {
             return empty();
         }
 

--- a/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
@@ -36,8 +36,7 @@ class SetupStatementsRewriter {
 
     J.Block rewriteMethodBody() {
         List<Statement> statements = methodBody.getStatements();
-        // iterate over each statement in the method body, find JMockit blocks and
-        // rewrite them
+        // iterate over each statement in the method body, find JMockit blocks and rewrite them
         for (Statement s : statements) {
             if (!JMockitUtils.getJMockitBlock(s).isPresent()) {
                 continue;
@@ -55,8 +54,8 @@ class SetupStatementsRewriter {
 
             // Account for Expectations which may contain multiple blocks
             List<Statement> statementList = new ArrayList<>();
-            if (TypeUtils.isAssignableTo("mockit.Expectations", nc.getType())
-                    || TypeUtils.isAssignableTo("mockit.Verifications", nc.getType())) {
+            if (TypeUtils.isAssignableTo("mockit.Expectations", nc.getType()) ||
+                TypeUtils.isAssignableTo("mockit.Verifications", nc.getType())) {
                 statementList.addAll(nc.getBody().getStatements());
             } else {
                 statementList.add(expectationsBlock);
@@ -141,8 +140,8 @@ class SetupStatementsRewriter {
             return false;
         }
         if (identifier.getType() instanceof JavaType.Method
-                && TypeUtils.isAssignableTo("mockit.Invocations",
-                        ((JavaType.Method) identifier.getType()).getDeclaringType())) {
+            && TypeUtils.isAssignableTo("mockit.Invocations",
+                ((JavaType.Method) identifier.getType()).getDeclaringType())) {
             return false;
         }
         JavaType.Variable fieldType = identifier.getFieldType();
@@ -151,8 +150,8 @@ class SetupStatementsRewriter {
         }
         for (JavaType.FullyQualified annotationType : fieldType.getAnnotations()) {
             if (TypeUtils.isAssignableTo("mockit.Mocked", annotationType)
-                    || TypeUtils.isAssignableTo("mockit.Injectable", annotationType)
-                    || TypeUtils.isAssignableTo("mockit.Tested", annotationType)) {
+                || TypeUtils.isAssignableTo("mockit.Injectable", annotationType)
+                || TypeUtils.isAssignableTo("mockit.Tested", annotationType)) {
                 return false;
             }
         }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/SetupStatementsRewriter.java
@@ -36,7 +36,8 @@ class SetupStatementsRewriter {
 
     J.Block rewriteMethodBody() {
         List<Statement> statements = methodBody.getStatements();
-        // iterate over each statement in the method body, find JMockit blocks and rewrite them
+        // iterate over each statement in the method body, find JMockit blocks and
+        // rewrite them
         for (Statement s : statements) {
             if (!JMockitUtils.getJMockitBlock(s).isPresent()) {
                 continue;
@@ -54,7 +55,8 @@ class SetupStatementsRewriter {
 
             // Account for Expectations which may contain multiple blocks
             List<Statement> statementList = new ArrayList<>();
-            if (TypeUtils.isAssignableTo("mockit.Expectations", nc.getType())) {
+            if (TypeUtils.isAssignableTo("mockit.Expectations", nc.getType())
+                    || TypeUtils.isAssignableTo("mockit.Verifications", nc.getType())) {
                 statementList.addAll(nc.getBody().getStatements());
             } else {
                 statementList.add(expectationsBlock);
@@ -139,8 +141,8 @@ class SetupStatementsRewriter {
             return false;
         }
         if (identifier.getType() instanceof JavaType.Method
-            && TypeUtils.isAssignableTo("mockit.Invocations",
-                ((JavaType.Method) identifier.getType()).getDeclaringType())) {
+                && TypeUtils.isAssignableTo("mockit.Invocations",
+                        ((JavaType.Method) identifier.getType()).getDeclaringType())) {
             return false;
         }
         JavaType.Variable fieldType = identifier.getFieldType();
@@ -149,8 +151,8 @@ class SetupStatementsRewriter {
         }
         for (JavaType.FullyQualified annotationType : fieldType.getAnnotations()) {
             if (TypeUtils.isAssignableTo("mockit.Mocked", annotationType)
-                || TypeUtils.isAssignableTo("mockit.Injectable", annotationType)
-                || TypeUtils.isAssignableTo("mockit.Tested", annotationType)) {
+                    || TypeUtils.isAssignableTo("mockit.Injectable", annotationType)
+                    || TypeUtils.isAssignableTo("mockit.Tested", annotationType)) {
                 return false;
             }
         }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -724,4 +724,57 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenMultipleBlockInSingleVerification() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.Verifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Verifications() {
+                          {
+                          myObject.wait();
+                          myObject.wait(anyLong, anyInt);
+                          }
+                          {
+                          myObject.wait(anyLong);
+                          times = 2;
+                          }
+                      };
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.mockito.Mockito.*;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      verify(myObject).wait();
+                      verify(myObject).wait(anyLong(), anyInt());
+                      verify(myObject, times(2)).wait(anyLong());
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -41,12 +41,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -59,14 +59,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject).wait(anyLong(), anyInt());
@@ -88,12 +88,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -106,14 +106,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.verify;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject).wait();
@@ -133,17 +133,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait();
                       myObject.wait();
@@ -157,18 +157,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import static org.mockito.Mockito.times;
               import static org.mockito.Mockito.verify;
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait();
                       myObject.wait();
@@ -188,7 +188,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           java(
             """
               import java.util.List;
-
+              
               class MyObject {
                   public String getSomeField(List<String> input) {
                       return "X";
@@ -203,17 +203,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import mockit.Mocked;
               import mockit.Verifications;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   MyObject myObject;
-
+              
                   void test() {
                       myObject.getSomeField(new ArrayList<>());
                       myObject.getSomeOtherField(new Object());
@@ -227,18 +227,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   MyObject myObject;
-
+              
                   void test() {
                       myObject.getSomeField(new ArrayList<>());
                       myObject.getSomeOtherField(new Object());
@@ -260,17 +260,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import mockit.Verifications;
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -282,18 +282,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
             """
               import java.util.ArrayList;
               import java.util.List;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject).wait(anyLong(), eq(10));
@@ -314,12 +314,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       String a = "a";
                       String s = "s";
@@ -336,15 +336,15 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.verify;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       String a = "a";
                       String s = "s";
@@ -369,12 +369,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                                                        
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       String a = "a";
                       myObject.wait(1L);
@@ -388,15 +388,15 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.anyLong;
               import static org.mockito.Mockito.verify;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       String a = "a";
                       myObject.wait(1L);
@@ -418,12 +418,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -439,14 +439,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait(10L, 10);
                       myObject.wait(10L, 10);
@@ -469,12 +469,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -488,14 +488,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(2)).wait(anyLong(), anyInt());
@@ -516,12 +516,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -535,14 +535,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atMost(5)).wait(anyLong(), anyInt());
@@ -563,12 +563,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       new Verifications() {{
@@ -583,14 +583,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-                  
+              
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(1)).wait(anyLong(), anyInt());
@@ -612,15 +612,15 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-                                                        
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   @Mocked
                   Object myOtherObject;
-
+              
                   void test() {
                       myObject.hashCode();
                       myOtherObject.wait();
@@ -639,17 +639,17 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   @Mock
                   Object myOtherObject;
-
+              
                   void test() {
                       myObject.hashCode();
                       myOtherObject.wait();
@@ -676,18 +676,18 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait();
                       new Verifications() {{
-
+              
                           myObject.wait();
-
+              
                           myObject.wait(anyLong, anyInt);
                       }};
                       myObject.wait(1L);
@@ -703,14 +703,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       myObject.wait();
                       verify(myObject).wait();
@@ -735,12 +735,12 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       new Verifications() {
                           {
@@ -759,14 +759,14 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       verify(myObject).wait();
                       verify(myObject).wait(anyLong(), anyInt());


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->

This is a change similar to [the one I made before: Pull Request 596](https://github.com/openrewrite/rewrite-testing-frameworks/pull/596)

Cope with a corner case in refactoring JMockit Verifications.
Sometimes programmers will use more than one curly braces in one Verification block. 
This is bizarre and confusing, because it looks like there are multiple "anonymous class" here while in fact these curly braces do not make any effective difference. It will be ideal if such code can also be refactored automatically.

Usually people write code like this:

```java
new Verifications() {{
    myObject.wait();
    myObject.wait(anyLong, anyInt);
    myObject.wait(anyLong);
    times = 2;
}};
```

while some programmers prefer grouping related statements with redundant curly braces

```java
new Verifications() {
    {
    myObject.wait();
    myObject.wait(anyLong, anyInt);
    }
    {
    myObject.wait(anyLong);
    times = 2;
    }
};
```

Such code snippet can not be refactored automatically.

## What's your motivation?
We encountered problem in dealing with several legacy projects.
Some codes can not be refactored automatically, while manually changing them seems tedious, since they are not complex at all. We located and solved this problem, which can save us quite a lot of time.
Benefited a lot from the OpenRewrite project previously, we believe that more people and more legacy projects should be able to take advantage of it.

## Anything in particular you'd like reviewers to focus on?
This change is similar to the one I made for "multiple blocks in one Expectations block", I only modified the IF statement to cope with not only Expectation block but also Verifications block. Moreover, I adhere to the convention of the changes made by @timtebeek for my last pull request.
I read the best practice so I kept the LST untouched.
The change has been tested by the entire test suite. As far as I can see, everything works fine.
Please note that the new code might need to be formatted to comply with the existing convention.

## Anyone you would like to review specifically?
@timtebeek I would be very happy if you can review this, it is an easy fix.

## Have you considered any alternatives or workarounds?
Maybe changing the LST is a better solution, but I do not think it is worthy since this is not a common case.
Users can also use a script to remove the curly braces before applying this recipe, but that is an invasive way.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
