### PR TITLE
Add recipe for replacing deprecated method AbstractDateAssert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     runtimeOnly("tech.picnic.error-prone-support:error-prone-contrib:latest.release:recipes")
     compileOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+    compileOnly("org.assertj:assertj-core:3.+")
 
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")

--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseTo.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseTo.java
@@ -15,14 +15,12 @@
  */
 package org.openrewrite.java.testing.assertj;
 
-import java.util.Date;
-
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import org.openrewrite.java.template.RecipeDescriptor;
 
-import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import java.util.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RecipeDescriptor(
@@ -38,7 +36,6 @@ public class IsEqualToIgnoringMillisToIsCloseTo {
     }
 
     @AfterTemplate
-    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)
     void isCloseToAfter(Date date1, Date date2) {
         assertThat(date1).isCloseTo(date2, 1000L);
     }

--- a/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseTo.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseTo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import java.util.Date;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RecipeDescriptor(
+        name = "Replace `AbstractDateAssert#isEqualToIgnoringMillis(java.util.Date)` by `by isCloseTo(Date, long)`",
+        description = "`isEqualToIgnoringMillis()` is deprecated in favor of `isCloseTo()`."
+)
+@SuppressWarnings({"java:S1874", "deprecation"})
+public class IsEqualToIgnoringMillisToIsCloseTo {
+
+    @BeforeTemplate
+    void isEqualToIgnoringMillisBefore(Date date1, Date date2) {
+        assertThat(date1).isEqualToIgnoringMillis(date2);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)
+    void isCloseToAfter(Date date1, Date date2) {
+        assertThat(date1).isCloseTo(date2, 1000L);
+    }
+}

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -26,6 +26,7 @@ recipeList:
   - org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ
   - org.openrewrite.java.testing.assertj.JUnitToAssertj
   - org.openrewrite.java.testing.testng.TestNgToAssertj
+  - org.openrewrite.java.testing.assertj.IsEqualToIgnoringMillisToIsCloseToTest
   - org.openrewrite.java.testing.assertj.StaticImports
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.SimplifyAssertJAssertions

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -26,7 +26,7 @@ recipeList:
   - org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ
   - org.openrewrite.java.testing.assertj.JUnitToAssertj
   - org.openrewrite.java.testing.testng.TestNgToAssertj
-  - org.openrewrite.java.testing.assertj.IsEqualToIgnoringMillisToIsCloseToTest
+  - org.openrewrite.java.testing.assertj.IsEqualToIgnoringMillisToIsCloseToRecipe
   - org.openrewrite.java.testing.assertj.StaticImports
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.SimplifyAssertJAssertions

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseToTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseToTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.assertj;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class IsEqualToIgnoringMillisToIsCloseToTest implements RewriteTest {
+
+    @Test
+    @DocumentExample
+    void replaceDeprecation() {
+        rewriteRun(spec -> spec.recipe(new IsEqualToIgnoringMillisToIsCloseToRecipe()),
+          //language=java
+          java("""
+            import java.util.Date;
+
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            class A {
+              public void foo(Date date1, Date date2) {
+                assertThat(date1).isEqualToIgnoringMillis(date2);
+              }
+            }
+            """, """
+            import java.util.Date;
+
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            class A {
+              public void foo(Date date1, Date date2) {
+                assertThat(date1).isCloseTo(date2, 1000L);
+              }
+            }
+            """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseToTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseToTest.java
@@ -28,27 +28,29 @@ class IsEqualToIgnoringMillisToIsCloseToTest implements RewriteTest {
     void replaceDeprecation() {
         rewriteRun(spec -> spec.recipe(new IsEqualToIgnoringMillisToIsCloseToRecipe()),
           //language=java
-          java("""
-            import java.util.Date;
-
-            import static org.assertj.core.api.Assertions.assertThat;
-
-            class A {
-              public void foo(Date date1, Date date2) {
-                assertThat(date1).isEqualToIgnoringMillis(date2);
-              }
-            }
-            """, """
-            import java.util.Date;
-
-            import static org.assertj.core.api.Assertions.assertThat;
-
-            class A {
-              public void foo(Date date1, Date date2) {
-                assertThat(date1).isCloseTo(date2, 1000L);
-              }
-            }
+          java(
             """
+              import org.assertj.core.api.Assertions;
+
+              import java.util.Date;
+
+              class A {
+                  public void foo(Date date1, Date date2) {
+                      Assertions.assertThat(date1).isEqualToIgnoringMillis(date2);
+                  }
+              }
+              """,
+            """
+              import org.assertj.core.api.Assertions;
+
+              import java.util.Date;
+
+              class A {
+                  public void foo(Date date1, Date date2) {
+                      Assertions.assertThat(date1).isCloseTo(date2, 1000L);
+                  }
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
This adds a recipe to replace `org.assertj.core.api.AbstractDateAssert.isEqualToIgnoringMillis(java.util.Date)` by the proposed method `isCloseTo()`

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
New refaster recipe `java/org/openrewrite/java/testing/assertj/IsEqualToIgnoringMillisToIsCloseTo.java`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
closes#653

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
The recipe is not working yet as expected. It should add a static import for the method, but does not.

Not sure what I should test as negative case here.

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
