### PR TITLE
Jmockit mockito full verifications and Refactor tests

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
@@ -96,7 +96,7 @@ class JMockitBlockRewriter {
 
         // iterate over the statements and build a list of grouped method invocations and related statements eg times
         List<List<Statement>> methodInvocationsToRewrite = new ArrayList<>();
-        List<J.Identifier> mocks = new ArrayList<>();
+        List<J.Identifier> uniqueMocks = new ArrayList<>();
         int methodInvocationIdx = -1;
         for (Statement jmockitBlockStatement : jmockitBlock.getStatements()) {
             if (jmockitBlockStatement instanceof J.MethodInvocation) {
@@ -108,8 +108,8 @@ class JMockitBlockRewriter {
                         methodInvocationIdx++;
                         methodInvocationsToRewrite.add(new ArrayList<>());
                     }
-                    if (mocks.stream().noneMatch(mock -> mock.getType().equals(object.getType()) && mock.getSimpleName().equals(object.getSimpleName()))) {
-                        mocks.add(object);
+                    if (uniqueMocks.stream().noneMatch(mock -> mock.getType().equals(object.getType()) && mock.getSimpleName().equals(object.getSimpleName()))) {
+                        uniqueMocks.add(object);
                     }
                 }
             }
@@ -128,7 +128,7 @@ class JMockitBlockRewriter {
         methodInvocationsToRewrite.forEach(this::rewriteMethodInvocation);
 
         if (blockType == FullVerifications) {
-            rewriteFullVerifications(new ArrayList<>(mocks));
+            rewriteFullVerifications(new ArrayList<>(uniqueMocks));
         }
         return methodBody;
     }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockRewriter.java
@@ -237,9 +237,7 @@ class JMockitBlockRewriter {
 
     private void rewriteFullVerifications(List<Object> mocks) {
         StringBuilder sb = new StringBuilder(VERIFY_NO_INTERACTIONS_TEMPLATE_PREFIX);
-        for (int i = 0; i < mocks.size(); i++) {
-            sb.append(ANY_TEMPLATE_FIELD).append(","); // verifyNoMoreInteractions(mock1, mock2 ...
-        }
+        mocks.forEach(mock -> sb.append(ANY_TEMPLATE_FIELD).append(",")); // verifyNoMoreInteractions(mock1, mock2 ...
         sb.deleteCharAt(sb.length() - 1);
         sb.append(")");
         rewriteTemplate(sb.toString(), mocks, nextStatementCoordinates);

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockToMockito.java
@@ -26,31 +26,34 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.openrewrite.java.testing.jmockit.JMockitBlockType.*;
+import static org.openrewrite.java.testing.jmockit.JMockitBlockType.getSupportedTypesStr;
+import static org.openrewrite.java.testing.jmockit.JMockitBlockType.values;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class JMockitBlockToMockito extends Recipe {
 
+    private static final String SUPPORTED_TYPES = getSupportedTypesStr();
+
     @Override
     public String getDisplayName() {
-        return "Rewrite JMockit Expectations, Verifications and NonStrictExpectations";
+        return "Rewrite JMockit " + SUPPORTED_TYPES;
     }
 
     @Override
     public String getDescription() {
-        return "Rewrites JMockit `Expectations, Verifications and NonStrictExpectations` blocks to Mockito statements.";
+        return "Rewrites JMockit `" + SUPPORTED_TYPES + "` blocks to Mockito statements.";
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.or(
-                new UsesType<>(Expectations.getFqn(), false),
-                new UsesType<>(Verifications.getFqn(), false),
-                new UsesType<>(NonStrictExpectations.getFqn(), false)), new RewriteJMockitBlockVisitor());
+        @SuppressWarnings("rawtypes")
+        UsesType[] usesTypes = Arrays.stream(values()).map(blockType -> new UsesType<>(blockType.getFqn(), false)).toArray(UsesType[]::new);
+        return Preconditions.check(Preconditions.or(usesTypes), new RewriteJMockitBlockVisitor());
     }
 
     private static class RewriteJMockitBlockVisitor extends JavaIsoVisitor<ExecutionContext> {

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -27,11 +27,7 @@ enum JMockitBlockType {
     Verifications,
     FullVerifications;
 
-    private final String fqn;
-
-    JMockitBlockType() {
-        this.fqn = "mockit." + this.name();
-    }
+    private final String fqn = "mockit." + this.name();
 
     boolean isVerifications() {
         return this == Verifications || this == FullVerifications;

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -33,12 +33,12 @@ enum JMockitBlockType {
         this.fqn = "mockit." + this.name();
     }
 
-    public boolean isVerifications() {
+    boolean isVerifications() {
         String blockType = this.name();
         return blockType.equals(Verifications.name()) || blockType.equals(FullVerifications.name());
     }
 
-    public static String getSupportedTypesStr() {
+    static String getSupportedTypesStr() {
         StringBuilder sb = new StringBuilder();
         Arrays.stream(values()).forEach(value -> sb.append(value).append(", "));
         return sb.substring(0, sb.length() - 2);

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -17,16 +17,30 @@ package org.openrewrite.java.testing.jmockit;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 enum JMockitBlockType {
 
     Expectations,
+    NonStrictExpectations,
     Verifications,
-    NonStrictExpectations;
+    FullVerifications;
 
     private final String fqn;
 
     JMockitBlockType() {
         this.fqn = "mockit." + this.name();
+    }
+
+    public boolean isVerifications() {
+        String blockType = this.name();
+        return blockType.equals(Verifications.name()) || blockType.equals(FullVerifications.name());
+    }
+
+    public static String getSupportedTypesStr() {
+        StringBuilder sb = new StringBuilder();
+        Arrays.stream(values()).forEach(value -> sb.append(value).append(", "));
+        return sb.substring(0, sb.length() - 2);
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
+++ b/src/main/java/org/openrewrite/java/testing/jmockit/JMockitBlockType.java
@@ -34,8 +34,7 @@ enum JMockitBlockType {
     }
 
     boolean isVerifications() {
-        String blockType = this.name();
-        return blockType.equals(Verifications.name()) || blockType.equals(FullVerifications.name());
+        return this == Verifications || this == FullVerifications;
     }
 
     static String getSupportedTypesStr() {

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitAnnotatedArgumentToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitAnnotatedArgumentToMockitoTest.java
@@ -17,28 +17,10 @@ package org.openrewrite.java.testing.jmockit;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class JMockitAnnotatedArgumentToMockitoTest implements RewriteTest {
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec
-          .parser(JavaParser.fromJavaVersion()
-            .logCompilationWarningsAndErrors(true)
-            .classpathFromResources(new InMemoryExecutionContext(),
-              "junit-jupiter-api-5.9",
-              "jmockit-1.49"
-            ))
-          .recipeFromResource(
-            "/META-INF/rewrite/jmockit.yml",
-            "org.openrewrite.java.testing.jmockit.JMockitToMockito"
-          );
-    }
+class JMockitAnnotatedArgumentToMockitoTest extends JMockitTestBase {
 
     @DocumentExample
     @Test

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitDelegateToMockitoTest.java
@@ -19,11 +19,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
 
 /**
  * At the moment, JMockit Delegates are not migrated to mockito. What I'm seeing is that they are being trashed
@@ -32,12 +29,7 @@ import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultPa
  */
 @Disabled
 @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/522")
-class JMockitDelegateToMockitoTest implements RewriteTest {
-
-    @Override
-    public void defaults(RecipeSpec spec) {
-        setDefaultParserSettings(spec);
-    }
+class JMockitDelegateToMockitoTest extends JMockitTestBase {
 
     @DocumentExample
     @Test

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -18,18 +18,10 @@ package org.openrewrite.java.testing.jmockit;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
 
-class JMockitExpectationsToMockitoTest implements RewriteTest {
-
-    @Override
-    public void defaults(RecipeSpec spec) {
-        setDefaultParserSettings(spec);
-    }
+class JMockitExpectationsToMockitoTest extends JMockitTestBase {
 
     @DocumentExample
     @Test

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitFullVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitFullVerificationsToMockitoTest.java
@@ -17,20 +17,13 @@ package org.openrewrite.java.testing.jmockit;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
 
 /**
  * Not doing comprehensive testing as it is covered in JMockitVerificationsToMockitoTest and shares same code path
  */
-class JMockitFullVerificationsToMockitoTest implements RewriteTest {
-    @Override
-    public void defaults(RecipeSpec spec) {
-        setDefaultParserSettings(spec);
-    }
+class JMockitFullVerificationsToMockitoTest extends JMockitTestBase {
 
     @DocumentExample
     @Test
@@ -68,7 +61,7 @@ class JMockitFullVerificationsToMockitoTest implements RewriteTest {
               import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
-              
+                            
               import static org.mockito.Mockito.*;
                             
               @ExtendWith(MockitoExtension.class)

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitFullVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitFullVerificationsToMockitoTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.jmockit;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
+
+/**
+ * Not doing comprehensive testing as it is covered in JMockitVerificationsToMockitoTest and shares same code path
+ */
+class JMockitFullVerificationsToMockitoTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        setDefaultParserSettings(spec);
+    }
+
+    @DocumentExample
+    @Test
+    void whenTimes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.FullVerifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      new FullVerifications() {{
+                          myObject.wait(anyLong, anyInt);
+                          times = 2;
+                      }};
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      verify(myObject, times(2)).wait(anyLong(), anyInt());
+                      verifyNoMoreInteractions(myObject);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @DocumentExample
+    @Test
+    void whenOtherStatements() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.FullVerifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      new FullVerifications() {{
+                          myObject.wait(anyLong, anyInt);
+                      }};
+                      System.out.println("bla");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      verify(myObject).wait(anyLong(), anyInt());
+                      verifyNoMoreInteractions(myObject);
+                      System.out.println("bla");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenMultipleMocks() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.FullVerifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                  
+                  @Mocked
+                  String str;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      str.notify();
+                      new FullVerifications() {{
+                          myObject.wait(anyLong, anyInt);
+                          times = 2;
+                          str.notify();
+                      }};
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                  
+                  @Mock
+                  String str;
+                            
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait(10L, 10);
+                      str.notify();
+                      verify(myObject, times(2)).wait(anyLong(), anyInt());
+                      verify(str).notify();
+                      verifyNoMoreInteractions(myObject, str);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void whenMultipleInvocationsSameMock() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import mockit.FullVerifications;
+              import mockit.Mocked;
+              import mockit.integration.junit5.JMockitExtension;
+              import org.junit.jupiter.api.extension.ExtendWith;
+                            
+              @ExtendWith(JMockitExtension.class)
+              class MyTest {
+                  @Mocked
+                  Object myObject;
+                  
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait();
+                      new FullVerifications() {{
+                          myObject.wait(anyLong, anyInt);
+                          myObject.wait();
+                      }};
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+                            
+              import static org.mockito.Mockito.*;
+                            
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myObject;
+                 
+                  void test() {
+                      myObject.wait(10L, 10);
+                      myObject.wait();
+                      verify(myObject).wait(anyLong(), anyInt());
+                      verify(myObject).wait();
+                      verifyNoMoreInteractions(myObject);
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
@@ -1,0 +1,14 @@
+package org.openrewrite.java.testing.jmockit;
+
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
+
+public class JMockitTestBase implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        setDefaultParserSettings(spec);
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
@@ -5,7 +5,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
 
-public class JMockitTestBase implements RewriteTest {
+class JMockitTestBase implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitTestBase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.jmockit;
 
 import org.openrewrite.test.RecipeSpec;

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitVerificationsToMockitoTest.java
@@ -17,18 +17,11 @@ package org.openrewrite.java.testing.jmockit;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.test.RecipeSpec;
-import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
-import static org.openrewrite.java.testing.jmockit.JMockitTestUtils.setDefaultParserSettings;
 
-class JMockitVerificationsToMockitoTest implements RewriteTest {
-    @Override
-    public void defaults(RecipeSpec spec) {
-        setDefaultParserSettings(spec);
-    }
+class JMockitVerificationsToMockitoTest extends JMockitTestBase {
 
     @DocumentExample
     @Test
@@ -684,7 +677,7 @@ class JMockitVerificationsToMockitoTest implements RewriteTest {
               
                   void test() {
                       myObject.wait();
-                      new Verifications() {{              
+                      new Verifications() {{        
                           myObject.wait();              
                           myObject.wait(anyLong, anyInt);
                       }};


### PR DESCRIPTION
## What's changed?
Migrate JMockit FullVerifications to Mockito
https://www.javadoc.io/doc/org.jmockit/jmockit/latest/mockit/FullVerifications.html
https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html <- for verifyNoMoreInteractions

Replacing FullVerifications with standard mockito verify and then add one line of verifyNoMoreInteractions(mocks. ..)

Also do a refactor of tests to remove some unnecessary code - add a new JMockitTestBase which sets the default parser settings and other tests can inherit from that, hope it's ok to use inhertance here, if not please let me know. I think it makes a lot of sense here.

## What's your motivation?
Just wanted to add this feature to enhance the current migration scope, InOrderVerifications feature was requested here https://github.com/jmockit/jmockit1/issues/729#issuecomment-2406723779 and this will also help pave the way for that

## Anyone you would like to review specifically?
@timtebeek @tinder-dthomson as FYI, and if wants to review also (I know he is busy)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
