### PR TITLE
[660] Use the correct implementation of the MethodOrderer for the @Te…

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/arquillian/ReplaceArquillianInSequenceAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/arquillian/ReplaceArquillianInSequenceAnnotation.java
@@ -69,7 +69,7 @@ public class ReplaceArquillianInSequenceAnnotation extends Recipe {
                                                 !service(AnnotationService.class).matches(updateCursor(cd), TEST_METHOD_ORDER_MATCHER)) {
                                             maybeAddImport(METHOD_ORDERER);
                                             maybeAddImport(TEST_METHOD_ORDER);
-                                            return JavaTemplate.builder("@TestMethodOrder(MethodOrderer.class)")
+                                            return JavaTemplate.builder("@TestMethodOrder(MethodOrderer.OrderAnnotation.class)")
                                                     .imports(METHOD_ORDERER, TEST_METHOD_ORDER)
                                                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
                                                     .build()

--- a/src/test/java/org/openrewrite/java/testing/arquillian/ArquillianJUnit4ToArquillianJunit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/arquillian/ArquillianJUnit4ToArquillianJunit5Test.java
@@ -65,7 +65,7 @@ class ArquillianJUnit4ToArquillianJunit5Test implements RewriteTest {
                         <dependency>
                             <groupId>org.jboss.arquillian.junit5</groupId>
                             <artifactId>arquillian-junit5-container</artifactId>
-                            <version>1.9.1.Final</version>
+                            <version>1.9.2.Final</version>
                             <scope>test</scope>
                         </dependency>
                     </dependencies>

--- a/src/test/java/org/openrewrite/java/testing/arquillian/ReplaceArquillianInSequenceAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/arquillian/ReplaceArquillianInSequenceAnnotationTest.java
@@ -54,7 +54,7 @@ class ReplaceArquillianInSequenceAnnotationTest implements RewriteTest {
               import org.junit.jupiter.api.Order;
               import org.junit.jupiter.api.TestMethodOrder;
 
-              @TestMethodOrder(MethodOrderer.class)
+              @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
               class A {
                   @Order(2)
                   void second() {}


### PR DESCRIPTION
…stMethodOrder annotation.

resolves #660 

## What's changed?

Changed the value for the `@TestMethodOrder` class to `MethodOrderer.OrderAnnotation.class` when migrating Arquillian JUnit 4 tests to JUnit 5 that use the `@InSequence` annotation.

## What's your motivation?
The current value, `MethodOrderer.class`, is an interface and cannot be instantiated.

## Have you considered any alternatives or workarounds?

The only workaround is to simply manually change the annotation value. 

## Any additional context

N/A

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
