### PR TITLE
refactor: Annotate methods which may return `null` with `@Nullable`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveEmptyTests.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveEmptyTests.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.cleanup;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -53,8 +54,9 @@ public class RemoveEmptyTests extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new FindEmptyMethods(false), new JavaVisitor<ExecutionContext>() {
+
             @Override
-            public J visitMethodDeclaration(MethodDeclaration method, ExecutionContext ctx) {
+            public @Nullable J visitMethodDeclaration(MethodDeclaration method, ExecutionContext ctx) {
                 if (hasTestAnnotation(method) && isEmptyMethod(method)) {
                     //noinspection ConstantConditions
                     return null;

--- a/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MigrateJUnitTestCase.java
@@ -83,7 +83,7 @@ public class MigrateJUnitTestCase extends Recipe {
 
                     @SuppressWarnings("ConstantConditions")
                     @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    public @Nullable J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
                         if ((mi.getSelect() != null && TypeUtils.isOfClassType(mi.getSelect().getType(), "junit.framework.TestCase")) ||
                             (mi.getMethodType() != null && TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), "junit.framework.TestCase"))) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -108,7 +108,7 @@ public class TemporaryFolderToTempDir extends Recipe {
             }
 
             @Override
-            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
                 updateCursor(mi);
                 if (mi.getSelect() != null && mi.getMethodType() != null &&

--- a/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
@@ -101,7 +101,7 @@ public class TestRuleToTestInfo extends Recipe {
         }
 
         @Override
-        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+        public @Nullable J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
             J.NewClass nc = super.visitNewClass(newClass, ctx);
             if (TypeUtils.isOfClassType(nc.getType(), "org.junit.rules.TestName")) {
                 //noinspection ConstantConditions

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -168,7 +168,7 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
         }
 
         @Override
-        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
 
             Map<String, J.MethodInvocation> mockStaticInvocationsByClassName = getCursor().getNearestMessage(MOCK_STATIC_INVOCATIONS);


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.staticanalysis.AnnotateNullableMethods?organizationId=T3BlblJld3JpdGU%3D