### PR TITLE
Add mockito-junit-jupiter when using runner in JUnit 4

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -196,6 +196,13 @@ tags:
   - junit
   - mockito
 recipeList:
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.mockito
+      artifactId: mockito-junit-jupiter
+      version: 4.x
+      onlyIfUsing: org.mockito..MockitoJUnit*Runner
+      acceptTransitive: true
+      scope: test
   - org.openrewrite.java.testing.mockito.Mockito1to4Migration
   - org.openrewrite.java.testing.mockito.MockitoJUnitRunnerSilentToExtension
   - org.openrewrite.java.testing.junit5.RunnerToExtension:

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -253,7 +253,7 @@ recipeList:
       groupId: io.vertx
       artifactId: vertx-junit5
       version: 4.x
-      onlyIfUsing: io.vertx.junit5.VertxExtension
+      onlyIfUsing: org.vertx.testtools.VertxUnitRunner
       acceptTransitive: true
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -168,13 +168,6 @@ recipeList:
   - org.openrewrite.java.testing.mockito.MockUtilsToStatic
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
   - org.openrewrite.java.testing.mockito.ReplacePowerMockito
-  - org.openrewrite.java.dependencies.AddDependency:
-      groupId: org.mockito
-      artifactId: mockito-junit-jupiter
-      version: 3.x
-      onlyIfUsing: org.mockito.junit.jupiter.*
-      acceptTransitive: true
-      scope: test
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.mockito
       artifactId: "*"

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.gradle.Assertions.buildGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
-import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 @SuppressWarnings({"NewClassNamingConvention", "EqualsWithItself", "deprecation", "LanguageMismatch"})
@@ -40,7 +40,7 @@ class JUnit5MigrationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "hamcrest-2.2"))
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "hamcrest-2.2", "mockito-all-1.10"))
           .recipe(Environment.builder()
             .scanRuntimeClasspath("org.openrewrite.java.testing.junit5")
             .build()
@@ -437,6 +437,80 @@ class JUnit5MigrationTest implements RewriteTest {
               </project>
               """,
             spec -> spec.markers(new BuildTool(Tree.randomId(), BuildTool.Type.Maven, "3.5.4"))
+          )
+        );
+    }
+
+    @Test
+    void addMockitoJupiterDependencyIfExtendWithPresent() {
+        rewriteRun(
+          mavenProject("sample",
+            //language=java
+            srcMainJava(
+              java(
+                """
+                  import org.junit.runner.RunWith;
+                  import org.mockito.runners.MockitoJUnitRunner;
+
+                  @RunWith(MockitoJUnitRunner.class)
+                  public class MyClassTest {}
+                  """,
+                """
+                  import org.junit.jupiter.api.extension.ExtendWith;
+                  import org.mockito.junit.jupiter.MockitoExtension;
+
+                  @ExtendWith(MockitoExtension.class)
+                  public class MyClassTest {}
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>0.0.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>junit</groupId>
+                            <artifactId>junit</artifactId>
+                            <version>4.12</version>
+                            <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <version>2.23.4</version>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>0.0.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-core</artifactId>
+                            <version>4.11.0</version>
+                            <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-junit-jupiter</artifactId>
+                            <version>4.11.0</version>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -40,7 +40,7 @@ class JUnit5MigrationTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "hamcrest-2.2", "mockito-all-1.10"))
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13"))
           .recipe(Environment.builder()
             .scanRuntimeClasspath("org.openrewrite.java.testing.junit5")
             .build()
@@ -81,6 +81,9 @@ class JUnit5MigrationTest implements RewriteTest {
     void assertThatReceiver() {
         //language=java
         rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "hamcrest-2.2")),
           java(
             """
               import org.junit.Assert;
@@ -444,6 +447,13 @@ class JUnit5MigrationTest implements RewriteTest {
     @Test
     void addMockitoJupiterDependencyIfExtendWithPresent() {
         rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-4.13", "mockito-all-1.10"))
+            .recipe(Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.testing.junit5")
+              .build()
+              .activateRecipes("org.openrewrite.java.testing.junit5.UseMockitoExtension")),
           mavenProject("sample",
             //language=java
             srcMainJava(
@@ -495,6 +505,12 @@ class JUnit5MigrationTest implements RewriteTest {
                     <artifactId>project</artifactId>
                     <version>0.0.1</version>
                     <dependencies>
+                        <dependency>
+                            <groupId>junit</groupId>
+                            <artifactId>junit</artifactId>
+                            <version>4.12</version>
+                            <scope>test</scope>
+                        </dependency>
                         <dependency>
                             <groupId>org.mockito</groupId>
                             <artifactId>mockito-core</artifactId>

--- a/src/test/java/org/openrewrite/java/testing/testng/TestNgToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/testng/TestNgToAssertJTest.java
@@ -165,9 +165,9 @@ class TestNgToAssertJTest implements RewriteTest {
               class Test {
                   void aaa(Object obj) {
                       assertThat(1).isEqualTo(1);
-                      assertThat(1).as("foo").isEqualTo(1);
+                      assertThat(1).withFailMessage("foo").isEqualTo(1);
                       assertThat(1).isNotEqualTo(2);
-                      assertThat(1).as("foo").isNotEqualTo(2);
+                      assertThat(1).withFailMessage("foo").isNotEqualTo(2);
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Add `mockito-junit-jupiter`dependency 
https://github.com/openrewrite/rewrite-testing-frameworks/blob/6aa80c958f3fc0d0c9954c7a24dd0481fe49eb83/src/main/resources/META-INF/rewrite/mockito.yml#L171-L177 expected to handle `@MockitoExtension` didn't work because `AddDependency` is a scanning recipe and scanning for `org.mockito.junit.jupiter.*` is performed before the package is added on `editSources` phase by [RunnerToExtension](https://github.com/openrewrite/rewrite-testing-frameworks/blob/6aa80c958f3fc0d0c9954c7a24dd0481fe49eb83/src/main/resources/META-INF/rewrite/junit5.yml#L201)
Now `onlyIfUsing` is looking for the initial runners that are present on the `scanSources` phase. 
**Note:** if the old version of recipe is ran in two cycles then it adds `mockito-junit-jupiter` dependency in the second cycle.

## What's your motivation?
- Fixes https://github.com/openrewrite/rewrite-testing-frameworks/issues/640


## Have you considered any alternatives or workarounds?
Alternatives considered:
1. Modify `RunnerToExtension` to handle addition of a dependency if needed. It contradicts the best practice [If it can be declarative, it should be declarative](
https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices#if-it-can-be-declarative-it-should-be-declarative)
2. Make `RunnerToExtension` recipe to cause another cycle. It contradicts the best practice [Stay single cycle](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices#stay-single-cycle)

## Any additional context
There is a similar `rewrite runners -> add dependency` sequence in [vertx migration](https://github.com/openrewrite/rewrite-testing-frameworks/blob/6aa80c958f3fc0d0c9954c7a24dd0481fe49eb83/src/main/resources/META-INF/rewrite/junit5.yml#L234C29-L234C65) but it is looking for `org.vertx.testtools.VertxUnitRunner` which doesn't exist and it seems to be a separate issue.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
