### PR TITLE
Fix final field `@InjectMock` recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/NoInitializationForInjectMock.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/NoInitializationForInjectMock.java
@@ -36,7 +36,8 @@ public class NoInitializationForInjectMock extends Recipe {
 
     @Override
     public String getDescription() {
-        return "Removes unnecessary initialization for fields annotated with `@InjectMocks` in Mockito tests.";
+        return "Removes unnecessary initialization for fields annotated with `@InjectMocks` in Mockito tests. If the" +
+               " field was final, the final modifier is removed.";
     }
 
     @Override
@@ -47,7 +48,10 @@ public class NoInitializationForInjectMock extends Recipe {
                 J.VariableDeclarations vd = super.visitVariableDeclarations(variableDeclarations, ctx);
 
                 if (isField(getCursor()) && new AnnotationService().matches(getCursor(), INJECT_MOCKS)) {
-                    return vd.withVariables(ListUtils.map(vd.getVariables(), it -> it.withInitializer(null)));
+                    return maybeAutoFormat(vd, vd
+                                    .withModifiers(ListUtils.map(vd.getModifiers(), modifier -> modifier.getType() == J.Modifier.Type.Final ? null : modifier))
+                                    .withVariables(ListUtils.map(vd.getVariables(), it -> it.withInitializer(null))),
+                            ctx, getCursor().getParentOrThrow());
                 }
 
                 return vd;

--- a/src/test/java/org/openrewrite/java/testing/mockito/NoInitializationForInjectMockTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/NoInitializationForInjectMockTest.java
@@ -69,4 +69,40 @@ class NoInitializationForInjectMockTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void removeInitializationOfInjectMocksWithFinal() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyObject {
+                  private String someField;
+
+                  public MyObject(String someField) {
+                      this.someField = someField;
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import org.mockito.InjectMocks;
+
+              class MyTest {
+                  @InjectMocks
+                  final MyObject myObject = new MyObject("someField");
+              }
+              """,
+            """
+              import org.mockito.InjectMocks;
+
+              class MyTest {
+                  @InjectMocks
+                  MyObject myObject;
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The `NoInitializationForInjectMock` recipe removes unnecessary initializers for fields that have already been marked with the `@InjectMocks` annotation. However, a compile error will occur if that field is currently final since it sees an uninitialized field. The recipe has been modified to remove the final modifier to remedy this.


## Motivation
Take the following code:
```java
@InjectMocks
final MyObject myObject = new MyObject("someField");
```
Applying the current recipe yields
```java
@InjectMocks
final MyObject myObject; // Does not compile
```
Applying the modified recipe yields
```java
@InjectMocks
MyObject myObject;
```

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
Alternatively, you might consider skipping any final fields instead or adding an option to choose the behavior.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
