### PR TITLE
Add AssertJ dependency if using Hamcrest

### DIFF
--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -39,6 +39,14 @@ tags:
   - hamcrest
   - assertj
 recipeList:
+  # Add dependency if not already present
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.assertj
+      artifactId: assertj-core
+      version: 3.x
+      onlyIfUsing: org.hamcrest.*
+      acceptTransitive: true
+
   # First change `is(..)` to `Matchers.is(..)` for consistent matching
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: org.hamcrest.core.* *(..)
@@ -319,10 +327,3 @@ recipeList:
       notMatcher: empty
       assertion: isNotEmpty
 
-  # Add dependency if not already present
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: org.assertj
-      artifactId: assertj-core
-      version: 3.x
-      onlyIfUsing: org.assertj.core.api.Assertions
-      acceptTransitive: true

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -68,7 +69,7 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
                   Biscuit(String name) {
                       this.name = name;
                   }
-              
+
                   int getChocolateChipCount() {
                       return 10;
                   }
@@ -122,12 +123,12 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
           java(
                 """
             import org.junit.jupiter.api.Test;
-            
+
             import static org.hamcrest.MatcherAssert.assertThat;
             import static org.hamcrest.Matchers.allOf;
             import static org.hamcrest.Matchers.equalTo;
             import static org.hamcrest.Matchers.hasLength;
-            
+
             class ATest {
                 @Test
                 void test() {
@@ -164,12 +165,12 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
           java(
                 """
             import org.junit.jupiter.api.Test;
-            
+
             import static org.hamcrest.MatcherAssert.assertThat;
             import static org.hamcrest.Matchers.anyOf;
             import static org.hamcrest.Matchers.equalTo;
             import static org.hamcrest.Matchers.hasLength;
-            
+
             class ATest {
                 @Test
                 void test() {
@@ -218,9 +219,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         //language=java
         String template = """
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test() {
@@ -276,9 +277,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         //language=java
         String template = """
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test() {
@@ -315,9 +316,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         //language=java
         String template = """
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test() {
@@ -362,9 +363,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         //language=java
         String template = """
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test() {
@@ -404,9 +405,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         String template = """
           import java.util.List;
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test(String item) {
@@ -441,9 +442,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         String template = """
           import java.util.Map;
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test(String key, String value) {
@@ -490,9 +491,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         //language=java
         String template = """
           import org.junit.jupiter.api.Test;
-          
+
           %s
-          
+
           class ATest {
               @Test
               void test() {
@@ -512,10 +513,10 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         @Language("java")
         private static final String JAVA_BEFORE = """
           import org.junit.jupiter.api.Test;
-          
+
           import static org.hamcrest.MatcherAssert.assertThat;
           import static org.hamcrest.Matchers.equalTo;
-          
+
           class ATest {
               @Test
               void test() {
@@ -527,9 +528,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         @Language("java")
         private static final String JAVA_AFTER = """
           import org.junit.jupiter.api.Test;
-          
+
           import static org.assertj.core.api.Assertions.assertThat;
-          
+
           class ATest {
               @Test
               void test() {
@@ -541,7 +542,6 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         @Test
         void assertjMavenDependencyAddedWithTestScope() {
             rewriteRun(
-              spec -> spec.expectedCyclesThatMakeChanges(2),
               mavenProject("project",
                 srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
                 //language=xml
@@ -587,21 +587,23 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
           );
         }
 
+        @Disabled("After inexplicably null")
         @Test
         void assertjGradleDependencyAddedWithTestScope() {
             rewriteRun(
-              spec -> spec.beforeRecipe(withToolingApi()).expectedCyclesThatMakeChanges(2),
               mavenProject("project",
                 srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
-                buildGradle("""
+                //language=groovy
+                buildGradle(
+                  """
                   plugins {
                       id "java-library"
                   }
-                  
+
                   repositories {
                       mavenCentral()
                   }
-                  
+
                   dependencies {
                       testImplementation "org.hamcrest:hamcrest:2.2"
                   }
@@ -610,11 +612,11 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
                   plugins {
                       id "java-library"
                   }
-                  
+
                   repositories {
                       mavenCentral()
                   }
-                  
+
                   dependencies {
                       testImplementation "org.assertj:%s"
                       testImplementation "org.hamcrest:hamcrest:2.2"
@@ -685,14 +687,14 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
             """
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.core.Is.is;
-              
+
               import org.junit.jupiter.api.Test;
-              
+
               class DebugTest {
                   class Foo {
                       int i = 8;
                   }
-              
+
                   @Test
                   void ba() {
                       assertThat(System.out, is(System.out));
@@ -702,14 +704,14 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-              
+
               import org.junit.jupiter.api.Test;
-              
+
               class DebugTest {
                   class Foo {
                       int i = 8;
                   }
-              
+
                   @Test
                   void ba() {
                       assertThat(System.out).isEqualTo(System.out);
@@ -732,9 +734,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               import static org.hamcrest.core.IsEqual.equalTo;
               import static org.hamcrest.core.IsNot.not;
               import static org.hamcrest.core.IsSame.sameInstance;
-              
+
               import org.junit.jupiter.api.Test;
-              
+
               class DebugTest {
                   @Test
                   void ba() {
@@ -746,9 +748,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               """,
             """
               import static org.assertj.core.api.Assertions.assertThat;
-              
+
               import org.junit.jupiter.api.Test;
-              
+
               class DebugTest {
                   @Test
                   void ba() {

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -121,40 +120,40 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
-            import org.junit.jupiter.api.Test;
+            """
+              import org.junit.jupiter.api.Test;
 
-            import static org.hamcrest.MatcherAssert.assertThat;
-            import static org.hamcrest.Matchers.allOf;
-            import static org.hamcrest.Matchers.equalTo;
-            import static org.hamcrest.Matchers.hasLength;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.allOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
 
-            class ATest {
-                @Test
-                void test() {
-                    String str1 = "Hello world!";
-                    String str2 = "Hello world!";
-                    assertThat(str1, allOf(equalTo(str2), hasLength(12)));
-                }
-            }
-            """, """
-            import org.junit.jupiter.api.Test;
+              class ATest {
+                  @Test
+                  void test() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, allOf(equalTo(str2), hasLength(12)));
+                  }
+              }
+              """, """
+              import org.junit.jupiter.api.Test;
 
-            import static org.assertj.core.api.Assertions.assertThat;
+              import static org.assertj.core.api.Assertions.assertThat;
 
-            class ATest {
-                @Test
-                void test() {
-                    String str1 = "Hello world!";
-                    String str2 = "Hello world!";
-                    assertThat(str1)
-                            .satisfies(
-                                    arg -> assertThat(arg).isEqualTo(str2),
-                                    arg -> assertThat(arg).hasSize(12)
-                            );
-                }
-            }
-            """));
+              class ATest {
+                  @Test
+                  void test() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1)
+                              .satisfies(
+                                      arg -> assertThat(arg).isEqualTo(str2),
+                                      arg -> assertThat(arg).hasSize(12)
+                              );
+                  }
+              }
+              """));
     }
 
     @Test
@@ -163,40 +162,40 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
-            import org.junit.jupiter.api.Test;
+            """
+              import org.junit.jupiter.api.Test;
 
-            import static org.hamcrest.MatcherAssert.assertThat;
-            import static org.hamcrest.Matchers.anyOf;
-            import static org.hamcrest.Matchers.equalTo;
-            import static org.hamcrest.Matchers.hasLength;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.anyOf;
+              import static org.hamcrest.Matchers.equalTo;
+              import static org.hamcrest.Matchers.hasLength;
 
-            class ATest {
-                @Test
-                void test() {
-                    String str1 = "Hello world!";
-                    String str2 = "Hello world!";
-                    assertThat(str1, anyOf(equalTo(str2), hasLength(12)));
-                }
-            }
-            """, """
-            import org.junit.jupiter.api.Test;
+              class ATest {
+                  @Test
+                  void test() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, anyOf(equalTo(str2), hasLength(12)));
+                  }
+              }
+              """, """
+              import org.junit.jupiter.api.Test;
 
-            import static org.assertj.core.api.Assertions.assertThat;
+              import static org.assertj.core.api.Assertions.assertThat;
 
-            class ATest {
-                @Test
-                void test() {
-                    String str1 = "Hello world!";
-                    String str2 = "Hello world!";
-                    assertThat(str1)
-                            .satisfiesAnyOf(
-                                    arg -> assertThat(arg).isEqualTo(str2),
-                                    arg -> assertThat(arg).hasSize(12)
-                            );
-                }
-            }
-            """));
+              class ATest {
+                  @Test
+                  void test() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1)
+                              .satisfiesAnyOf(
+                                      arg -> assertThat(arg).isEqualTo(str2),
+                                      arg -> assertThat(arg).hasSize(12)
+                              );
+                  }
+              }
+              """));
     }
 
     private static Stream<Arguments> arrayReplacements() {
@@ -332,14 +331,14 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
         String after = template.formatted(importsAfter, "assertThat(%s).%s(%s);".formatted(actual, assertJAssertion, matcherArgs));
         rewriteRun(
           java(
-                """
-            class Biscuit {
-                String name;
-                Biscuit(String name) {
-                    this.name = name;
-                }
-            }
-            """),
+            """
+              class Biscuit {
+                  String name;
+                  Biscuit(String name) {
+                      this.name = name;
+                  }
+              }
+              """),
           java(before, after));
     }
 
@@ -546,87 +545,87 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
                 srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
                 //language=xml
                 pomXml("""
-                  <project>
-                      <modelVersion>4.0.0</modelVersion>
-                      <groupId>com.example</groupId>
-                      <artifactId>demo</artifactId>
-                      <version>0.0.1-SNAPSHOT</version>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.hamcrest</groupId>
-                              <artifactId>hamcrest</artifactId>
-                              <version>2.2</version>
-                              <scope>test</scope>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """,
-                sourceSpecs -> sourceSpecs.after(after -> """
-                  <project>
-                      <modelVersion>4.0.0</modelVersion>
-                      <groupId>com.example</groupId>
-                      <artifactId>demo</artifactId>
-                      <version>0.0.1-SNAPSHOT</version>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.assertj</groupId>
-                              <artifactId>assertj-core</artifactId>
-                              <version>%s</version>
-                              <scope>test</scope>
-                          </dependency>
-                          <dependency>
-                              <groupId>org.hamcrest</groupId>
-                              <artifactId>hamcrest</artifactId>
-                              <version>2.2</version>
-                              <scope>test</scope>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """.formatted(Pattern.compile("<version>(3\\.2.*)</version>").matcher(requireNonNull(after)).results().findFirst().orElseThrow().group(1))))
-            )
-          );
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>demo</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.hamcrest</groupId>
+                                <artifactId>hamcrest</artifactId>
+                                <version>2.2</version>
+                                <scope>test</scope>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                    """,
+                  sourceSpecs -> sourceSpecs.after(after -> """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>demo</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.assertj</groupId>
+                                <artifactId>assertj-core</artifactId>
+                                <version>%s</version>
+                                <scope>test</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.hamcrest</groupId>
+                                <artifactId>hamcrest</artifactId>
+                                <version>2.2</version>
+                                <scope>test</scope>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                    """.formatted(Pattern.compile("<version>(3\\.2.*)</version>").matcher(requireNonNull(after)).results().findFirst().orElseThrow().group(1))))
+              )
+            );
         }
 
-        @Disabled("After inexplicably null")
         @Test
         void assertjGradleDependencyAddedWithTestScope() {
             rewriteRun(
+              spec -> spec.beforeRecipe(withToolingApi()),
               mavenProject("project",
                 srcTestJava(java(JAVA_BEFORE, JAVA_AFTER)),
                 //language=groovy
                 buildGradle(
                   """
-                  plugins {
-                      id "java-library"
-                  }
+                    plugins {
+                        id "java-library"
+                    }
 
-                  repositories {
-                      mavenCentral()
-                  }
+                    repositories {
+                        mavenCentral()
+                    }
 
-                  dependencies {
-                      testImplementation "org.hamcrest:hamcrest:2.2"
-                  }
-                  """,
-                sourceSpecs -> sourceSpecs.after(after -> """
-                  plugins {
-                      id "java-library"
-                  }
+                    dependencies {
+                        testImplementation "org.hamcrest:hamcrest:2.2"
+                    }
+                    """,
+                  sourceSpecs -> sourceSpecs.after(after -> """
+                    plugins {
+                        id "java-library"
+                    }
 
-                  repositories {
-                      mavenCentral()
-                  }
+                    repositories {
+                        mavenCentral()
+                    }
 
-                  dependencies {
-                      testImplementation "org.assertj:%s"
-                      testImplementation "org.hamcrest:hamcrest:2.2"
-                  }
-                  """
-                  .formatted(Pattern.compile("(assertj-core:[^\"]*)").matcher(requireNonNull(after)).results().findFirst().orElseThrow().group(1))
+                    dependencies {
+                        testImplementation "org.assertj:%s"
+                        testImplementation "org.hamcrest:hamcrest:2.2"
+                    }
+                    """
+                    .formatted(Pattern.compile("(assertj-core:[^\"]*)").matcher(requireNonNull(after)).results().findFirst().orElseThrow().group(1))
+                  )
                 )
               )
-            )
-          );
+            );
         }
     }
 
@@ -805,7 +804,7 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
       }
     )
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/526")
-    void greaterThanOrEqualToDate(String type){
+    void greaterThanOrEqualToDate(String type) {
         rewriteRun(
           java(
             """


### PR DESCRIPTION
## What's changed?
Flipped around when we add the dependency, as we saw it needlessly added, and to the wrong Gradle configuration.