### PR TITLE
Migrate JMockit block to Mockito which contains redundant "this" prefix for arg matcher and migrate array as parameter for any 

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/ArgumentMatchersRewriter.java
@@ -106,14 +106,13 @@ class ArgumentMatchersRewriter {
             Expression expression = methodArgument;
 
             // identifiers following "this." should be also be considered if they are
-            // eligible
+            // eligible, if so, convert it to the identifier for refactoring
             if (methodArgument instanceof J.FieldAccess) {
-                J.FieldAccess fa = (J.FieldAccess) methodArgument;
-                if (fa.getTarget() instanceof J.Identifier &&
-                        ((J.Identifier) fa.getTarget()).getSimpleName().equals("this")) {
-
+                J.FieldAccess fieldAccess = (J.FieldAccess) methodArgument;
+                if (fieldAccess.getTarget() instanceof J.Identifier &&
+                        ((J.Identifier) fieldAccess.getTarget()).getSimpleName().equals("this")) {
+                            expression = fieldAccess.getName();
                 }
-                expression = ((J.FieldAccess) methodArgument).getName();
             }
             arguments.add(expression);
         }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -210,7 +210,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
@@ -1083,7 +1083,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-              
+
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1104,7 +1104,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-              
+
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(2)).wait(anyLong(), anyInt());
@@ -1130,7 +1130,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-              
+
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1151,7 +1151,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-              
+
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atMost(5)).wait(anyLong(), anyInt());
@@ -1177,7 +1177,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mocked
                   Object myObject;
-              
+
                   void test() {
                       new Expectations() {{
                           myObject.wait(anyLong, anyInt);
@@ -1199,7 +1199,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               class MyTest {
                   @Mock
                   Object myObject;
-              
+
                   void test() {
                       myObject.wait(10L, 10);
                       verify(myObject, atLeast(1)).wait(anyLong(), anyInt());
@@ -1500,7 +1500,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenMultipleExpectationsNoResults() { 
+    void whenMultipleExpectationsNoResults() {
         //language=java
         rewriteRun(
           java(
@@ -1558,7 +1558,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenWithRedundantThisModifier() { 
+    void whenWithRedundantThisModifier() {
         //language=java
         rewriteRun(
           java(

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -668,6 +668,9 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   public String getSomeOtherField(Object input) {
                       return "Y";
                   }
+                  public String getSomeArrayField(Object input) {
+                      return "Z";
+                  }
               }
               """
           ),
@@ -694,9 +697,12 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                           result = null;
                           myObject.getSomeOtherField((Object) any);
                           result = null;
+                          myObject.getSomeArrayField((byte[]) any);
+                          result = null;
                       }};
                       assertNull(myObject.getSomeField(new ArrayList<>()));
                       assertNull(myObject.getSomeOtherField(new Object()));
+                      assertNull(myObject.getSomeArrayField(new byte[0]));
                   }
               }
               """,
@@ -719,8 +725,10 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                   void test() {
                       when(myObject.getSomeField(anyList())).thenReturn(null);
                       when(myObject.getSomeOtherField(any(Object.class))).thenReturn(null);
+                      when(myObject.getSomeArrayField(any(byte[].class))).thenReturn(null);
                       assertNull(myObject.getSomeField(new ArrayList<>()));
                       assertNull(myObject.getSomeOtherField(new Object()));
+                      assertNull(myObject.getSomeArrayField(new byte[0]));
                   }
               }
               """
@@ -1542,6 +1550,57 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       myObject.wait();
                       verify(myObject).wait(anyLong());
                       verify(myObject).wait();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenWithRedundantThisModifier() { 
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Expectations() {{
+                          myObject.wait(this.anyLong, anyInt);
+                      }};
+                      myObject.wait();
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNull;
+              import static org.mockito.Mockito.*;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      myObject.wait();
+                      verify(myObject).wait(anyLong(), anyInt());
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -777,4 +777,51 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenRedundantThisInVerification() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.Verifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+
+                  void test() {
+                      new Verifications() {{
+                          myObject.wait(this.anyLong, anyInt);
+                          myObject.wait(anyLong);
+
+                      }};
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              import static org.mockito.Mockito.*;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+
+                  void test() {
+                      verify(myObject).wait(anyLong(), anyInt());
+                      verify(myObject).wait(anyLong());
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -894,5 +894,4 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           )
         );
     }
-
 }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -795,6 +795,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   void test() {
                       new Verifications() {{
                           myObject.wait(this.anyLong, this.anyInt);
+                          myObject.wait(anyLong, this.anyInt);
                       }};
                   }
               }
@@ -812,6 +813,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
                   Object myObject;
               
                   void test() {
+                      verify(myObject).wait(anyLong(), anyInt());
                       verify(myObject).wait(anyLong(), anyInt());
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -684,10 +684,8 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               
                   void test() {
                       myObject.wait();
-                      new Verifications() {{
-              
-                          myObject.wait();
-              
+                      new Verifications() {{              
+                          myObject.wait();              
                           myObject.wait(anyLong, anyInt);
                       }};
                       myObject.wait(1L);
@@ -779,7 +777,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenRedundantThisInVerification() {
+    void whenWithRedundantThisModifier() {
         //language=java
         rewriteRun(
           java(
@@ -788,17 +786,15 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import mockit.Mocked;
               import mockit.integration.junit5.JMockitExtension;
               import org.junit.jupiter.api.extension.ExtendWith;
-
+              
               @ExtendWith(JMockitExtension.class)
               class MyTest {
                   @Mocked
                   Object myObject;
-
+              
                   void test() {
                       new Verifications() {{
-                          myObject.wait(this.anyLong, anyInt);
-                          myObject.wait(anyLong);
-
+                          myObject.wait(this.anyLong, this.anyInt);
                       }};
                   }
               }
@@ -807,21 +803,22 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-
+              
               import static org.mockito.Mockito.*;
-
+              
               @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myObject;
-
+              
                   void test() {
                       verify(myObject).wait(anyLong(), anyInt());
-                      verify(myObject).wait(anyLong());
                   }
               }
               """
           )
         );
     }
+
+
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Be able to cope with corner cases in refactoring JMockit Verifications.

1. Normally, `anyString` in JMockit should be refactored to `anyString()` in Mockito, so as to `anyInt` or `anyLong`. But when there are redundant `this` before `anyString`, the code will not be processed because OpenWrite treat `anyString` as an `J.Identifier` object where as `this.anyString` as a `J.FieldAccess` object. My patch will do a type cast for this exact case.
2. Normally, `(Object) any` in Mockito should be refactored to `any(Object.class)` in Mockito. This works for simple Object. But when `Object` is an array such as `(byte[]) any`, OpenRewrite will not change it to `any(byte[].class)` because the class type of `byte[]` is not `JavaType.FullyQualified`. I added processing branch for this case.

Corresponding unit tests were also added.


## What's your motivation?

We encountered problem in dealing with several legacy projects.
Some codes can not be refactored automatically, while manually changing them seems tedious, since they are not complex at all. We located and solved this problem, which can save us quite a lot of time.
Benefited a lot from the OpenRewrite project previously, we believe that more people and more legacy projects should be able to take advantage of it.

## Anything in particular you'd like reviewers to focus on?
My solution for the second question is obviously not the perfect one, because the element type of array could be another array so theoretically  this could be a infinite loop. Solving such problem will take me much more time and energy. 
But I guess that is a rare case which is almost impossible to encounter, so my code simply assume that the element type of the array is plain object.

## Anyone you would like to review specifically?
@timtebeek Please have a look again on my code, amigo :)

## Have you considered any alternatives or workarounds?
Yes, as I mentioned above, I think a perfect solution for the second question is unworthy.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
