### PR TITLE
Added default warn strictness if no strictness modifiers are used.

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/MockitoJUnitToMockitoExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MockitoJUnitToMockitoExtension.java
@@ -114,7 +114,12 @@ public class MockitoJUnitToMockitoExtension extends Recipe {
                     maybeAddImport("org.junit.jupiter.api.extension.ExtendWith");
                     maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
 
-                    if (strictness != null) {
+                    if (strictness == null) {
+                        // As we are in a Rule, and rules where always warn by default,
+                        // we cannot use junit5 Strictness.STRICT_STUBS during migration
+                        strictness = "Strictness.WARN";
+                    }
+                    if (!strictness.contains("STRICT_STUBS")) {
                         cd = JavaTemplate.builder("@MockitoSettings(strictness = " + strictness + ")")
                                 .doBeforeParseTemplate(System.out::println)
                                 .javaParser(JavaParser.fromJavaVersion()
@@ -156,7 +161,7 @@ public class MockitoJUnitToMockitoExtension extends Recipe {
                             strictness = "Strictness.LENIENT";
                             break;
                     }
-                    if (strictness != null && !strictness.contains("STRICT_STUBS")) {
+                    if (strictness != null) {
                         strictness = strictness.startsWith("Strictness.") ? strictness : "Strictness." + strictness;
                         getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, STRICTNESS_KEY, strictness);
                     }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitToMockitoExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitToMockitoExtensionTest.java
@@ -64,8 +64,11 @@ class MockitoJUnitToMockitoExtensionTest implements RewriteTest {
               import org.junit.rules.TemporaryFolder;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
               
               @ExtendWith(MockitoExtension.class)
+              @MockitoSettings(strictness = Strictness.WARN)
               class MyTest {
               
                   @Rule
@@ -103,9 +106,12 @@ class MockitoJUnitToMockitoExtensionTest implements RewriteTest {
               import org.junit.runners.MethodSorters;
               import org.mockito.Mock;
               import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
               
               @ExtendWith(MockitoExtension.class)
               @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+              @MockitoSettings(strictness = Strictness.WARN)
               class MyTest {
               }
               """
@@ -266,12 +272,15 @@ class MockitoJUnitToMockitoExtensionTest implements RewriteTest {
               import org.mockito.junit.MockitoJUnit;
               import org.mockito.junit.VerificationCollector;
               import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
               
               import java.util.List;
               
               import static org.mockito.Mockito.verify;
               
               @ExtendWith(MockitoExtension.class)
+              @MockitoSettings(strictness = Strictness.WARN)
               class MyTest {
               
                   @Rule


### PR DESCRIPTION
## What's changed?
In previous PR, I forgot to include a default if the tests where not using silent or strictness calls. 
Went for WARN as default as that's the default in junit4, and other wise junit5 would start failing on these tests.