### PR TITLE
JMockit to Mockito IllegalArumentException No enum constant VerificationsInOrder

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitUtils.java
@@ -16,9 +16,11 @@
 package org.openrewrite.java.testing.jmockit;
 
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import static java.util.Optional.empty;
@@ -29,20 +31,19 @@ class JMockitUtils {
         if (!(s instanceof J.NewClass)) {
             return empty();
         }
+
         J.NewClass nc = (J.NewClass) s;
-        if (!(nc.getClazz() instanceof J.Identifier)) {
-            return empty();
-        }
-        J.Identifier clazz = (J.Identifier) nc.getClazz();
-
-        // JMockit block should be composed of a block within another block
-        if (nc.getBody() == null ||
-            (nc.getBody().getStatements().size() != 1 &&
-             !TypeUtils.isAssignableTo("mockit.Expectations", clazz.getType()) &&
-             !TypeUtils.isAssignableTo("mockit.Verifications", clazz.getType()))) {
+        if (nc.getBody() == null || nc.getClazz() == null) {
             return empty();
         }
 
-        return Optional.of(JMockitBlockType.valueOf(clazz.getSimpleName()));
+        JavaType type = nc.getClazz().getType();
+        if (type == null) {
+            return empty();
+        }
+
+        return Arrays.stream(JMockitBlockType.values())
+                .filter(supportedType -> TypeUtils.isOfClassType(type, supportedType.getFqn()))
+                .findFirst();
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -210,7 +210,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+                            
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
@@ -1492,7 +1492,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
     }
 
     @Test
-    void whenMultipleExpectationsNoResults() { 
+    void whenMultipleExpectationsNoResults() {
         //language=java
         rewriteRun(
           java(
@@ -1613,6 +1613,50 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       assertEquals("a", myObject.getSomeStringField());
                       when(myObject.getSomeStringField()).thenReturn("b");
                       assertEquals("b", myObject.getSomeStringField());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenEmptyBlock() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.Expectations;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                 
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                 
+                  void test() {
+                      new Expectations() {{
+                      }};
+                      myObject.wait(1L);
+                      myObject.wait(2L, 1);                                   
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                                                        
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(1L);
+                      myObject.wait(2L, 1);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -210,7 +210,7 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-                            
+              
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.mockito.Mockito.when;
 
@@ -1640,7 +1640,6 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                       new Expectations() {{
                       }};
                       myObject.wait(1L);
-                      myObject.wait(2L, 1);                                   
                   }
               }
               """,
@@ -1656,7 +1655,6 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
                             
                   void test() {
                       myObject.wait(1L);
-                      myObject.wait(2L, 1);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -777,4 +777,55 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenUnsupportedType() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.VerificationsInOrder;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                 
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                 
+                  void test() {
+                      myObject.wait(1L);
+                      myObject.wait(2L, 1);
+                      new VerificationsInOrder() {{
+                          myObject.wait();
+                          myObject.wait(anyLong, anyInt);
+                      }};
+                  }
+              }
+              """,
+            """
+              import mockit.VerificationsInOrder;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                                                        
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(1L);
+                      myObject.wait(2L, 1);
+                      new VerificationsInOrder() {{
+                          myObject.wait();
+                          myObject.wait(anyLong, anyInt);
+                      }};
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
IllegalArgumentException generated when running jmockit to mockito recipe on code containing jmockit block VerificationsInOrder, raised here https://github.com/jmockit/jmockit1/issues/729#issuecomment-2406723779

https://javadoc.io/doc/org.jmockit/jmockit/latest/mockit/VerificationsInOrder.html

Stack trace

lang.IllegalArgumentException: No enum constant org.openrewrite.java.testing.jmo
ckit.JMockitBlockType.VerificationsInOrder
[ERROR] java.base/java.lang.Enum.valueOf(Enum.java:273)
[ERROR] org.openrewrite.java.testing.jmockit.JMockitBlockType.valueOf(JMockitB
lockType.java:20)
[ERROR] org.openrewrite.java.testing.jmockit.JMockitUtils.getJMockitBlock(JMoc
kitUtils.java:46)
[ERROR] org.openrewrite.java.testing.jmockit.SetupStatementsRewriter.rewriteMe
thodBody(SetupStatementsRewriter.java:41)
[ERROR] org.openrewrite.java.testing.jmockit.JMockitBlockToMockito$RewriteJMoc
kitBlockVisitor.visitMethodDeclaration(JMockitBlockToMockito.java:66)
[ERROR] org.openrewrite.java.testing.jmockit.JMockitBlockToMockito$RewriteJMoc
kitBlockVisitor.visitMethodDeclaration(JMockitBlockToMockito.java:56)

## Anyone you would like to review specifically?
@timtebeek @tinder-dthomson (understand he may be busy)

## Have you considered any alternatives or workarounds?
Yes - actually do migrate the above JMockit block. Need to use Mockito inOrder.verify(...). This will take time to do, so for now, just skipping migrating this block without generating exception. Anyway, we should ensure that any unsupported JMockit block types are not migrated, so this fix should be done anyway.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
