### PR TITLE
Supporting arguments in PowerMockitoWhenNewToMockito

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -819,4 +819,66 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void whenNewWithArguments() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+            import org.powermock.api.mockito.PowerMockito;
+            import static org.powermock.api.mockito.PowerMockito.*;
+
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class MyTest2 {
+                public static class SomeTexts {
+                    String text;
+                    public SomeTexts(String text) { this.text = text; }
+                    public String getText() { return text; }
+                }
+
+                @Test
+                public final void testWords() throws Exception {
+                    SomeTexts mock = PowerMockito.mock(SomeTexts.class);
+                    PowerMockito.whenNew(SomeTexts.class).withArguments("Have a nice day!").thenReturn(mock);
+
+                    SomeTexts st = new SomeTexts("Have a nice day!");
+                    when(st.getText()).thenReturn("overridden");
+
+                    assertEquals("overridden", st.getText());
+                }
+            }
+            """,
+            """
+            import org.mockito.MockedConstruction;
+            import org.mockito.Mockito;
+            import static org.mockito.Mockito.when;
+
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertEquals;
+
+            public class MyTest2 {
+                public static class SomeTexts {
+                    String text;
+                    public SomeTexts(String text) { this.text = text; }
+                    public String getText() { return text; }
+                }
+
+                @Test
+                public final void testWords() throws Exception {
+                    try (MockedConstruction<SomeTexts> mockSomeTexts = Mockito.mockConstruction(SomeTexts.class)) {
+
+                        SomeTexts st = new SomeTexts("Have a nice day!");
+                        when(st.getText()).thenReturn("overridden");
+
+                        assertEquals("overridden", st.getText());
+                    }
+                }
+            }
+            """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.java.testing.mockito;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -820,8 +822,9 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
         );
     }
 
-    @Test
-    void whenNewWithArguments() {
+    @ParameterizedTest
+    @ValueSource(strings = {"withArguments(\"Have a nice day!\")", "withAnyArguments()"})
+    void whenNewWithArguments(String methodCall) {
         //language=java
         rewriteRun(
           java(
@@ -842,7 +845,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                 @Test
                 public final void testWords() throws Exception {
                     SomeTexts mock = PowerMockito.mock(SomeTexts.class);
-                    PowerMockito.whenNew(SomeTexts.class).withArguments("Have a nice day!").thenReturn(mock);
+                    PowerMockito.whenNew(SomeTexts.class).METHODCALL.thenReturn(mock);
 
                     SomeTexts st = new SomeTexts("Have a nice day!");
                     when(st.getText()).thenReturn("overridden");
@@ -850,7 +853,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                     assertEquals("overridden", st.getText());
                 }
             }
-            """,
+            """.replaceAll("METHODCALL", methodCall),
             """
             import org.mockito.MockedConstruction;
             import org.mockito.Mockito;


### PR DESCRIPTION
## What's changed?

Continuation of #684.

Enhancing the support for `PowerMockitoWhenNewToMockito` recipe for mocking constructors other than 0-arg ones (as #684 did).

## What's your motivation?

To address one of the customers' feedback.

## Anything in particular you'd like reviewers to focus on?

Yes! I am glad you are asking:

As submitted the code will **ignore** the actual mocked constructor arguments, resulting in mocking all creations of objects of given class. As opposed to only some, i.e. these whose arguments matched. This is because based on my research, I couldn't find any direct counterpart of input like `.withArguments("param1", 3)`.

The reason I think ignoring the arguments is that I think typically you are interested in mocking just one call to the constructor. And even if you are interested in multiple calls. This is still **possible** with the code given. You mock one class, and then call `when()` twice with different arguments to provide different return values of the object methods.
