### PR TITLE
Feat add access to acc ai rewrite comprehension

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/search/FindUnitTests.java
+++ b/src/main/java/org/openrewrite/java/testing/search/FindUnitTests.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.search;
 
-import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.ScanningRecipe;
@@ -24,6 +23,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.IsLikelyNotTest;
 import org.openrewrite.java.search.IsLikelyTest;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +33,15 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 
 public class FindUnitTests extends ScanningRecipe<FindUnitTests.Accumulator> {
+
+    Accumulator acc;
+
+    public FindUnitTests() {
+    }
+
+    public FindUnitTests(Accumulator acc) {
+        this.acc = acc;
+    }
 
     @Override
     public String getDisplayName() {
@@ -48,10 +57,17 @@ public class FindUnitTests extends ScanningRecipe<FindUnitTests.Accumulator> {
 
     public static class Accumulator {
         Map<UnitTest, Set<J.MethodInvocation>> unitTestAndTheirMethods = new HashMap<>();
+
+        public Map<UnitTest, Set<J.MethodInvocation>> getUnitTestAndTheirMethods() {
+            return unitTestAndTheirMethods;
+        }
     }
 
     @Override
     public Accumulator getInitialValue(ExecutionContext ctx) {
+        if (acc != null) {
+            return acc;
+        }
         return new Accumulator();
     }
 
@@ -101,6 +117,7 @@ public class FindUnitTests extends ScanningRecipe<FindUnitTests.Accumulator> {
                         }
                     }
                 }
+                SearchResult.found(methodDeclaration);
                 return super.visitMethodDeclaration(methodDeclaration, ctx);
             }
         };
@@ -109,9 +126,3 @@ public class FindUnitTests extends ScanningRecipe<FindUnitTests.Accumulator> {
 
 }
 
-@Value
-class UnitTest {
-    String clazz;
-    String unitTestName;
-    String unitTest;
-}

--- a/src/main/java/org/openrewrite/java/testing/search/UnitTest.java
+++ b/src/main/java/org/openrewrite/java/testing/search/UnitTest.java
@@ -1,0 +1,10 @@
+package org.openrewrite.java.testing.search;
+
+import lombok.Value;
+
+@Value
+public class UnitTest {
+    String clazz;
+    String unitTestName;
+    String unitTest;
+}

--- a/src/main/java/org/openrewrite/java/testing/search/UnitTest.java
+++ b/src/main/java/org/openrewrite/java/testing/search/UnitTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openrewrite.java.testing.search;
 
 import lombok.Value;
@@ -7,4 +23,9 @@ public class UnitTest {
     String clazz;
     String unitTestName;
     String unitTest;
+
+    @Override
+    public String toString() {
+        return clazz + "." + unitTestName;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Adding access to accumulator for the recipe FindUnitTest, such that rewrite-comprehension may use the recipe to augment the information being supplied to an LLM. 


