### PR TITLE
`PowerMockitoMockStaticToMockito` should not remove existing `mockStatic` initializer

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -190,7 +190,9 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
 
             if (MOCKED_STATIC_MATCHER.matches(mi)) {
                 determineTestGroups();
-                if (!getCursor().getPath(o -> o instanceof J.Assignment || o instanceof J.Try.Resource).hasNext()) {
+                if (!getCursor().getPath(o -> o instanceof J.VariableDeclarations ||
+                                              o instanceof J.Assignment ||
+                                              o instanceof J.Try.Resource).hasNext()) {
                     //noinspection DataFlowIssue
                     return null;
                 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -695,7 +695,9 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
             class TestClass {
                 MockedStatic<String> mocked = mockStatic(String.class);
             }
-            """));
+            """
+          )
+        );
     }
 
     @Test

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -682,6 +682,23 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/611")
+    void existingMockitoMockStaticShouldNotBeTouched() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+            import static org.mockito.Mockito.mockStatic;
+
+            import org.mockito.MockedStatic;
+
+            class TestClass {
+                MockedStatic<String> mocked = mockStatic(String.class);
+            }
+            """));
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/358")
     void doesNotExplodeOnTopLevelMethodDeclaration() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->


## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
* Fixes https://github.com/openrewrite/rewrite-testing-frameworks/issues/611

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek @knutwannheden 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
