### PR TITLE
Use JUnit5's `assertSame` or `assertNotSame` instead of `assertTrue(... == ...)`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -19,12 +19,12 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,13 +32,13 @@ import java.util.List;
 public class UseAssertSame extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Use JUnit5's `assertSame` or `assertNotSame` instead of assertTrue(... == ...)";
+        return "Use JUnit5's `assertSame` or `assertNotSame` instead of `assertTrue(... == ...)`";
     }
 
     @Override
     public String getDescription() {
         return "Prefers the usage of `assertSame` or `assertNotSame` methods instead of using of vanilla assertTrue " +
-                "or assertFalse with a boolean comparison.";
+               "or assertFalse with a boolean comparison.";
     }
 
     @Override
@@ -48,45 +48,37 @@ public class UseAssertSame extends Recipe {
         TreeVisitor<?, ExecutionContext> orMatcher = Preconditions.or(new UsesMethod<>(assertTrueMatcher), new UsesMethod<>(assertFalseMatcher));
         return Preconditions.check(orMatcher, new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
-                J.MethodDeclaration m = super.visitMethodDeclaration(methodDecl, ctx);
-                if (m.getBody() == null) {
-                    return m;
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(methodInvocation, ctx);
+                if (!assertTrueMatcher.matches(mi) && !assertFalseMatcher.matches(mi)) {
+                    return mi;
                 }
-                return m.withBody(m.getBody().withStatements(ListUtils.flatMap(m.getBody().getStatements(), methodStatement -> {
-                    if (!(methodStatement instanceof J.MethodInvocation)) {
-                        return methodStatement;
-                    }
-                    J.MethodInvocation methodInvocation = (J.MethodInvocation) methodStatement;
-                    if (!assertTrueMatcher.matches(methodInvocation) && !assertFalseMatcher.matches(methodInvocation)) {
-                        return methodStatement;
-                    }
 
-                    Expression firstArgument = methodInvocation.getArguments().get(0);
-                    List<Expression> argumentsTail = methodInvocation.getArguments().subList(1, methodInvocation.getArguments().size());
-                    if (!(firstArgument instanceof J.Binary)) {
-                        return methodStatement;
-                    }
-                    J.Binary binary = (J.Binary) firstArgument;
-                    if (binary.getOperator() != J.Binary.Type.Equal && binary.getOperator() != J.Binary.Type.NotEqual) {
-                        return methodStatement;
-                    }
-                    boolean positive = binary.getOperator() == J.Binary.Type.Equal == assertTrueMatcher.matches(methodInvocation);
-                    List<Expression> newArguments = new ArrayList<>();
-                    newArguments.add(binary.getLeft());
-                    newArguments.add(binary.getRight());
-                    newArguments.addAll(argumentsTail);
+                Expression firstArgument = mi.getArguments().get(0);
+                if (!(firstArgument instanceof J.Binary)) {
+                    return mi;
+                }
+                J.Binary binary = (J.Binary) firstArgument;
+                if (binary.getOperator() != J.Binary.Type.Equal && binary.getOperator() != J.Binary.Type.NotEqual) {
+                    return mi;
+                }
+                boolean positive = binary.getOperator() == J.Binary.Type.Equal == assertTrueMatcher.matches(mi);
+                List<Expression> newArguments = new ArrayList<>();
+                newArguments.add(binary.getLeft());
+                newArguments.add(binary.getRight());
+                newArguments.addAll(mi.getArguments().subList(1, mi.getArguments().size()));
 
-                    String newMethodName = positive ? "assertSame" : "assertNotSame";
+                String newMethodName = positive ? "assertSame" : "assertNotSame";
 
-                    maybeRemoveImport("org.junit.jupiter.api.Assertions");
-                    maybeAddImport("org.junit.jupiter.api.Assertions", newMethodName);
+                maybeRemoveImport("org.junit.jupiter.api.Assertions");
+                maybeAddImport("org.junit.jupiter.api.Assertions", newMethodName);
 
-                    return methodInvocation
-                            .withName(methodInvocation.getName().withSimpleName(newMethodName))
-                            .withArguments(newArguments);
-                })));
+                JavaType.Method newType = ((JavaType.Method) mi.getName().getType()).withName(newMethodName);
+                return mi.withName(mi.getName().withSimpleName(newMethodName).withType(newType))
+                        .withMethodType(newType)
+                        .withArguments(newArguments);
             }
         });
     }
+
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -1,0 +1,77 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UseAssertSame extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Uses JUnit5's `assertSame` or `assertNotSame` instead of assertTrue(... == ...)";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Prefers the usage of `assertSame` or `assertNotSame` methods instead of using of vanilla assertTrue " +
+                "or assertFalse with a boolean comparison.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        MethodMatcher assertTrueMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(..)");
+        MethodMatcher assertFalseMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assertFalse(..)");
+        TreeVisitor<?, ExecutionContext> orMatcher = Preconditions.or(new UsesMethod<>(assertTrueMatcher), new UsesMethod<>(assertFalseMatcher));
+        return Preconditions.check(orMatcher, new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(methodDecl, ctx);
+                if (m.getBody() == null) {
+                    return m;
+                }
+                return m.withBody(m.getBody().withStatements(ListUtils.flatMap(m.getBody().getStatements(), methodStatement -> {
+                    if (!(methodStatement instanceof J.MethodInvocation)) {
+                        return methodStatement;
+                    }
+                    J.MethodInvocation methodInvocation = (J.MethodInvocation) methodStatement;
+                    if (!assertTrueMatcher.matches(methodInvocation) && !assertFalseMatcher.matches(methodInvocation)) {
+                        return methodStatement;
+                    }
+
+                    Expression firstArgument = methodInvocation.getArguments().get(0);
+                    List<Expression> argumentsTail = methodInvocation.getArguments().subList(1, methodInvocation.getArguments().size());
+                    if (!(firstArgument instanceof J.Binary)) {
+                        return methodStatement;
+                    }
+                    J.Binary binary = (J.Binary) firstArgument;
+                    if (binary.getOperator() != J.Binary.Type.Equal && binary.getOperator() != J.Binary.Type.NotEqual) {
+                        return methodStatement;
+                    }
+                    boolean positive = binary.getOperator() == J.Binary.Type.Equal == assertTrueMatcher.matches(methodInvocation);
+                    List<Expression> newArguments = new ArrayList<>();
+                    newArguments.add(binary.getLeft());
+                    newArguments.add(binary.getRight());
+                    newArguments.addAll(argumentsTail);
+
+                    String newMethodName = positive ? "assertSame" : "assertNotSame";
+
+                    maybeRemoveImport("org.junit.jupiter.api.Assertions");
+                    maybeAddImport("org.junit.jupiter.api.Assertions", newMethodName);
+
+                    return methodInvocation
+                            .withName(methodInvocation.getName().withSimpleName(newMethodName))
+                            .withArguments(newArguments);
+                })));
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class UseAssertSame extends Recipe {
     @Override
     public String getDisplayName() {
-        return "Uses JUnit5's `assertSame` or `assertNotSame` instead of assertTrue(... == ...)";
+        return "Use JUnit5's `assertSame` or `assertNotSame` instead of assertTrue(... == ...)";
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.openrewrite.ExecutionContext;

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
@@ -9,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class UseAssertSameTest implements RewriteTest {
+class UseAssertSameTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
@@ -1,0 +1,177 @@
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class UseAssertSameTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5.9"))
+          .recipe(new UseAssertSame());
+    }
+
+    @DocumentExample
+    @Test
+    void assertSameForSimpleBooleanComparison() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = number;
+                      assertTrue(number == otherNumber);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertSame;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = number;
+                      assertSame(number, otherNumber);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void usingStringMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = number;
+                      assertTrue(number == otherNumber, "Something is not right");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertSame;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = number;
+                      assertSame(number, otherNumber, "Something is not right");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void assertFalse() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertFalse;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = "thirty-seven";
+                      assertFalse(number == otherNumber);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = "thirty-seven";
+                      assertNotSame(number, otherNumber);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notEqual() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = "thirty-seven";
+                      assertTrue(number != otherNumber);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      String number = "thirty-six";
+                      String otherNumber = "thirty-seven";
+                      assertNotSame(number, otherNumber);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Adding a new recipe for converting:
```
assertTrue(a == b);
```
to
```
assertSame(a, b);
```
for JUnit5 test code as suggested in 
- #260

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
