### PR TITLE
Retain Mockito Kotlin `whenever` as needed

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -136,7 +136,9 @@ public class CleanupMockitoImports extends Recipe {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, List<String> methods) {
                 J.MethodInvocation mi = super.visitMethodInvocation(method, methods);
-                if (MOCKITO_METHOD_NAMES.contains(mi.getSimpleName()) && TypeUtils.isWellFormedType(mi.getType())) {
+                if (MOCKITO_METHOD_NAMES.contains(mi.getSimpleName()) &&
+                        mi.getSelect() == null &&
+                        TypeUtils.isWellFormedType(mi.getType())) {
                     methods.add(mi.getSimpleName());
                 }
                 return mi;

--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -98,21 +98,24 @@ public class CleanupMockitoImports extends Recipe {
             if (tree instanceof JavaSourceFile) {
                 JavaSourceFile sf = (JavaSourceFile) tree;
 
-                // Prevent removing mockito imports when an associated mockito method type is not well formed
-                final List<String> unknownTypeMethodInvocationNames = new ArrayList<>();
-                new WellFormedMockitoMethodTypeVisitor().visit(sf, unknownTypeMethodInvocationNames);
+                // Determine Mockito methods that are present with valid type information
+                List<String> mockitoMethodsUsed = new MockitoMethodTypeVisitor().reduce(sf, new ArrayList<>());
 
-                final List<String> qualifiedMethodInvocationNames = new ArrayList<>();
-                new QualifiedMockitoMethodTypeVisitor().visit(sf, qualifiedMethodInvocationNames);
+                // Prevent removing mockito imports when an associated mockito method type is not well formed
+                List<String> unknownTypeMethodInvocationNames = new WellFormedMockitoMethodTypeVisitor().reduce(sf, new ArrayList<>());
+                List<String> qualifiedMethodInvocationNames = new QualifiedMockitoMethodTypeVisitor().reduce(sf, new ArrayList<>());
 
                 for (J.Import _import : sf.getImports()) {
                     if (_import.getPackageName().startsWith("org.mockito")) {
                         boolean isMockitoKotlinImport = _import.getPackageName().startsWith("org.mockito.kotlin");
                         if (_import.isStatic() || isMockitoKotlinImport) {
                             String staticName = _import.getQualid().getSimpleName();
-                            if ("*".equals(staticName) && !possibleMockitoMethod(unknownTypeMethodInvocationNames)) {
+                            if (mockitoMethodsUsed.contains(staticName)) {
+                                continue;
+                            }
+                            if ("*".equals(staticName)) {
                                 maybeRemoveImport(_import.getPackageName() + "." + _import.getClassName());
-                            } else if (!"*".equals(staticName) && !unknownTypeMethodInvocationNames.contains(staticName)) {
+                            } else if (!unknownTypeMethodInvocationNames.contains(staticName)) {
                                 String fullyQualifiedName = _import.getPackageName();
                                 if (!isMockitoKotlinImport) {
                                     fullyQualifiedName += "." + _import.getClassName();
@@ -129,14 +132,15 @@ public class CleanupMockitoImports extends Recipe {
             return tree;
         }
 
-        private boolean possibleMockitoMethod(List<String> methodNamesHavingNullType) {
-            for (String missingMethod : methodNamesHavingNullType) {
-                if (MOCKITO_METHOD_NAMES.contains(missingMethod)) {
-                    return true;
+        private static class MockitoMethodTypeVisitor extends JavaIsoVisitor<List<String>> {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, List<String> methods) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, methods);
+                if (MOCKITO_METHOD_NAMES.contains(mi.getSimpleName()) && TypeUtils.isWellFormedType(mi.getType())) {
+                    methods.add(mi.getSimpleName());
                 }
+                return mi;
             }
-
-            return false;
         }
 
         private static class WellFormedMockitoMethodTypeVisitor extends JavaIsoVisitor<List<String>> {

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockUpToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockUpToMockitoTest.java
@@ -186,7 +186,7 @@ class JMockitMockUpToMockitoTest implements RewriteTest {
               import static org.junit.Assert.assertEquals;
               import static org.mockito.AdditionalAnswers.delegatesTo;
               import static org.mockito.Answers.CALLS_REAL_METHODS;
-              import static org.mockito.ArgumentMatchers.*;
+              import static org.mockito.ArgumentMatchers.nullable;
               import static org.mockito.Mockito.*;
 
               public class MockUpTest {

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.testing.junit5;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -308,4 +308,27 @@ class CleanupMockitoImportsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void handleKotlinWhenever() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.mockito.Mock
+              import org.mockito.kotlin.whenever
+              class Foo {
+                @Mock
+                private lateinit var foo: Foo;
+                fun foo() : String {
+                    return "foo"
+                }
+                fun baz() {
+                  whenever(foo.foo()).thenReturn("bar")
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Previously we saw these imports removed. The type information is actually present for these methods, meaning the old logic was perhaps not working as well as it should have.