### PR TITLE
Add support for Junit 4 matchers on AssertionsArgumentOrder

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
@@ -32,13 +32,16 @@ import java.util.*;
 
 public class AssertionsArgumentOrder extends Recipe {
 
-    private static final MethodMatcher[] jupiterAssertionMatchers = new MethodMatcher[]{
+    private static final MethodMatcher[] junitAssertionsMatchers = new MethodMatcher[]{
             new MethodMatcher("org.junit.jupiter.api.Assertions assertArrayEquals(..)"),
             new MethodMatcher("org.junit.jupiter.api.Assertions assertEquals(..)"),
             new MethodMatcher("org.junit.jupiter.api.Assertions assertNotEquals(..)"),
             new MethodMatcher("org.junit.jupiter.api.Assertions assertSame(..)"),
             new MethodMatcher("org.junit.jupiter.api.Assertions assertNotSame(..)"),
-            new MethodMatcher("org.junit.jupiter.api.Assertions assertArrayEquals(..)")
+            new MethodMatcher("org.junit.Assert assertEquals(..)"),
+            new MethodMatcher("org.junit.Assert assertNotEquals(..)"),
+            new MethodMatcher("org.junit.Assert assertSame(..)"),
+            new MethodMatcher("org.junit.Assert assertNotSame(..)")
     };
     private static final MethodMatcher jupiterAssertIterableEqualsMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertIterableEquals(..)");
 
@@ -55,7 +58,7 @@ public class AssertionsArgumentOrder extends Recipe {
     private static final TreeVisitor<?, ExecutionContext> precondition;
 
     static {
-        List<MethodMatcher> matchers = new ArrayList<>(Arrays.asList(jupiterAssertionMatchers));
+        List<MethodMatcher> matchers = new ArrayList<>(Arrays.asList(junitAssertionsMatchers));
         matchers.add(jupiterAssertIterableEqualsMatcher);
         matchers.add(jupiterAssertNullMatcher);
         matchers.addAll(Arrays.asList(testNgMatcher));
@@ -97,7 +100,7 @@ public class AssertionsArgumentOrder extends Recipe {
 
             final Expression expected;
             final Expression actual;
-            if (isJupiterAssertion(mi)) {
+            if (isJunitAssertion(mi)) {
                 expected = mi.getArguments().get(0);
                 actual = mi.getArguments().get(1);
             } else if (isTestNgAssertion(mi)) {
@@ -157,8 +160,8 @@ public class AssertionsArgumentOrder extends Recipe {
             return false;
         }
 
-        private boolean isJupiterAssertion(J.MethodInvocation mi) {
-            for (MethodMatcher assertionMethodMatcher : jupiterAssertionMatchers) {
+        private boolean isJunitAssertion(J.MethodInvocation mi) {
+            for (MethodMatcher assertionMethodMatcher : junitAssertionsMatchers) {
                 if (assertionMethodMatcher.matches(mi)) {
                     return true;
                 }

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
@@ -155,7 +155,6 @@ class AssertionsArgumentOrderTest implements RewriteTest {
         );
     }
 
-
     @Test
     void jupiterAssertNullAndAssertNotNull() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
@@ -73,7 +73,7 @@ class AssertionsArgumentOrderTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/636")
-    void junit4AssertEqualsHavingPrimitiveArg() {
+    void junit4AssertEqualsHavingStringArg() {
         rewriteRun(
           //language=java
           java(
@@ -83,8 +83,9 @@ class AssertionsArgumentOrderTest implements RewriteTest {
               class MyTest {
                   void someMethod() {
                       assertEquals(result(), "result");
-                      assertEquals(result(), "result", "message");
-                      assertEquals(0L, 1L);
+                      assertEquals("result", result());
+                      assertEquals("message", result(), "result");
+                      assertEquals("message", "result", result());
                   }
                   String result() {
                       return "result";
@@ -97,8 +98,9 @@ class AssertionsArgumentOrderTest implements RewriteTest {
               class MyTest {
                   void someMethod() {
                       assertEquals("result", result());
-                      assertEquals("result", result(), "message");
-                      assertEquals(0L, 1L);
+                      assertEquals("result", result());
+                      assertEquals("message", "result", result());
+                      assertEquals("message", "result", result());
                   }
                   String result() {
                       return "result";
@@ -109,9 +111,53 @@ class AssertionsArgumentOrderTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/636")
+    void junit4AssertEqualsHavingPrimitiveArg() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.Assert.assertEquals;
+
+              class MyTest {
+                  void someMethod() {
+                      assertEquals(0L, 1L);
+                      assertEquals(1L, 0L);
+                      assertEquals(longResult(), 0L);
+                      assertEquals(0L, longResult());
+                      assertEquals("message", 0L, longResult());
+                      assertEquals("message", longResult(), 0L);
+                  }
+                  long longResult() {
+                      return 0L;
+                  }
+              }
+              """,
+            """
+              import static org.junit.Assert.assertEquals;
+
+              class MyTest {
+                  void someMethod() {
+                      assertEquals(0L, 1L);
+                      assertEquals(1L, 0L);
+                      assertEquals(0L, longResult());
+                      assertEquals(0L, longResult());
+                      assertEquals("message", 0L, longResult());
+                      assertEquals("message", 0L, longResult());
+                  }
+                  long longResult() {
+                      return 0L;
+                  }
+              }
+              """
+          )
+        );
+    }
+
 
     @Test
-    void junitAssertNullAndAssertNotNull() {
+    void jupiterAssertNullAndAssertNotNull() {
         rewriteRun(
           //language=java
           java(
@@ -141,6 +187,48 @@ class AssertionsArgumentOrderTest implements RewriteTest {
                       assertNull(result(), "message");
                       assertNotNull(result(), "message");
                       assertNotNull(result(), "message");
+                  }
+                  String result() {
+                      return "result";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/636")
+    void junitAssertNullAndAssertNotNull() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.Assert.assertNotNull;
+              import static org.junit.Assert.assertNull;
+
+              class MyTest {
+                  void someMethod() {
+                      assertNull(result(), "message");
+                      assertNull("message", result());
+                      assertNotNull(result(), "message");
+                      assertNotNull("message", result());
+                  }
+                  String result() {
+                      return "result";
+                  }
+              }
+              """,
+            """
+              import static org.junit.Assert.assertNotNull;
+              import static org.junit.Assert.assertNull;
+
+              class MyTest {
+                  void someMethod() {
+                      assertNull("message", result());
+                      assertNull("message", result());
+                      assertNotNull("message", result());
+                      assertNotNull("message", result());
                   }
                   String result() {
                       return "result";
@@ -283,6 +371,46 @@ class AssertionsArgumentOrderTest implements RewriteTest {
                   void someMethod() {
                       assertArrayEquals(new String[]{""}, result());
                       assertArrayEquals(new String[]{""}, result(), "message");
+                  }
+                  String[] result() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/636")
+    void junitAssertArrayEquals() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.Assert.assertArrayEquals;
+
+              class MyTest {
+                  void someMethod() {
+                      assertArrayEquals(result(), new String[]{""});
+                      assertArrayEquals(new String[]{""}, result());
+                      assertArrayEquals("message", new String[]{""}, result());
+                      assertArrayEquals("message", result(), new String[]{""});
+                  }
+                  String[] result() {
+                      return null;
+                  }
+              }
+              """,
+            """
+              import static org.junit.Assert.assertArrayEquals;
+
+              class MyTest {
+                  void someMethod() {
+                      assertArrayEquals(new String[]{""}, result());
+                      assertArrayEquals(new String[]{""}, result());
+                      assertArrayEquals("message", new String[]{""}, result());
+                      assertArrayEquals("message", new String[]{""}, result());
                   }
                   String[] result() {
                       return null;


### PR DESCRIPTION
- fixes https://github.com/openrewrite/rewrite-testing-frameworks/issues/636

## What's changed?
Added support for Junit 4 matchers in the `AssertionsArgumentOrder` recipe : 
- assertEquals
- assertNotEquals
- assertSame
- assertNotSame

## What's your motivation?
Junit 5 migration is sometimes complicated so supporting Junit 4 is a plus.

## Anything in particular you'd like reviewers to focus on?
Did not add support for assertIterableEquals (does not exist in Junit 4), for assertArrayEquals and assertNull as the signature differs from Junit 5.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
