### PR TITLE
ReplacePowerMockito to support `PowerMockito.whenNew` constructor mocking - the simplest case

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -56,7 +56,6 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                                 J.MethodInvocation select2 = (J.MethodInvocation) select1.getSelect();
                                 if (PM_WHEN_NEW.matches(select2) && select2.getArguments().size() == 1) {
                                     maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
-                                    maybeAddImport("org.mockito.Mockito", "whenConstructed");
 
                                     Cursor c = getCursor();
                                     while (c != null && !(c.getValue() instanceof J.MethodDeclaration)) {

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -84,7 +84,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                     JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                             .contextSensitive()
                             .build();
-                    J.MethodDeclaration applied = template.apply(updateCursor(ret), method.getCoordinates().replaceBody());
+                    J.MethodDeclaration applied = template.apply(getCursor(), method.getCoordinates().replaceBody());
                     J.Try tryy = (J.Try) applied.getBody().getStatements().get(0);
                     return autoFormat(applied.withBody(applied.getBody().withStatements(Collections.singletonList(tryy.withBody(originalBody)))), ctx);
                 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -131,11 +131,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                             }
                             return true;
                         });
-                        if (variables.isEmpty()) {
-                            return null;
-                        } else {
-                            return ret.withVariables(variables);
-                        }
+                        return variables.isEmpty() ? null : ret.withVariables(variables);
                     }
                 };
             }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.mockito;
 
 import org.openrewrite.*;

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -102,9 +102,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
             }
 
             private JavaIsoVisitor<ExecutionContext> removeMockUsagesVisitor(List<J.FieldAccess> mockArguments, String inMethodSignature) {
-                Set<String> mockedClassNames = mockArguments.stream().map(fa -> {
-                    return ((J.Identifier) fa.getTarget()).getSimpleName();
-                }).collect(Collectors.toSet());
+                Set<String> mockedClassNames = mockArguments.stream().map(fa -> ((J.Identifier) fa.getTarget()).getSimpleName()).collect(Collectors.toSet());
                 return new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -46,9 +46,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
         return Preconditions.check(
                 new UsesMethod<>(PM_WHEN_NEW),
                 new JavaVisitor<ExecutionContext>() {
-
-                    public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         if (THEN_RETURN.matches(method) && method.getSelect() instanceof J.MethodInvocation) {
                             J.MethodInvocation select1 = (J.MethodInvocation) method.getSelect();
                             if (WITH_NO_ARGUMENTS.matches(select1) && select1.getSelect() instanceof J.MethodInvocation) {
@@ -69,12 +67,12 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                                 }
                             }
                         }
-                        return super.visitMethodInvocation(method, executionContext);
+                        return super.visitMethodInvocation(method, ctx);
                     }
 
                     @Override
-                    public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
-                        J ret = super.visitMethodDeclaration(method, executionContext);
+                    public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                        J ret = super.visitMethodDeclaration(method, ctx);
                         J.FieldAccess mockArgument = getCursor().getMessage("POWERMOCKITO_WHEN_NEW_REPLACED");
                         if (mockArgument != null && ret instanceof J.MethodDeclaration) {
                             J.MethodDeclaration retM = (J.MethodDeclaration) ret;
@@ -90,7 +88,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                                     .build();
                             J.MethodDeclaration applied = template.apply(updateCursor(ret), method.getBody().getCoordinates().firstStatement());
                             J.Try tryy = (J.Try) applied.getBody().getStatements().get(0);
-                            return autoFormat(applied.withBody(applied.getBody().withStatements(Collections.singletonList(tryy.withBody(originalBody)))), executionContext);
+                            return autoFormat(applied.withBody(applied.getBody().withStatements(Collections.singletonList(tryy.withBody(originalBody)))), ctx);
                         }
                         return ret;
                     }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -91,6 +91,8 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                         String variableNameForMock = VariableNameUtils.generateVariableName("mock" + mockedClassName, updateCursor(ret), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
                         JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                                 .contextSensitive()
+                                .imports("org.mockito.MockedConstruction")
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core"))
                                 .build();
                         J.MethodDeclaration applied = template.apply(getCursor(), method.getCoordinates().replaceBody());
                         J.Try tryy = (J.Try) applied.getBody().getStatements().get(0);

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.mockito;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
@@ -46,7 +47,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
         return Preconditions.check(
                 new UsesMethod<>(PM_WHEN_NEW),
                 new JavaVisitor<ExecutionContext>() {
-                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                    public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         if (THEN_RETURN.matches(method) && method.getSelect() instanceof J.MethodInvocation) {
                             J.MethodInvocation select1 = (J.MethodInvocation) method.getSelect();
                             if (WITH_NO_ARGUMENTS.matches(select1) && select1.getSelect() instanceof J.MethodInvocation) {

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.mockito;
 
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
@@ -102,7 +101,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                 return ret;
             }
 
-            private @NotNull JavaIsoVisitor<ExecutionContext> removeMockUsagesVisitor(List<J.FieldAccess> mockArguments, String inMethodSignature) {
+            private JavaIsoVisitor<ExecutionContext> removeMockUsagesVisitor(List<J.FieldAccess> mockArguments, String inMethodSignature) {
                 Set<String> mockedClassNames = mockArguments.stream().map(fa -> {
                     return ((J.Identifier) fa.getTarget()).getSimpleName();
                 }).collect(Collectors.toSet());

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -84,8 +84,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                     JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                             .contextSensitive()
                             .build();
-                    // For some reason the getCoordinates().replace() didn't work. Thus using the trick of `.firstStatement()` and then removing the extra statements
-                    J.MethodDeclaration applied = template.apply(updateCursor(ret), method.getBody().getCoordinates().firstStatement());
+                    J.MethodDeclaration applied = template.apply(updateCursor(ret), method.getCoordinates().replaceBody());
                     J.Try tryy = (J.Try) applied.getBody().getStatements().get(0);
                     return autoFormat(applied.withBody(applied.getBody().withStatements(Collections.singletonList(tryy.withBody(originalBody)))), ctx);
                 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -57,10 +57,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                                 if (PM_WHEN_NEW.matches(select2) && select2.getArguments().size() == 1) {
                                     maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
 
-                                    Cursor c = getCursor();
-                                    while (c != null && !(c.getValue() instanceof J.MethodDeclaration)) {
-                                        c = c.getParent();
-                                    }
+                                    Cursor c = getCursor().dropParentUntil(c -> c instanceof J.MethodDeclaration);
                                     Expression argument = select2.getArguments().get(0);
                                     if (c != null && argument instanceof J.FieldAccess) {
                                         c.putMessage("POWERMOCKITO_WHEN_NEW_REPLACED", (J.FieldAccess) argument);

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -1,0 +1,42 @@
+package org.openrewrite.java.testing.mockito;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+
+public class PowerMockitoWhenNewToMockito extends Recipe {
+
+    private static final MethodMatcher PM_WHEN_NEW = new MethodMatcher("org.powermock.api.mockito.PowerMockito whenNew(..)");
+
+    @Override
+    public String getDisplayName() {
+        return "Replace `PowerMockito.whenNew` with Mockito counterpart";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces `PowerMockito.whenNew` calls with respective `Mockito.whenConstructed` calls.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+         return Preconditions.check(
+                 new UsesMethod<>(PM_WHEN_NEW),
+                 new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                if (PM_WHEN_NEW.matches(method)) {
+                    maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
+                    maybeAddImport("org.mockito.Mockito", "whenConstructed");
+                    // TODO add cursor message
+                }
+                return super.visitMethodInvocation(method, executionContext);
+            }
+        });
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -80,7 +80,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                     maybeAddImport("org.mockito.MockedConstruction", false);
 
                     String mockedClassName = ((J.Identifier) mockArgument.getTarget()).getSimpleName();
-                    String variableNameForMock = VariableNameUtils.generateVariableName("mock" + mockedClassName, getCursor(), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
+                    String variableNameForMock = VariableNameUtils.generateVariableName("mock" + mockedClassName, updateCursor(ret), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
                     JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                             .contextSensitive()
                             .build();

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -29,6 +29,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.openrewrite.java.VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER;
+import static org.openrewrite.java.VariableNameUtils.generateVariableName;
+
 public class PowerMockitoWhenNewToMockito extends Recipe {
 
     private static final MethodMatcher PM_WHEN_NEW = new MethodMatcher("org.powermock.api.mockito.PowerMockito whenNew(..)");
@@ -88,7 +91,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
 
                     for (J.FieldAccess mockArgument: mockArguments) {
                         String mockedClassName = ((J.Identifier) mockArgument.getTarget()).getSimpleName();
-                        String variableNameForMock = VariableNameUtils.generateVariableName("mock" + mockedClassName, updateCursor(ret), VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER);
+                        String variableNameForMock = generateVariableName("mock" + mockedClassName, updateCursor(ret), INCREMENT_NUMBER);
                         JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                                 .contextSensitive()
                                 .imports("org.mockito.MockedConstruction")

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -47,6 +47,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
         return Preconditions.check(
                 new UsesMethod<>(PM_WHEN_NEW),
                 new JavaVisitor<ExecutionContext>() {
+                    @Override
                     public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         if (THEN_RETURN.matches(method) && method.getSelect() instanceof J.MethodInvocation) {
                             J.MethodInvocation select1 = (J.MethodInvocation) method.getSelect();

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -57,9 +57,9 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                                 if (PM_WHEN_NEW.matches(select2) && select2.getArguments().size() == 1) {
                                     maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
 
-                                    Cursor c = getCursor().dropParentUntil(c -> c instanceof J.MethodDeclaration);
+                                    Cursor c = getCursor().dropParentUntil(x -> x instanceof J.MethodDeclaration);
                                     Expression argument = select2.getArguments().get(0);
-                                    if (c != null && argument instanceof J.FieldAccess) {
+                                    if (argument instanceof J.FieldAccess) {
                                         c.putMessage("POWERMOCKITO_WHEN_NEW_REPLACED", (J.FieldAccess) argument);
                                         return null;
                                     }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -81,7 +81,7 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                 J ret = super.visitMethodDeclaration(method, ctx);
                 List<J.FieldAccess> mockArguments = getCursor().getMessage("POWERMOCKITO_WHEN_NEW_REPLACED");
                 if (mockArguments != null && ret instanceof J.MethodDeclaration) {
-                    doAfterVisit(removeMockUsagesVisitor(mockArguments, method.toString()));
+                    doAfterVisit(removeMockUsagesVisitor(mockArguments, method));
 
                     J.MethodDeclaration retM = (J.MethodDeclaration) ret;
 
@@ -106,14 +106,14 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                 return ret;
             }
 
-            private JavaIsoVisitor<ExecutionContext> removeMockUsagesVisitor(List<J.FieldAccess> mockArguments, String inMethodSignature) {
+            private JavaIsoVisitor<ExecutionContext> removeMockUsagesVisitor(List<J.FieldAccess> mockArguments, J.MethodDeclaration inMethod) {
                 Set<String> mockedClassNames = mockArguments.stream().map(fa -> ((J.Identifier) fa.getTarget()).getSimpleName()).collect(Collectors.toSet());
                 return new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         J.VariableDeclarations ret = super.visitVariableDeclarations(multiVariable, ctx);
                         Cursor containingMethod = getCursor().dropParentUntil(x -> x instanceof J.MethodDeclaration);
-                        if (!inMethodSignature.equals(containingMethod.getValue().toString())) {
+                        if (!inMethod.equals(containingMethod.getValue())) {
                             return ret;
                         }
                         List<J.VariableDeclarations.NamedVariable> variables = ListUtils.filter(ret.getVariables(), varr -> {

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -1,17 +1,23 @@
 package org.openrewrite.java.testing.mockito;
 
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.*;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.openrewrite.Tree.randomId;
 
 public class PowerMockitoWhenNewToMockito extends Recipe {
 
     private static final MethodMatcher PM_WHEN_NEW = new MethodMatcher("org.powermock.api.mockito.PowerMockito whenNew(..)");
+    private static final MethodMatcher WITH_NO_ARGUMENTS = new MethodMatcher("*..* withNoArguments(..)");
+    private static final MethodMatcher THEN_RETURN = new MethodMatcher("org.mockito.stubbing.OngoingStubbing thenReturn(..)");
 
     @Override
     public String getDisplayName() {
@@ -25,18 +31,65 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-         return Preconditions.check(
-                 new UsesMethod<>(PM_WHEN_NEW),
-                 new JavaIsoVisitor<ExecutionContext>() {
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
-                if (PM_WHEN_NEW.matches(method)) {
-                    maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
-                    maybeAddImport("org.mockito.Mockito", "whenConstructed");
-                    // TODO add cursor message
-                }
-                return super.visitMethodInvocation(method, executionContext);
-            }
-        });
+        return Preconditions.check(
+                new UsesMethod<>(PM_WHEN_NEW),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                        if (THEN_RETURN.matches(method) && method.getSelect() instanceof J.MethodInvocation) {
+                            J.MethodInvocation select1 = (J.MethodInvocation) method.getSelect();
+                            if (WITH_NO_ARGUMENTS.matches(select1) && select1.getSelect() instanceof J.MethodInvocation) {
+                                J.MethodInvocation select2 = (J.MethodInvocation) select1.getSelect();
+                                if (PM_WHEN_NEW.matches(select2)) {
+                                    maybeRemoveImport("org.powermock.api.mockito.PowerMockito");
+                                    maybeAddImport("org.mockito.Mockito", "whenConstructed");
+
+                                    Cursor c = getCursor();
+                                    while (c != null && !(c.getValue() instanceof J.MethodDeclaration)) {
+                                        c = c.getParent();
+                                    }
+                                    if (c != null) {
+                                        c.putMessage("POWERMOCKITO_WHEN_NEW_REPLACED", select2.getArguments());
+                                        c.putMessage("POWERMOCKITO_WHEN_NEW_CURSOR", getCursor());
+                                        return null;
+                                    }
+                                }
+                            }
+                        }
+                        return super.visitMethodInvocation(method, executionContext);
+                    }
+
+                    @Override
+                    public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                        J ret = super.visitMethodDeclaration(method, executionContext);
+                        List<Expression> mockArguments = getCursor().getMessage("POWERMOCKITO_WHEN_NEW_REPLACED");
+                        if (mockArguments != null && ret instanceof J.MethodDeclaration) {
+                            J.MethodDeclaration retM = (J.MethodDeclaration) ret;
+                            J.Block originalBody = retM.getBody();
+
+                            // onlyIfReferenced=false as `maybeAddImport` doesn't seem to find the type referred to in a try statement
+                            maybeAddImport("org.mockito.MockedConstruction", false);
+
+                            List<JRightPadded<J.Try.Resource>> resources = mockArguments.stream().map(arg -> {
+                                // TODO "m" is not a good name
+                                J.Identifier name = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "m", null, null);
+                                JavaType typeMockito = JavaType.buildType("org.mockito.Mockito");
+                                JRightPadded<Expression> mockitoSelect = JRightPadded.build(new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "Mockito", typeMockito, null));
+                                J.Identifier mockConstructionIdentifier = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "mockConstruction", null, null);
+                                Expression expr = new J.MethodInvocation(randomId(), Space.EMPTY, Markers.EMPTY, mockitoSelect, null, mockConstructionIdentifier, JContainer.build(Collections.singletonList(JRightPadded.build(arg))), null);
+                                J.VariableDeclarations.NamedVariable varr = new J.VariableDeclarations.NamedVariable(randomId(), Space.EMPTY, Markers.EMPTY, name, Collections.emptyList(), JLeftPadded.build(expr), null);
+                                JContainer<Expression> lhsTypeParameter = JContainer.build(Collections.singletonList(JRightPadded.build(new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "Generator", null, null))));
+                                NameTree todoIdentifier = new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "MockedConstruction", null, null);
+                                TypeTree typeexpr = new J.ParameterizedType(randomId(), Space.EMPTY, Markers.EMPTY, todoIdentifier, lhsTypeParameter, null);
+                                TypedTree vd = new J.VariableDeclarations(randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), Collections.emptyList(), typeexpr, null, Collections.emptyList(), Collections.singletonList(JRightPadded.build(varr)));
+                                J.Try.Resource r = new J.Try.Resource(randomId(), Space.EMPTY, Markers.EMPTY, vd, false);
+                                return JRightPadded.build(r);
+                            }).collect(Collectors.toList());
+                            J.Try tryy = new J.Try(randomId(), Space.EMPTY, Markers.EMPTY, JContainer.build(resources), originalBody, Collections.emptyList(), null);
+                            return autoFormat(retM.withBody(originalBody.withStatements(Collections.singletonList(tryy))), executionContext);
+                        }
+                        return ret;
+                    }
+                });
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -46,7 +46,8 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
         return Preconditions.check(
                 new UsesMethod<>(PM_WHEN_NEW),
                 new JavaVisitor<ExecutionContext>() {
-                    @Override
+
+                    public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                     public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
                         if (THEN_RETURN.matches(method) && method.getSelect() instanceof J.MethodInvocation) {
                             J.MethodInvocation select1 = (J.MethodInvocation) method.getSelect();

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoWhenNewToMockito.java
@@ -92,14 +92,14 @@ public class PowerMockitoWhenNewToMockito extends Recipe {
                     for (J.FieldAccess mockArgument: mockArguments) {
                         String mockedClassName = ((J.Identifier) mockArgument.getTarget()).getSimpleName();
                         String variableNameForMock = generateVariableName("mock" + mockedClassName, updateCursor(ret), INCREMENT_NUMBER);
-                        JavaTemplate template = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
+                        J.MethodDeclaration appliedTemplate = JavaTemplate.builder(String.format("try (MockedConstruction<%s> %s = Mockito.mockConstruction(%s.class)) { } ", mockedClassName, variableNameForMock, mockedClassName))
                                 .contextSensitive()
                                 .imports("org.mockito.MockedConstruction")
                                 .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core"))
-                                .build();
-                        J.MethodDeclaration applied = template.apply(getCursor(), method.getCoordinates().replaceBody());
-                        J.Try tryy = (J.Try) applied.getBody().getStatements().get(0);
-                        retM = applied.withBody(applied.getBody().withStatements(Collections.singletonList(tryy.withBody(retM.getBody()))));
+                                .build()
+                                .apply(getCursor(), method.getCoordinates().replaceBody());
+                        J.Try try_ = (J.Try) appliedTemplate.getBody().getStatements().get(0);
+                        retM = appliedTemplate.withBody(appliedTemplate.getBody().withStatements(Collections.singletonList(try_.withBody(retM.getBody()))));
                     }
                     return autoFormat(retM, ctx);
                 }

--- a/src/main/resources/META-INF/rewrite/powermockito.yml
+++ b/src/main/resources/META-INF/rewrite/powermockito.yml
@@ -42,6 +42,7 @@ recipeList:
       methodPattern: org.powermock.api.mockito.PowerMockito when(..)
       fullyQualifiedTargetTypeName: org.mockito.Mockito
   - org.openrewrite.java.testing.mockito.PowerMockitoMockStaticToMockito
+  - org.openrewrite.java.testing.mockito.PowerMockitoWhenNewToMockito
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.powermock
       artifactId: powermock-api-mockito*

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -680,11 +680,10 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                         return 436;
                       }
                   }
-
                   @Test
                   public final void testNumbers() throws Exception {
-                      Generator mock2 = mock(Generator.class);
-                      PowerMockito.whenNew(Generator.class).withNoArguments().thenReturn(mock2);
+                      Generator mock = mock(Generator.class);
+                      PowerMockito.whenNew(Generator.class).withNoArguments().thenReturn(mock);
 
                       Generator gen = new Generator();
                       when(gen.getLuckyNumber()).thenReturn(504);
@@ -716,7 +715,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                   @Test
                   public final void testNumbers() throws Exception {
                       try (MockedConstruction<Generator> mockGenerator = Mockito.mockConstruction(Generator.class)) {
-                          Generator mock2 = mock(Generator.class);
+                          Generator mock = mock(Generator.class);
 
                           Generator gen = new Generator();
                           when(gen.getLuckyNumber()).thenReturn(504);
@@ -730,6 +729,105 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void whenNewTwoMocks() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+            import org.powermock.api.mockito.PowerMockito;
+            import static org.powermock.api.mockito.PowerMockito.*;
+
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class MyTest {
+                static class Generator1 {
+                    public int getLuckyNumber() {
+                      return 436;
+                    }
+                }
+                static class Generator2 {
+                    public int getLuckyNumber() {
+                      return 136;
+                    }
+                }
+
+                @Test
+                public final void testNumbers() throws Exception {
+                    Generator1 mock1 = mock(Generator1.class);
+                    PowerMockito.whenNew(Generator1.class).withNoArguments().thenReturn(mock1);
+
+                    Generator1 gen1 = new Generator1();
+                    when(gen1.getLuckyNumber()).thenReturn(504);
+
+                    assertEquals(504, gen1.getLuckyNumber());
+
+                    Generator2 mock2 = mock(Generator2.class);
+                    PowerMockito.whenNew(Generator2.class).withNoArguments().thenReturn(mock2);
+
+                    Generator2 gen2 = new Generator2();
+                    when(gen2.getLuckyNumber()).thenReturn(504);
+
+                    assertEquals(504, gen2.getLuckyNumber());
+                }
+
+                public final String otherMethod() {
+                  return "no change here";
+                }
+            }
+            """,
+            """
+            import static org.mockito.Mockito.when;
+            import static org.mockito.Mockito.mock;
+
+            import org.junit.jupiter.api.Test;
+            import org.mockito.MockedConstruction;
+
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class MyTest {
+                static class Generator1 {
+                    public int getLuckyNumber() {
+                      return 436;
+                    }
+                }
+                static class Generator2 {
+                    public int getLuckyNumber() {
+                      return 136;
+                    }
+                }
+
+                @Test
+                public final void testNumbers() throws Exception {
+                    try (MockedConstruction<Generator2> mockGenerator2 = Mockito.mockConstruction(Generator2.class)) {
+                        try (MockedConstruction<Generator1> mockGenerator1 = Mockito.mockConstruction(Generator1.class)) {
+                            Generator1 mock1 = mock(Generator1.class);
+
+                            Generator1 gen1 = new Generator1();
+                            when(gen1.getLuckyNumber()).thenReturn(504);
+
+                            assertEquals(504, gen1.getLuckyNumber());
+
+                            Generator2 mock2 = mock(Generator2.class);
+
+                            Generator2 gen2 = new Generator2();
+                            when(gen2.getLuckyNumber()).thenReturn(504);
+
+                            assertEquals(504, gen2.getLuckyNumber());
+                        }
+                    }
+                }
+
+                public final String otherMethod() {
+                  return "no change here";
+                }
+            }
+            """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -675,51 +675,59 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               public class MyTest {
-                static class Generator {
-                    public int getLuckyNumber() {
+                  static class Generator {
+                      public int getLuckyNumber() {
                         return 436;
-                    }
-                }
+                      }
+                  }
 
-                @Test
-                public final void testNumbers() throws Exception {
-                    Generator mock2 = mock(Generator.class);
-                    PowerMockito.whenNew(Generator.class).withNoArguments().thenReturn(mock2);
+                  @Test
+                  public final void testNumbers() throws Exception {
+                      Generator mock2 = mock(Generator.class);
+                      PowerMockito.whenNew(Generator.class).withNoArguments().thenReturn(mock2);
 
-                    Generator gen = new Generator();
-                    when(gen.getLuckyNumber()).thenReturn(504);
+                      Generator gen = new Generator();
+                      when(gen.getLuckyNumber()).thenReturn(504);
 
-                    assertEquals(504, gen.getLuckyNumber());
-                }
+                      assertEquals(504, gen.getLuckyNumber());
+                  }
+
+                  public final String otherMethod() {
+                    return "no change here";
+                  }
               }
               """,
               """
-              import static org.mockito.Mockito.mock;
               import static org.mockito.Mockito.when;
-              import org.mockito.MockedConstruction;
-              import org.mockito.Mockito;
-              import static org.mockito.Mockito.*;
+              import static org.mockito.Mockito.mock;
 
               import org.junit.jupiter.api.Test;
+              import org.mockito.MockedConstruction;
+
               import static org.junit.jupiter.api.Assertions.assertEquals;
 
               public class MyTest {
-                static class Generator {
-                    public int getLuckyNumber() {
+                  static class Generator {
+                      public int getLuckyNumber() {
                         return 436;
-                    }
-                }
+                      }
+                  }
 
-                @Test
-                public final void testNumbers() throws Exception {
-                    try (MockedConstruction<Generator> m = Mockito.mockConstruction(Generator.class)){
-                        Generator mock2 = mock(Generator.class);
-                        Generator gen = new Generator();
-                        when(gen.getLuckyNumber()).thenReturn(504);
+                  @Test
+                  public final void testNumbers() throws Exception {
+                      try (MockedConstruction<Generator> m = Mockito.mockConstruction(Generator.class)) {
+                          Generator mock2 = mock(Generator.class);
 
-                        assertEquals(504, gen.getLuckyNumber());
-                    }
-                }
+                          Generator gen = new Generator();
+                          when(gen.getLuckyNumber()).thenReturn(504);
+
+                          assertEquals(504, gen.getLuckyNumber());
+                      }
+                  }
+
+                  public final String otherMethod() {
+                    return "no change here";
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -661,4 +661,68 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenNew() {
+        //language=java
+        rewriteRun(
+          java(
+              """
+              import org.powermock.api.mockito.PowerMockito;
+              import static org.powermock.api.mockito.PowerMockito.*;
+
+              import org.junit.jupiter.api.Test;
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              public class MyTest {
+                static class Generator {
+                    public int getLuckyNumber() {
+                        return 436;
+                    }
+                }
+
+                @Test
+                public final void testNumbers() throws Exception {
+                    Generator mock2 = mock(Generator.class);
+                    PowerMockito.whenNew(Generator.class).withNoArguments().thenReturn(mock2);
+
+                    Generator gen = new Generator();
+                    when(gen.getLuckyNumber()).thenReturn(504);
+
+                    assertEquals(504, gen.getLuckyNumber());
+                }
+              }
+              """,
+              """
+              import static org.mockito.Mockito.mock;
+              import static org.mockito.Mockito.when;
+              import org.mockito.MockedConstruction;
+              import org.mockito.Mockito;
+              import static org.mockito.Mockito.*;
+
+              import org.junit.jupiter.api.Test;
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              public class MyTest {
+                static class Generator {
+                    public int getLuckyNumber() {
+                        return 436;
+                    }
+                }
+
+                @Test
+                public final void testNumbers() throws Exception {
+                    try (MockedConstruction<Generator> m = Mockito.mockConstruction(Generator.class)){
+                        Generator mock2 = mock(Generator.class);
+                        Generator gen = new Generator();
+                        when(gen.getLuckyNumber()).thenReturn(504);
+
+                        assertEquals(504, gen.getLuckyNumber());
+                    }
+                }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -715,7 +715,6 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                   @Test
                   public final void testNumbers() throws Exception {
                       try (MockedConstruction<Generator> mockGenerator = Mockito.mockConstruction(Generator.class)) {
-                          Generator mock = mock(Generator.class);
 
                           Generator gen = new Generator();
                           when(gen.getLuckyNumber()).thenReturn(504);
@@ -775,10 +774,6 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
 
                     assertEquals(504, gen2.getLuckyNumber());
                 }
-
-                public final String otherMethod() {
-                  return "no change here";
-                }
             }
             """,
             """
@@ -806,14 +801,11 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                 public final void testNumbers() throws Exception {
                     try (MockedConstruction<Generator2> mockGenerator2 = Mockito.mockConstruction(Generator2.class)) {
                         try (MockedConstruction<Generator1> mockGenerator1 = Mockito.mockConstruction(Generator1.class)) {
-                            Generator1 mock1 = mock(Generator1.class);
 
                             Generator1 gen1 = new Generator1();
                             when(gen1.getLuckyNumber()).thenReturn(504);
 
                             assertEquals(504, gen1.getLuckyNumber());
-
-                            Generator2 mock2 = mock(Generator2.class);
 
                             Generator2 gen2 = new Generator2();
                             when(gen2.getLuckyNumber()).thenReturn(504);
@@ -821,10 +813,6 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                             assertEquals(504, gen2.getLuckyNumber());
                         }
                     }
-                }
-
-                public final String otherMethod() {
-                  return "no change here";
                 }
             }
             """

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -715,7 +715,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
 
                   @Test
                   public final void testNumbers() throws Exception {
-                      try (MockedConstruction<Generator> m = Mockito.mockConstruction(Generator.class)) {
+                      try (MockedConstruction<Generator> mockGenerator = Mockito.mockConstruction(Generator.class)) {
                           Generator mock2 = mock(Generator.class);
 
                           Generator gen = new Generator();


### PR DESCRIPTION
## What's changed?

Adding support to `ReplacePowerMockito` for dealing with constructor mocking using `PowerMockito.whenNew` in the **simplest case** only - i.e. when using no arguments constructor.

The plan is to have another PR for constructors with arguments.

## What's your motivation?

To address one of the customers' feedback.

## Context

Related:#646
