### PR TITLE
No `@Nested` for inner composed annotation

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddMissingNested.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddMissingNested.java
@@ -86,7 +86,8 @@ public class AddMissingNested extends Recipe {
             J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
             boolean alreadyNested = classDecl.getLeadingAnnotations().stream()
                     .anyMatch(a -> TypeUtils.isOfClassType(a.getType(), NESTED));
-            if (!alreadyNested && hasTestMethods(cd)) {
+            boolean isAnnotationType = cd.getKind() == J.ClassDeclaration.Kind.Type.Annotation;
+            if (!isAnnotationType && !alreadyNested && hasTestMethods(cd)) {
                 cd = JavaTemplate.builder("@Nested")
                         .javaParser(JavaParser.fromJavaVersion()
                                 .classpathFromResources(ctx, "junit-jupiter-api-5.9"))

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddMissingNestedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddMissingNestedTest.java
@@ -203,4 +203,29 @@ class AddMissingNestedTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotNestAnnotationType() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+            import static java.lang.annotation.RetentionPolicy.RUNTIME;
+            
+            import java.lang.annotation.Retention;
+            import org.junit.jupiter.api.Test;
+            
+            public class SingleTest {
+                @CustomTest
+                public void test() {
+                }
+            
+                @Retention(RUNTIME)
+                @Test
+                @interface CustomTest {
+                }
+            }
+            """)
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Do not _nest_ an inner `@interface` class.

## What's your motivation?
When using annotation composition (as an inner class of a test class), the `AddMissingNested` recipe is nesting that inner class. That is not correct.

## Have you considered any alternatives or workarounds?
yes, excluding a _child_ recipe but according to several discussions that is and will not be supported.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files