### PR TITLE
SimplifyChainedAssertJAssertion drops method calls in replacement

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
@@ -30,10 +30,7 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -163,19 +160,16 @@ public class SimplifyChainedAssertJAssertion extends Recipe {
 
             return "assertThat(#{any()}).%s(#{any()})";
         }
-    }
 
-    private Expression extractEitherArgument(boolean assertThatArgumentIsEmpty, Expression assertThatArgument, Expression methodToReplaceArgument) {
-        if (assertThatArgumentIsEmpty) {
-            return methodToReplaceArgument;
-        }
-        // Only on the assertThat argument do we possibly replace the argument with the select; such as list.size() -> list
-        if (assertThatArgument instanceof J.MethodInvocation) {
-            J.MethodInvocation methodInvocation = (J.MethodInvocation) assertThatArgument;
-            if (chainedAssertion.equals(methodInvocation.getSimpleName()) && methodInvocation.getSelect() != null) {
-                return methodInvocation.getSelect();
+        private Expression extractEitherArgument(boolean assertThatArgumentIsEmpty, Expression assertThatArgument, Expression methodToReplaceArgument) {
+            if (assertThatArgumentIsEmpty) {
+                return methodToReplaceArgument;
             }
+            // Only on the assertThat argument do we possibly replace the argument with the select; such as list.size() -> list
+            if (CHAINED_ASSERT_MATCHER.matches(assertThatArgument)) {
+                return Objects.requireNonNull(((J.MethodInvocation) assertThatArgument).getSelect());
+            }
+            return assertThatArgument;
         }
-        return assertThatArgument;
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
@@ -165,15 +165,15 @@ public class SimplifyChainedAssertJAssertion extends Recipe {
         }
     }
 
-    private static Expression extractEitherArgument(boolean assertThatArgumentIsEmpty, Expression assertThatArgument, Expression methodToReplaceArgument) {
+    private Expression extractEitherArgument(boolean assertThatArgumentIsEmpty, Expression assertThatArgument, Expression methodToReplaceArgument) {
         if (assertThatArgumentIsEmpty) {
             return methodToReplaceArgument;
         }
         // Only on the assertThat argument do we possibly replace the argument with the select; such as list.size() -> list
         if (assertThatArgument instanceof J.MethodInvocation) {
-            Expression select = ((J.MethodInvocation) assertThatArgument).getSelect();
-            if (select != null) {
-                return select;
+            J.MethodInvocation methodInvocation = (J.MethodInvocation) assertThatArgument;
+            if (chainedAssertion.equals(methodInvocation.getSimpleName()) && methodInvocation.getSelect() != null) {
+                return methodInvocation.getSelect();
             }
         }
         return assertThatArgument;

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionTest.java
@@ -42,7 +42,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat("hello world".isEmpty()).isTrue();
@@ -51,7 +51,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat("hello world").isEmpty();
@@ -71,7 +71,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod(String actual) {
                       assertThat(actual.isEmpty()).as("Reason").isTrue();
@@ -80,7 +80,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod(String actual) {
                       assertThat(actual).as("Reason").isEmpty();
@@ -102,12 +102,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString().isEmpty()).isTrue();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -115,12 +115,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString()).isEmpty();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -141,14 +141,14 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import java.nio.file.Path;
-
+              
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void string(String actual) {
                       assertThat(actual.startsWith("prefix")).isTrue();
                   }
-
+              
                   void path(Path actual) {
                       assertThat(actual.startsWith("prefix")).isTrue();
                   }
@@ -156,14 +156,14 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import java.nio.file.Path;
-
+              
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void string(String actual) {
                       assertThat(actual).startsWith("prefix");
                   }
-
+              
                   void path(Path actual) {
                       assertThat(actual).startsWithRaw(Path.of("prefix"));
                   }
@@ -181,13 +181,13 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       String expected = "hello world";
                       assertThat(getString().equalsIgnoreCase(expected)).isTrue();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -195,13 +195,13 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       String expected = "hello world";
                       assertThat(getString()).isEqualToIgnoringCase(expected);
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -219,13 +219,13 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       int length = 5;
                       assertThat(getString().length()).isEqualTo(length);
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -233,13 +233,13 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       int length = 5;
                       assertThat(getString()).hasSize(length);
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -258,12 +258,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString().trim()).isEmpty();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -271,12 +271,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString()).isBlank();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -297,7 +297,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat("hello world".contains("lo wo")).isTrue();
@@ -307,7 +307,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat("hello world").contains("lo wo");
@@ -323,25 +323,22 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
     void stringContainsObjectMethod() {
         rewriteRun(
           spec -> spec.recipes(
-            new SimplifyChainedAssertJAssertion("contains", "isTrue", "contains", "java.lang.String"),
-            new SimplifyChainedAssertJAssertion("contains", "isFalse", "doesNotContain", "java.lang.String")
-          ),
+            new SimplifyChainedAssertJAssertion("contains", "isTrue", "contains", "java.lang.String")),
           //language=java
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-   
+              
               class Pojo {
                 public String getString() {
                     return "lo wo";
                 }
               }
-
+              
               class MyTest {
                   void testMethod() {
                       var pojo = new Pojo();
                       assertThat("hello world".contains(pojo.getString())).isTrue();
-                      assertThat("hello world".contains("lll")).isFalse();
                   }
               }
               """,
@@ -353,12 +350,11 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
                     return "lo wo";
                 }
               }
-
+              
               class MyTest {
                   void testMethod() {
                       var pojo = new Pojo();
                       assertThat("hello world").contains(pojo.getString());
-                      assertThat("hello world").doesNotContain("lll");
                   }
               }
               """
@@ -375,16 +371,16 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
             """
               import java.util.Collections;
               import java.util.Map;
-
+              
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       String key = "key";
                       String value = "value";
                       assertThat(getMap().get(key)).isEqualTo(value);
                   }
-
+              
                   Map<String, String> getMap() {
                       return Collections.emptyMap();
                   }
@@ -393,16 +389,16 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
             """
               import java.util.Collections;
               import java.util.Map;
-
+              
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       String key = "key";
                       String value = "value";
                       assertThat(getMap()).containsEntry(key, value);
                   }
-
+              
                   Map<String, String> getMap() {
                       return Collections.emptyMap();
                   }
@@ -420,9 +416,9 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import java.util.Map;
-
+              
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod(Map<String, String> map) {
                       // we don't yet support `containsKeys`
@@ -442,12 +438,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString().isEmpty()).isFalse();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -455,12 +451,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString()).isNotEmpty();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -478,12 +474,12 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
           java(
             """
               import static org.assertj.core.api.Assertions.assertThat;
-
+              
               class MyTest {
                   void testMethod() {
                       assertThat(getString().isBlank()).isFalse();
                   }
-
+              
                   String getString() {
                       return "hello world";
                   }
@@ -510,7 +506,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
                 """
                   import static org.assertj.core.api.Assertions.assertThat;
                   import java.util.Optional;
-
+                  
                   class Test {
                       void simpleTest(Optional<String> o) {
                           assertThat(o.isPresent()).isTrue();
@@ -523,7 +519,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
                 """
                   import static org.assertj.core.api.Assertions.assertThat;
                   import java.util.Optional;
-
+                  
                   class Test {
                       void simpleTest(Optional<String> o) {
                           assertThat(o).isPresent();
@@ -549,7 +545,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
                 """
                   import static org.assertj.core.api.Assertions.assertThat;
                   import java.util.Optional;
-
+                  
                   class Test {
                       void simpleTest(Optional<String> o) {
                           assertThat(o.get()).isEqualTo("foo");
@@ -560,7 +556,7 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
                 """
                   import static org.assertj.core.api.Assertions.assertThat;
                   import java.util.Optional;
-
+                  
                   class Test {
                       void simpleTest(Optional<String> o) {
                           assertThat(o).contains("foo");

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionTest.java
@@ -320,6 +320,53 @@ class SimplifyChainedAssertJAssertionTest implements RewriteTest {
     }
 
     @Test
+    void stringContainsObjectMethod() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new SimplifyChainedAssertJAssertion("contains", "isTrue", "contains", "java.lang.String"),
+            new SimplifyChainedAssertJAssertion("contains", "isFalse", "doesNotContain", "java.lang.String")
+          ),
+          //language=java
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+   
+              class Pojo {
+                public String getString() {
+                    return "lo wo";
+                }
+              }
+
+              class MyTest {
+                  void testMethod() {
+                      var pojo = new Pojo();
+                      assertThat("hello world".contains(pojo.getString())).isTrue();
+                      assertThat("hello world".contains("lll")).isFalse();
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class Pojo {
+                public String getString() {
+                    return "lo wo";
+                }
+              }
+
+              class MyTest {
+                  void testMethod() {
+                      var pojo = new Pojo();
+                      assertThat("hello world").contains(pojo.getString());
+                      assertThat("hello world").doesNotContain("lll");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void mapMethodDealsWithTwoArguments() {
         rewriteRun(
           spec -> spec.recipe(new SimplifyChainedAssertJAssertion("get", "isEqualTo", "containsEntry", "java.util.Map")),


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

- Fixes #628. 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
