### PR TITLE
Add `VerifyZeroToNoMoreInteractions` for Mockito 2

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
@@ -1,0 +1,66 @@
+package org.openrewrite.java.testing.mockito;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.dependencies.DependencyInsight;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class VerifyZeroToNoMoreInteractions extends ScanningRecipe<AtomicBoolean> {
+
+    private static final MethodMatcher ASSERT_INSTANCE_OF_MATCHER = new MethodMatcher("org.mockito.Mockito verifyZeroInteractions(..)", true);
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `verifyZeroInteractions() to `verifyNoMoreInteractions()";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `verifyZeroInteractions()` with `verifyNoMoreInteractions()` in Mockito tests when migration when using a Mockito version < 3.x.";
+    }
+
+    @Override
+    public AtomicBoolean getInitialValue(final ExecutionContext ctx) {
+        return new AtomicBoolean(false);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean usingOlderMockito) {
+        TreeVisitor<?, ExecutionContext> div = new DependencyInsight("org.mockito", "mockito-*", "[1.0,3.0)", null).getVisitor();
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (!usingOlderMockito.get() && div.visit(tree, ctx) != tree) {
+                    usingOlderMockito.set(true);
+                }
+                return tree;
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(AtomicBoolean usingOlderMockito) {
+        return Preconditions.check(usingOlderMockito.get(),
+                Preconditions.check(new UsesMethod<>(ASSERT_INSTANCE_OF_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation md = super.visitMethodInvocation(method, ctx);
+
+                        if (!ASSERT_INSTANCE_OF_MATCHER.matches(md)) {
+                            return md;
+                        }
+
+                        maybeAddImport("org.mockito.Mockito", "verifyNoMoreInteractions");
+                        maybeRemoveImport("org.mockito.Mockito.verifyZeroInteractions");
+
+                        return method.withName(md.getName().withSimpleName("verifyNoMoreInteractions"));
+                    }
+                })
+        );
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.mockito;
 
 import org.jspecify.annotations.Nullable;

--- a/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractions.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.testing.mockito;
 
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.java.ChangeMethodName;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.dependencies.DependencyInsight;
@@ -27,7 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class VerifyZeroToNoMoreInteractions extends ScanningRecipe<AtomicBoolean> {
 
-    private static final MethodMatcher ASSERT_INSTANCE_OF_MATCHER = new MethodMatcher("org.mockito.Mockito verifyZeroInteractions(..)", true);
+    private static final String VERIFY_ZERO_INTERACTIONS = "org.mockito.Mockito verifyZeroInteractions(..)";
+    private static final MethodMatcher ASSERT_INSTANCE_OF_MATCHER = new MethodMatcher(VERIFY_ZERO_INTERACTIONS, true);
 
     @Override
     public String getDisplayName() {
@@ -73,7 +75,8 @@ public class VerifyZeroToNoMoreInteractions extends ScanningRecipe<AtomicBoolean
                         maybeAddImport("org.mockito.Mockito", "verifyNoMoreInteractions");
                         maybeRemoveImport("org.mockito.Mockito.verifyZeroInteractions");
 
-                        return method.withName(md.getName().withSimpleName("verifyNoMoreInteractions"));
+                        ChangeMethodName changeMethodName = new ChangeMethodName(VERIFY_ZERO_INTERACTIONS, "verifyNoMoreInteractions", false, false);
+                        return (J.MethodInvocation) changeMethodName.getVisitor().visitNonNull(md, ctx);
                     }
                 })
         );

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -132,7 +132,7 @@ recipeList:
       oldParameterNames:
         - mode
         - verification
-  - org.openrewrite.java.testing.mockito.verifyZeroToNoMoreInteractions
+  - org.openrewrite.java.testing.mockito.VerifyZeroToNoMoreInteractions
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.mockito.Mockito verifyZeroInteractions(..)
       newMethodName: verifyNoInteractions

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -132,6 +132,7 @@ recipeList:
       oldParameterNames:
         - mode
         - verification
+  - org.openrewrite.java.testing.mockito.verifyZeroToNoMoreInteractions
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.mockito.Mockito verifyZeroInteractions(..)
       newMethodName: verifyNoInteractions

--- a/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
@@ -1,0 +1,214 @@
+package org.openrewrite.java.testing.mockito;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
+
+    @Language("xml")
+    private static final String POM_XML_WITH_MOCKITO_2 = """
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>bla.bla</groupId>
+        <artifactId>bla-bla</artifactId>
+        <version>1.0.0</version>
+        <dependencies>
+          <dependency>
+              <groupId>org.mockito</groupId>
+              <artifactId>mockito-core</artifactId>
+              <version>2.17.0</version>
+              <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </project>
+      """;
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api"))
+          .recipe(new VerifyZeroToNoMoreInteractions());
+    }
+
+    @Test
+    @DocumentExample
+    void shouldReplaceToNoMoreInteractions() {
+        //language=java
+        rewriteRun(
+          pomXml(POM_XML_WITH_MOCKITO_2),
+          java("""
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.junit.jupiter.api.Test;
+
+            import static org.mockito.Mockito.verifyZeroInteractions;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Test
+                void test() {
+                    verifyZeroInteractions(System.out);
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.junit.jupiter.api.Test;
+
+            import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Test
+                void test() {
+                    verifyNoMoreInteractions(System.out);
+                }
+            }
+            """));
+    }
+
+    @Test
+    void shouldNotReplaceToNoMoreInteractionsForImportOnly() {
+        //language=java
+        rewriteRun(
+          pomXml(POM_XML_WITH_MOCKITO_2),
+          java("""
+            import static org.mockito.Mockito.verifyZeroInteractions;
+
+            class MyTest {}
+            """));
+    }
+
+    @Test
+    void doesNotConvertAnyOtherMethods() {
+        rewriteRun(
+          pomXml(POM_XML_WITH_MOCKITO_2),
+          // language=java
+          java("""
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.mockito.Mock;
+            import org.junit.jupiter.api.Test;
+            import static org.mockito.Mockito.verifyZeroInteractions;
+            import static org.mockito.Mockito.verify;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Mock
+                Object myObject;
+
+                @Test
+                void test() {
+                    verifyZeroInteractions(System.out);
+                    verify(myObject);
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.mockito.Mock;
+            import org.junit.jupiter.api.Test;
+            import static org.mockito.Mockito.verifyNoMoreInteractions;
+            import static org.mockito.Mockito.verify;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Mock
+                Object myObject;
+
+                @Test
+                void test() {
+                    verifyNoMoreInteractions(System.out);
+                    verify(myObject);
+                }
+            }
+            """));
+    }
+
+    @Test
+    void doesConvertNestedMethodInvocations() {
+        rewriteRun(
+          pomXml(POM_XML_WITH_MOCKITO_2),
+          // language=java
+          java("""
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.junit.jupiter.api.Test;
+
+            import static org.junit.jupiter.api.Assertions.assertAll;
+            import static org.mockito.Mockito.verifyZeroInteractions;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Test
+                void test() {
+                    assertAll(() -> verifyZeroInteractions(System.out));
+                }
+            }
+            """, """
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.junit.jupiter.api.Test;
+
+            import static org.junit.jupiter.api.Assertions.assertAll;
+            import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Test
+                void test() {
+                    assertAll(() -> verifyNoMoreInteractions(System.out));
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void shouldNotRunOnNewerMockito3OrHigher() {
+        rewriteRun(
+          //language=xml
+          pomXml("""
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>bla.bla</groupId>
+              <artifactId>bla-bla</artifactId>
+              <version>1.0.0</version>
+              <dependencies>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>3.0.0</version>
+                    <scope>test</scope>
+                </dependency>
+              </dependencies>
+            </project>
+            """),
+          //language=java
+          java("""
+            import org.junit.jupiter.api.extension.ExtendWith;
+            import org.mockito.junit.jupiter.MockitoExtension;
+            import org.junit.jupiter.api.Test;
+
+            import static org.mockito.Mockito.verifyZeroInteractions;
+
+            @ExtendWith(MockitoExtension.class)
+            class MyTest {
+                @Test
+                void test() {
+                    verifyZeroInteractions(System.out);
+                }
+            }
+            """));
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
@@ -62,23 +62,25 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           pomXml(POM_XML_WITH_MOCKITO_2),
           java(
             """
-            import static org.mockito.Mockito.verifyZeroInteractions;
+              import static org.mockito.Mockito.verifyZeroInteractions;
 
-            class MyTest {
-                void test() {
-                    verifyZeroInteractions(System.out);
-                }
-            }
-            """,
+              class MyTest {
+                  void test() {
+                      verifyZeroInteractions(System.out);
+                  }
+              }
+              """,
             """
-            import static org.mockito.Mockito.verifyNoMoreInteractions;
+              import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-            class MyTest {
-                void test() {
-                    verifyNoMoreInteractions(System.out);
-                }
-            }
-            """));
+              class MyTest {
+                  void test() {
+                      verifyNoMoreInteractions(System.out);
+                  }
+              }
+              """
+          )
+        );
     }
 
     @Test
@@ -88,10 +90,12 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           pomXml(POM_XML_WITH_MOCKITO_2),
           java(
             """
-            import static org.mockito.Mockito.verifyZeroInteractions;
+              import static org.mockito.Mockito.verifyZeroInteractions;
 
-            class MyTest {}
-            """));
+              class MyTest {}
+              """
+          )
+        );
     }
 
     @Test
@@ -101,37 +105,39 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           // language=java
           java(
             """
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.mockito.Mock;
-            import static org.mockito.Mockito.verifyZeroInteractions;
-            import static org.mockito.Mockito.verify;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.Mock;
+              import static org.mockito.Mockito.verifyZeroInteractions;
+              import static org.mockito.Mockito.verify;
 
-            class MyTest {
-                @Mock
-                Object myObject;
+              class MyTest {
+                  @Mock
+                  Object myObject;
 
-                void test() {
-                    verifyZeroInteractions(System.out);
-                    verify(myObject);
-                }
-            }
-            """,
+                  void test() {
+                      verifyZeroInteractions(System.out);
+                      verify(myObject);
+                  }
+              }
+              """,
             """
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.mockito.Mock;
-            import static org.mockito.Mockito.verifyNoMoreInteractions;
-            import static org.mockito.Mockito.verify;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.Mock;
+              import static org.mockito.Mockito.verifyNoMoreInteractions;
+              import static org.mockito.Mockito.verify;
 
-            class MyTest {
-                @Mock
-                Object myObject;
+              class MyTest {
+                  @Mock
+                  Object myObject;
 
-                void test() {
-                    verifyNoMoreInteractions(System.out);
-                    verify(myObject);
-                }
-            }
-            """));
+                  void test() {
+                      verifyNoMoreInteractions(System.out);
+                      verify(myObject);
+                  }
+              }
+              """
+          )
+        );
     }
 
     @Test
@@ -141,29 +147,29 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           // language=java
           java(
             """
-            import java.util.function.Consumer;
+              import java.util.function.Consumer;
 
-            import static org.mockito.Mockito.verifyZeroInteractions;
+              import static org.mockito.Mockito.verifyZeroInteractions;
 
-            class MyTest {
-                void test() {
-                    Runnable f = () -> verifyZeroInteractions(System.out);
-                    f.run();
-                }
-            }
-            """,
+              class MyTest {
+                  void test() {
+                      Runnable f = () -> verifyZeroInteractions(System.out);
+                      f.run();
+                  }
+              }
+              """,
             """
-            import java.util.function.Consumer;
+              import java.util.function.Consumer;
 
-            import static org.mockito.Mockito.verifyNoMoreInteractions;
+              import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-            class MyTest {
-                void test() {
-                    Runnable f = () -> verifyNoMoreInteractions(System.out);
-                    f.run();
-                }
-            }
-            """
+              class MyTest {
+                  void test() {
+                      Runnable f = () -> verifyNoMoreInteractions(System.out);
+                      f.run();
+                  }
+              }
+              """
           )
         );
     }
@@ -174,33 +180,35 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           //language=xml
           pomXml(
             """
-            <project>
-              <modelVersion>4.0.0</modelVersion>
-              <groupId>bla.bla</groupId>
-              <artifactId>bla-bla</artifactId>
-              <version>1.0.0</version>
-              <dependencies>
-                <dependency>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                    <version>3.0.0</version>
-                    <scope>test</scope>
-                </dependency>
-              </dependencies>
-            </project>
-            """),
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>bla.bla</groupId>
+                <artifactId>bla-bla</artifactId>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency>
+                      <groupId>org.mockito</groupId>
+                      <artifactId>mockito-core</artifactId>
+                      <version>3.0.0</version>
+                      <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """),
           //language=java
           java(
             """
-            import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoExtension;
 
-            import static org.mockito.Mockito.verifyZeroInteractions;
+              import static org.mockito.Mockito.verifyZeroInteractions;
 
-            class MyTest {
-                void test() {
-                    verifyZeroInteractions(System.out);
-                }
-            }
-            """));
+              class MyTest {
+                  void test() {
+                      verifyZeroInteractions(System.out);
+                  }
+              }
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.mockito;
 
 import org.intellij.lang.annotations.Language;
@@ -45,7 +60,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         //language=java
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
-          java("""
+          java(
+                """
             import org.junit.jupiter.api.extension.ExtendWith;
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.junit.jupiter.api.Test;
@@ -81,7 +97,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         //language=java
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
-          java("""
+          java(
+                """
             import static org.mockito.Mockito.verifyZeroInteractions;
 
             class MyTest {}
@@ -93,7 +110,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
           // language=java
-          java("""
+          java(
+                """
             import org.junit.jupiter.api.extension.ExtendWith;
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.mockito.Mock;
@@ -139,7 +157,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
           // language=java
-          java("""
+          java(
+                """
             import org.junit.jupiter.api.extension.ExtendWith;
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.junit.jupiter.api.Test;
@@ -178,7 +197,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
     void shouldNotRunOnNewerMockito3OrHigher() {
         rewriteRun(
           //language=xml
-          pomXml("""
+          pomXml(
+                """
             <project>
               <modelVersion>4.0.0</modelVersion>
               <groupId>bla.bla</groupId>
@@ -195,7 +215,8 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
             </project>
             """),
           //language=java
-          java("""
+          java(
+                """
             import org.junit.jupiter.api.extension.ExtendWith;
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/VerifyZeroToNoMoreInteractionsTest.java
@@ -50,7 +50,7 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "mockito-core", "mockito-junit-jupiter", "junit-jupiter-api"))
+            .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3", "mockito-junit-jupiter-3"))
           .recipe(new VerifyZeroToNoMoreInteractions());
     }
 
@@ -61,30 +61,19 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
           java(
-                """
-            import org.junit.jupiter.api.extension.ExtendWith;
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.junit.jupiter.api.Test;
-
+            """
             import static org.mockito.Mockito.verifyZeroInteractions;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
-                @Test
                 void test() {
                     verifyZeroInteractions(System.out);
                 }
             }
-            """, """
-            import org.junit.jupiter.api.extension.ExtendWith;
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.junit.jupiter.api.Test;
-
+            """,
+            """
             import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
-                @Test
                 void test() {
                     verifyNoMoreInteractions(System.out);
                 }
@@ -98,7 +87,7 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         rewriteRun(
           pomXml(POM_XML_WITH_MOCKITO_2),
           java(
-                """
+            """
             import static org.mockito.Mockito.verifyZeroInteractions;
 
             class MyTest {}
@@ -111,39 +100,32 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           pomXml(POM_XML_WITH_MOCKITO_2),
           // language=java
           java(
-                """
-            import org.junit.jupiter.api.extension.ExtendWith;
+            """
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.mockito.Mock;
-            import org.junit.jupiter.api.Test;
             import static org.mockito.Mockito.verifyZeroInteractions;
             import static org.mockito.Mockito.verify;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
                 @Mock
                 Object myObject;
 
-                @Test
                 void test() {
                     verifyZeroInteractions(System.out);
                     verify(myObject);
                 }
             }
-            """, """
-            import org.junit.jupiter.api.extension.ExtendWith;
+            """,
+            """
             import org.mockito.junit.jupiter.MockitoExtension;
             import org.mockito.Mock;
-            import org.junit.jupiter.api.Test;
             import static org.mockito.Mockito.verifyNoMoreInteractions;
             import static org.mockito.Mockito.verify;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
                 @Mock
                 Object myObject;
 
-                @Test
                 void test() {
                     verifyNoMoreInteractions(System.out);
                     verify(myObject);
@@ -158,34 +140,27 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
           pomXml(POM_XML_WITH_MOCKITO_2),
           // language=java
           java(
-                """
-            import org.junit.jupiter.api.extension.ExtendWith;
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.junit.jupiter.api.Test;
+            """
+            import java.util.function.Consumer;
 
-            import static org.junit.jupiter.api.Assertions.assertAll;
             import static org.mockito.Mockito.verifyZeroInteractions;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
-                @Test
                 void test() {
-                    assertAll(() -> verifyZeroInteractions(System.out));
+                    Runnable f = () -> verifyZeroInteractions(System.out);
+                    f.run();
                 }
             }
-            """, """
-            import org.junit.jupiter.api.extension.ExtendWith;
-            import org.mockito.junit.jupiter.MockitoExtension;
-            import org.junit.jupiter.api.Test;
+            """,
+            """
+            import java.util.function.Consumer;
 
-            import static org.junit.jupiter.api.Assertions.assertAll;
             import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
-                @Test
                 void test() {
-                    assertAll(() -> verifyNoMoreInteractions(System.out));
+                    Runnable f = () -> verifyNoMoreInteractions(System.out);
+                    f.run();
                 }
             }
             """
@@ -198,7 +173,7 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
         rewriteRun(
           //language=xml
           pomXml(
-                """
+            """
             <project>
               <modelVersion>4.0.0</modelVersion>
               <groupId>bla.bla</groupId>
@@ -216,16 +191,12 @@ class VerifyZeroToNoMoreInteractionsTest implements RewriteTest {
             """),
           //language=java
           java(
-                """
-            import org.junit.jupiter.api.extension.ExtendWith;
+            """
             import org.mockito.junit.jupiter.MockitoExtension;
-            import org.junit.jupiter.api.Test;
 
             import static org.mockito.Mockito.verifyZeroInteractions;
 
-            @ExtendWith(MockitoExtension.class)
             class MyTest {
-                @Test
                 void test() {
                     verifyZeroInteractions(System.out);
                 }


### PR DESCRIPTION
## What's changed?
Extra recipe to migration the `verifyZeroInteractions` method for older Mockito versions:
> If coming from Mockito < 3 then change from verifyZeroInteractions to verifyNoMoreInteractions
if coming from Mockito 3+ then change from verifyZeroInteractions to verifyNoInteractions (as we do now)

## What's your motivation?
- fixes #630 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
