### PR TITLE
Add `Mockito1to5MigrationTest` to verify dependencies are upgraded

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
@@ -22,6 +22,9 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.testing.mockito;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
@@ -22,14 +22,10 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.java.Assertions.java;
-
 
 class Mockito1to5MigrationTest implements RewriteTest {
 
@@ -46,47 +42,30 @@ class Mockito1to5MigrationTest implements RewriteTest {
     @Test
     void modifyMockitoDependencies() {
         rewriteRun(
-          //language=groovy
           buildGradle(
+            //language=groovy
             """
-               plugins {
-                   id 'java-library'
-               }
-               repositories {
-                   mavenCentral()
-               }
-               dependencies {
-                   implementation("org.apache.commons:commons-lang3:3.17.0")
-                   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
-                   testImplementation("org.mockito:mockito-core:3.12.4")
-                   testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
-               }
-               test {
-                  useJUnitPlatform()
-               }
-               """,
-            spec -> spec.after(buildGradleAfter -> {
-                Matcher artifactMatcher = Pattern.compile("org\\.mockito:[\\D]+:(?<version>5\\.\\d+\\.\\d+)").matcher(buildGradleAfter);
-                assertThat(artifactMatcher.find()).describedAs("Expected 5.x.y in %s", buildGradleAfter).isTrue();
-                String versionNumber = artifactMatcher.group("version");
-                return """
-               plugins {
-                   id 'java-library'
-               }
-               repositories {
-                   mavenCentral()
-               }
-               dependencies {
-                   implementation("org.apache.commons:commons-lang3:3.17.0")
-                   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
-                   testImplementation("org.mockito:mockito-core:%s")
-                   testImplementation("org.mockito:mockito-junit-jupiter:%s")
-               }
-               test {
-                  useJUnitPlatform()
-               }
-                  """.formatted(versionNumber, versionNumber);
-          })),
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.17.0")
+                  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                  testImplementation("org.mockito:mockito-core:3.12.4")
+                  testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+              }
+              test {
+                 useJUnitPlatform()
+              }
+              """,
+            spec -> spec.after(buildGradleAfter -> assertThat(buildGradleAfter)
+              .containsPattern("org.apache.commons:commons-lang3:3.17.0")
+              .containsPattern("org.junit.jupiter:junit-jupiter-api:5.11.4")
+              .containsPattern("org\\.mockito:[\\D]+:(?<version>5\\.\\d+\\.\\d+)")
+              .actual())),
           //language=java
           java(
             """
@@ -97,9 +76,9 @@ class Mockito1to5MigrationTest implements RewriteTest {
               import java.util.List;
 
               @ExtendWith(MockitoExtension.class)
-              public class MyTest {
+              class MyTest {
                   @Test
-                  public void test() {
+                  void test() {
                       List<String> list = Mockito.mock(List.class);
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to5MigrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
+
+
+class Mockito1to5MigrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api", "mockito-core", "mockito-junit-jupiter"))
+          .recipeFromResources("org.openrewrite.java.testing.mockito.Mockito1to5Migration");
+    }
+
+    @DocumentExample
+    @Test
+    void modifyMockitoDependencies() {
+        rewriteRun(
+          //language=groovy
+          buildGradle(
+            """
+               plugins {
+                   id 'java-library'
+               }
+               repositories {
+                   mavenCentral()
+               }
+               dependencies {
+                   implementation("org.apache.commons:commons-lang3:3.17.0")
+                   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                   testImplementation("org.mockito:mockito-core:3.12.4")
+                   testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+               }
+               test {
+                  useJUnitPlatform()
+               }
+               """,
+            spec -> spec.after(buildGradleAfter -> {
+                Matcher artifactMatcher = Pattern.compile("org\\.mockito:[\\D]+:(?<version>5\\.\\d+\\.\\d+)").matcher(buildGradleAfter);
+                assertThat(artifactMatcher.find()).describedAs("Expected 5.x.y in %s", buildGradleAfter).isTrue();
+                String versionNumber = artifactMatcher.group("version");
+                return """
+               plugins {
+                   id 'java-library'
+               }
+               repositories {
+                   mavenCentral()
+               }
+               dependencies {
+                   implementation("org.apache.commons:commons-lang3:3.17.0")
+                   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                   testImplementation("org.mockito:mockito-core:%s")
+                   testImplementation("org.mockito:mockito-junit-jupiter:%s")
+               }
+               test {
+                  useJUnitPlatform()
+               }
+                  """.formatted(versionNumber, versionNumber);
+          })),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mockito;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import java.util.List;
+
+              @ExtendWith(MockitoExtension.class)
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      List<String> list = Mockito.mock(List.class);
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

new unit test:   Mockito1to5MigrationTest.java

## What's your motivation?

Motivation:  I could not find a unit test for Mockito1to5Migration

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
