### PR TITLE
Added handling of org.mockito.Mockito.eq(..) when simplifying mockito matchers

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGiven.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGiven.java
@@ -69,7 +69,7 @@ public class SimplifyMockitoVerifyWhenGiven extends Recipe {
                             updatedArguments.set(0, checkAndUpdateEq((J.MethodInvocation) mi.getArguments().get(0)));
                             mi = mi.withArguments(updatedArguments);
                         } else if (VERIFY_MATCHER.matches(mi.getSelect()) ||
-                                STUBBER_MATCHER.matches(mi.getSelect())) {
+                                   STUBBER_MATCHER.matches(mi.getSelect())) {
                             mi = checkAndUpdateEq(mi);
                         }
 
@@ -80,7 +80,7 @@ public class SimplifyMockitoVerifyWhenGiven extends Recipe {
 
                     private J.MethodInvocation checkAndUpdateEq(J.MethodInvocation methodInvocation) {
                         if (methodInvocation.getArguments().stream().allMatch(arg -> EQ_MATCHER.matches(arg) ||
-                                MOCKITO_EQ_MATCHER.matches(arg))) {
+                                                                                     MOCKITO_EQ_MATCHER.matches(arg))) {
                             return methodInvocation.withArguments(ListUtils.map(methodInvocation.getArguments(), invocation ->
                                     ((MethodCall) invocation).getArguments().get(0).withPrefix(invocation.getPrefix())));
                         }

--- a/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
@@ -42,7 +42,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.verify;
               import static org.mockito.Mockito.mock;
               import static org.mockito.ArgumentMatchers.eq;
-              
+
               class Test {
                   void test() {
                       var mockString = mock(String.class);
@@ -52,7 +52,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               """, """
               import static org.mockito.Mockito.verify;
               import static org.mockito.Mockito.mock;
-              
+
               class Test {
                   void test() {
                       var mockString = mock(String.class);
@@ -64,6 +64,38 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
         );
     }
 
+	@Test
+	void shouldRemoveUnneccesaryEqFromVerify_withMockitoStarImport() {
+		rewriteRun(
+		  //language=Java
+		  java(
+			"""
+              import static org.mockito.Mockito.eq;
+              import static org.mockito.Mockito.mock;
+              import static org.mockito.Mockito.verify;
+
+              class Test {
+                  void test() {
+                      var mockString = mock(String.class);
+                      verify(mockString).replace(eq("foo"), eq("bar"));
+                  }
+              }
+              """, """
+              import static org.mockito.Mockito.mock;
+              import static org.mockito.Mockito.verify;
+
+              class Test {
+                  void test() {
+                      var mockString = mock(String.class);
+                      verify(mockString).replace("foo", "bar");
+                  }
+              }
+              """
+		  )
+		);
+	}
+
+
     @Test
     void shouldRemoveUnneccesaryEqFromWhen() {
         rewriteRun(
@@ -73,7 +105,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
               import static org.mockito.ArgumentMatchers.eq;
-              
+
               class Test {
                   void test() {
                       var mockString = mock(String.class);
@@ -83,7 +115,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               """, """
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
-              
+
               class Test {
                   void test() {
                       var mockString = mock(String.class);
@@ -105,7 +137,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.when;
               import static org.mockito.ArgumentMatchers.eq;
               import static org.mockito.ArgumentMatchers.anyString;
-              
+
               class Test {
                   void test() {
                       var mockString = mock(String.class);
@@ -125,7 +157,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
             """
               import static org.mockito.Mockito.doThrow;
               import static org.mockito.ArgumentMatchers.eq;
-              
+
               class Test {
                   void test() {
                       doThrow(new RuntimeException()).when("foo").substring(eq(1));
@@ -133,7 +165,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               }
               """, """
               import static org.mockito.Mockito.doThrow;
-              
+
               class Test {
                   void test() {
                       doThrow(new RuntimeException()).when("foo").substring(1);
@@ -152,7 +184,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
             """
               import static org.mockito.BDDMockito.given;
               import static org.mockito.ArgumentMatchers.eq;
-              
+
               class Test {
                   void test() {
                       given("foo".substring(eq(1)));
@@ -160,7 +192,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               }
               """, """
               import static org.mockito.BDDMockito.given;
-              
+
               class Test {
                   void test() {
                       given("foo".substring(1));
@@ -181,13 +213,13 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.when;
               import static org.mockito.ArgumentMatchers.eq;
               import static org.mockito.ArgumentMatchers.anyString;
-              
+
               class Test {
                   void testRemoveEq() {
                       var mockString = mock(String.class);
                       when(mockString.replace(eq("foo"), eq("bar"))).thenReturn("bar");
                   }
-              
+
                   void testKeepEq() {
                       var mockString = mock(String.class);
                       when(mockString.replace(eq("foo"), anyString())).thenReturn("bar");
@@ -198,13 +230,13 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.when;
               import static org.mockito.ArgumentMatchers.eq;
               import static org.mockito.ArgumentMatchers.anyString;
-              
+
               class Test {
                   void testRemoveEq() {
                       var mockString = mock(String.class);
                       when(mockString.replace("foo", "bar")).thenReturn("bar");
                   }
-              
+
                   void testKeepEq() {
                       var mockString = mock(String.class);
                       when(mockString.replace(eq("foo"), anyString())).thenReturn("bar");
@@ -227,7 +259,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.doThrow;
               import static org.mockito.BDDMockito.given;
               import static org.mockito.ArgumentMatchers.eq;
-              
+
               class Test {
                   void test(Object v1, Object v2, Object v3, Object v4, Object v5, Foo foo) {
                       given(foo.bar(eq(v1), eq(v2), eq(v3))).willReturn(null);
@@ -236,7 +268,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
                       verify(foo).bar(eq(v1), eq(v2), eq(v3));
                   }
               }
-              
+
               class Foo {
                   Object bar(Object v1, Object v2, Object v3) { return null; }
                   String baz(Object v4, Object v5) { return  ""; }
@@ -248,7 +280,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
               import static org.mockito.Mockito.verify;
               import static org.mockito.Mockito.doThrow;
               import static org.mockito.BDDMockito.given;
-              
+
               class Test {
                   void test(Object v1, Object v2, Object v3, Object v4, Object v5, Foo foo) {
                       given(foo.bar(v1, v2, v3)).willReturn(null);
@@ -257,7 +289,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
                       verify(foo).bar(v1, v2, v3);
                   }
               }
-              
+
               class Foo {
                   Object bar(Object v1, Object v2, Object v3) { return null; }
                   String baz(Object v4, Object v5) { return  ""; }

--- a/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
@@ -64,12 +64,12 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
         );
     }
 
-	@Test
-	void shouldRemoveUnneccesaryEqFromVerify_withMockitoStarImport() {
-		rewriteRun(
-		  //language=Java
-		  java(
-			"""
+    @Test
+    void shouldRemoveUnneccesaryEqFromVerify_withMockitoStarImport() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
               import static org.mockito.Mockito.eq;
               import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.verify;
@@ -91,9 +91,9 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
                   }
               }
               """
-		  )
-		);
-	}
+          )
+        );
+    }
 
 
     @Test

--- a/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/SimplifyMockitoVerifyWhenGivenTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.mockito;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -65,6 +66,7 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/634")
     void shouldRemoveUnneccesaryEqFromVerify_withMockitoStarImport() {
         rewriteRun(
           //language=Java
@@ -94,7 +96,6 @@ class SimplifyMockitoVerifyWhenGivenTest implements RewriteTest {
           )
         );
     }
-
 
     @Test
     void shouldRemoveUnneccesaryEqFromWhen() {


### PR DESCRIPTION
- fixes https://github.com/openrewrite/rewrite-testing-frameworks/issues/634

## What's changed?
Added a test for [issue #634](https://github.com/openrewrite/rewrite-testing-frameworks/issues/634)
Added handling of org.mockito.Mockito.eq(..) when simplifying mockito matchers

## What's your motivation?
We are using `import static org.mockito.Mockito.*;` at my company, and in its current state this recipe does not support it.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
