### PR TITLE
Added recipe to remove `@VisibleForTesting` annotation when used from production code

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -42,10 +42,11 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
 
     @Override
     public String getDescription() {
-        return "The `@VisibleForTesting` annotation marks a method or field that is intentionally made more accessible (e.g., changing its visibility from private or package-private to public or protected) solely for testing purposes." +
+        return "The `@VisibleForTesting` annotation marks a method or field that is intentionally made more accessible (e.g., changing its visibility from private or package-private to public or protected) solely for testing purposes. " +
                 "The annotation serves as an indicator that the increased visibility is not part of the intended public API but exists only to support testability. " +
                 "This recipe removes the annotation where such an element is used from production classes. It identifies production classes as classes in `src/main` and test classes as classes in `src/test`. " +
                 "It will remove the `@VisibleForTesting` from methods, fields (both member fields and constants), constructors and inner classes. " +
+                "It does not support generic methods (e.g. `<T> T method(T);`. " +
                 "This recipe should not be used in an environment where QA tooling acts on the `@VisibleForTesting` annotation.";
     }
 

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -172,7 +172,6 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
                 return target;
             }
         };
-
         return Preconditions.check(new IsLikelyNotTest().getVisitor(), visitor);
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -1,0 +1,181 @@
+package org.openrewrite.java.testing.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.RemoveAnnotation;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends ScanningRecipe<RemoveVisibleForTestingAnnotationWhenUsedInProduction.Scanned> {
+
+    public static class Scanned {
+        List<JavaType.Method> methods = new ArrayList<>();
+        List<JavaType.Variable> fields = new ArrayList<>();
+        List<JavaType.Class> classes = new ArrayList<>();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Remove `@VisibleForTesting` annotation when target is used in production";
+    }
+
+    @Override
+    public String getDescription() {
+        return "The `@VisibleForTesting` annotation is used when a method or a field has been made more accessible then it would normally be, solely for testing purposes. " +
+                "This recipe removes the annotation where such an element is used from production classes. It identifies production classes as classes in `src/main` and test classes as classes in `src/test`. " +
+                "It will remove the `@VisibleForTesting` from methods, fields (both member fields and constants), constructors and inner classes. " +
+                "This recipe should not be used in an environment where QA tooling acts on the `@VisibleForTesting` annotation.";
+    }
+
+    @Override
+    public Scanned getInitialValue(ExecutionContext ctx) {
+        return new Scanned();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Scanned acc) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext executionContext) {
+                // Mark classes
+                if (fieldAccess.getTarget().getType() instanceof JavaType.Class) {
+                    JavaType.Class type = (JavaType.Class) fieldAccess.getTarget().getType();
+                    if (!acc.classes.contains(type)) {
+                        type.getAnnotations().forEach(annotation -> {
+                            if ("VisibleForTesting".equals(annotation.getClassName())) {
+                                J.CompilationUnit compilationUnit = getCursor().firstEnclosing(J.CompilationUnit.class);
+                                if (compilationUnit != null && compilationUnit.getSourcePath().startsWith("src/main")) {
+                                    acc.classes.add(type);
+                                }
+                            }
+                        });
+                    }
+                }
+                // Mark fields
+                if(fieldAccess.getName().getFieldType() != null && !acc.fields.contains(fieldAccess.getName().getFieldType())) {
+                    fieldAccess.getName().getFieldType().getAnnotations().forEach(annotation -> {
+                        if ("VisibleForTesting".equals(annotation.getClassName())) {
+                            J.CompilationUnit compilationUnit = getCursor().firstEnclosing(J.CompilationUnit.class);
+                            if (compilationUnit != null && compilationUnit.getSourcePath().startsWith("src/main")) {
+                                acc.fields.add(fieldAccess.getName().getFieldType());
+                            }
+                        }
+                    });
+                }
+
+                return super.visitFieldAccess(fieldAccess, executionContext);
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext executionContext) {
+                if (method.getMethodType() != null) {
+                    if (!acc.methods.contains(method.getMethodType())) {
+                        method.getMethodType().getAnnotations().forEach(annotation -> {
+                            if ("VisibleForTesting".equals(annotation.getClassName())) {
+                                J.CompilationUnit compilationUnit = getCursor().firstEnclosing(J.CompilationUnit.class);
+                                if (compilationUnit != null && compilationUnit.getSourcePath().startsWith("src/main")) {
+                                    acc.methods.add(method.getMethodType());
+                                }
+                            }
+                        });
+                    }
+                }
+                return super.visitMethodInvocation(method, executionContext);
+            }
+
+            @Override
+            public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext executionContext) {
+                // Mark constructors
+                if (newClass.getConstructorType() != null) {
+                    if(!acc.methods.contains(newClass.getConstructorType())) {
+                        newClass.getConstructorType().getAnnotations().forEach(annotation -> {
+                            if ("VisibleForTesting".equals(annotation.getClassName())) {
+                                J.CompilationUnit compilationUnit = getCursor().firstEnclosing(J.CompilationUnit.class);
+                                if (compilationUnit != null && compilationUnit.getSourcePath().startsWith("src/main")) {
+                                    acc.methods.add(newClass.getConstructorType());
+                                }
+                            }
+                        });
+                    }
+                }
+                // Mark classes
+                if (newClass.getClazz() != null && newClass.getClazz().getType() != null && newClass.getClazz().getType() instanceof JavaType.Class) {
+                    JavaType.Class clazzType = (JavaType.Class) newClass.getClazz().getType();
+                    if (!acc.classes.contains(clazzType)) {
+                        clazzType.getAnnotations().forEach(annotation -> {
+                            if ("VisibleForTesting".equals(annotation.getClassName())) {
+                                J.CompilationUnit compilationUnit = getCursor().firstEnclosing(J.CompilationUnit.class);
+                                if (compilationUnit != null && compilationUnit.getSourcePath().startsWith("src/main")) {
+                                    acc.classes.add(clazzType);
+                                }
+                            }
+                        });
+                    }
+                }
+                return super.visitNewClass(newClass, executionContext);
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Scanned acc) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
+                J.VariableDeclarations variableDeclarations = super.visitVariableDeclarations(multiVariable, executionContext);
+                if(!variableDeclarations.getVariables().isEmpty()) {
+                    // if none of the variables in the declaration are used from production code, the annotation should be kept
+                    boolean keepAnnotation = variableDeclarations.getVariables().stream().noneMatch(elem -> acc.fields.contains(elem.getVariableType()));
+                    if (!keepAnnotation) {
+                        Optional<J.Annotation> annotation = variableDeclarations.getLeadingAnnotations().stream()
+                                .filter(elem -> "VisibleForTesting".equals(elem.getSimpleName()))
+                                .findFirst();
+                        if (annotation.isPresent() && annotation.get().getType() instanceof JavaType.Class) {
+                            JavaType.Class type = (JavaType.Class) annotation.get().getType();
+                            return (J.VariableDeclarations) new RemoveAnnotation("@" + type.getFullyQualifiedName()).getVisitor().visitNonNull(variableDeclarations, executionContext, getCursor().getParentOrThrow());
+                        }
+                    }
+                }
+                return variableDeclarations;
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext executionContext) {
+                J.MethodDeclaration methodDeclaration = super.visitMethodDeclaration(method, executionContext);
+                if (acc.methods.contains(methodDeclaration.getMethodType())) {
+                    Optional<J.Annotation> annotation = methodDeclaration.getLeadingAnnotations().stream()
+                            .filter(elem -> "VisibleForTesting".equals(elem.getSimpleName()))
+                            .findFirst();
+                    if (annotation.isPresent() && annotation.get().getType() instanceof JavaType.Class) {
+                        JavaType.Class type = (JavaType.Class) annotation.get().getType();
+                        return (J.MethodDeclaration) new RemoveAnnotation("@" + type.getFullyQualifiedName()).getVisitor().visitNonNull(methodDeclaration, executionContext, getCursor().getParentOrThrow());
+                    }
+                }
+                return methodDeclaration;
+            }
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
+                J.ClassDeclaration classDeclaration = super.visitClassDeclaration(classDecl, executionContext);
+                if (acc.classes.contains(classDeclaration.getType())) {
+                    Optional<J.Annotation> annotation = classDeclaration.getLeadingAnnotations().stream()
+                            .filter(elem -> "VisibleForTesting".equals(elem.getSimpleName()))
+                            .findFirst();
+                    if (annotation.isPresent() && annotation.get().getType() instanceof JavaType.Class) {
+                        JavaType.Class type = (JavaType.Class) annotation.get().getType();
+                        return (J.ClassDeclaration) new RemoveAnnotation("@" + type.getFullyQualifiedName()).getVisitor().visitNonNull(classDeclaration, executionContext, getCursor().getParentOrThrow());
+                    }
+                }
+                return classDeclaration;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -28,8 +28,6 @@ import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.*;
 
-import static org.openrewrite.Preconditions.and;
-
 public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends ScanningRecipe<RemoveVisibleForTestingAnnotationWhenUsedInProduction.VisibleForTesting> {
 
     public static class VisibleForTesting {

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -15,8 +15,7 @@
  */
 package org.openrewrite.java.testing.cleanup;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
@@ -113,7 +112,7 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
                 }
             }
 
-            private @NotNull List<JavaType.FullyQualified> getAnnotations(JavaType type) {
+            private List<JavaType.FullyQualified> getAnnotations(JavaType type) {
                 if (type instanceof JavaType.Class) {
                     return ((JavaType.Class) type).getAnnotations();
                 } else if (type instanceof JavaType.Variable) {
@@ -163,7 +162,7 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
                 return classDeclaration;
             }
 
-            private <@Nullable T extends J> J getElement(ExecutionContext ctx, List<J.Annotation> leadingAnnotations, T target) {
+            private <T extends J> J getElement(ExecutionContext ctx, List<J.Annotation> leadingAnnotations, T target) {
                 Optional<J.Annotation> annotation = leadingAnnotations.stream()
                         .filter(elem -> "VisibleForTesting".equals(elem.getSimpleName()))
                         .findFirst();

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -70,11 +70,11 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
             }
 
             @Override
-            public J.MemberReference visitMemberReference(J.MemberReference mr, ExecutionContext executionContext) {
+            public J.MemberReference visitMemberReference(J.MemberReference mr, ExecutionContext ctx) {
                 if (mr.getMethodType() != null) {
                     checkAndRegister(acc.methods, mr.getMethodType());
                 }
-                return super.visitMemberReference(mr, executionContext);
+                return super.visitMemberReference(mr, ctx);
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.cleanup;
 
 import org.openrewrite.ExecutionContext;

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -22,6 +22,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.RemoveAnnotation;
 import org.openrewrite.java.search.IsLikelyNotTest;
+import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -167,6 +168,10 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
                 return classDeclaration;
             }
         };
-        return Preconditions.check(new IsLikelyNotTest().getVisitor(), visitor);
+        return Preconditions.check(
+                Preconditions.and(
+                        new IsLikelyNotTest().getVisitor(),
+                        new UsesType<>("*..VisibleForTesting", true)),
+                visitor);
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.cleanup;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;

--- a/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProduction.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.RemoveAnnotation;
 import org.openrewrite.java.search.IsLikelyNotTest;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
@@ -67,10 +68,10 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
 
             @Override
             public J.FieldAccess visitFieldAccess(J.FieldAccess fa, ExecutionContext ctx) {
-                if (fa.getTarget().getType() instanceof JavaType.Class) {
+                if (fa.getTarget().getType() instanceof JavaType.Class && !((JavaType.Class) fa.getTarget().getType()).hasFlags(Flag.Private)) {
                     checkAndRegister(acc.classPatterns, fa.getTarget().getType());
                 }
-                if (fa.getName().getFieldType() != null) {
+                if (fa.getName().getFieldType() != null && !fa.getName().getFieldType().hasFlags(Flag.Private)) {
                     checkAndRegister(acc.fieldPatterns, fa.getName().getFieldType());
                 }
                 return super.visitFieldAccess(fa, ctx);
@@ -78,7 +79,7 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
 
             @Override
             public J.MemberReference visitMemberReference(J.MemberReference mr, ExecutionContext ctx) {
-                if (mr.getMethodType() != null) {
+                if (mr.getMethodType() != null && !mr.getMethodType().hasFlags(Flag.Private)) {
                     checkAndRegister(acc.methodPatterns, mr.getMethodType());
                 }
                 return super.visitMemberReference(mr, ctx);
@@ -86,7 +87,7 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
 
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
-                if (mi.getMethodType() != null) {
+                if (mi.getMethodType() != null && !mi.getMethodType().hasFlags(Flag.Private)) {
                     checkAndRegister(acc.methodPatterns, mi.getMethodType());
                 }
                 return super.visitMethodInvocation(mi, ctx);
@@ -94,10 +95,10 @@ public class RemoveVisibleForTestingAnnotationWhenUsedInProduction extends Scann
 
             @Override
             public J.NewClass visitNewClass(J.NewClass nc, ExecutionContext ctx) {
-                if (nc.getConstructorType() != null) {
+                if (nc.getConstructorType() != null && !nc.getConstructorType().hasFlags(Flag.Private)) {
                     checkAndRegister(acc.methodPatterns, nc.getConstructorType());
                 }
-                if (nc.getClazz() != null && nc.getClazz().getType() instanceof JavaType.Class) {
+                if (nc.getClazz() != null && nc.getClazz().getType() instanceof JavaType.Class && !((JavaType.Class) nc.getClazz().getType()).hasFlags(Flag.Private)) {
                     checkAndRegister(acc.classPatterns, nc.getClazz().getType());
                 }
                 return super.visitNewClass(nc, ctx);

--- a/src/main/resources/META-INF/rewrite/cleanup.yml
+++ b/src/main/resources/META-INF/rewrite/cleanup.yml
@@ -24,3 +24,5 @@ tags:
 recipeList:
   - org.openrewrite.java.testing.cleanup.TestsShouldIncludeAssertions
   - org.openrewrite.java.testing.cleanup.RemoveTestPrefix
+  - org.openrewrite.java.testing.cleanup.RemoveVisibleForTestingAnnotationWhenUsedInProduction
+  - org.openrewrite.java.testing.cleanup.SimplifyTestThrows

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -1,0 +1,562 @@
+package org.openrewrite.java.testing.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.*;
+
+class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new RemoveVisibleForTestingAnnotationWhenUsedInProduction());
+    }
+
+    @DocumentExample
+    @Test
+    void document() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+
+                    @VisibleForTesting
+                    public String internalState;
+                    @VisibleForTesting
+                    public String externalState;
+
+                    @VisibleForTesting
+                    public String getInternalState() {
+                        return internalState;
+                    }
+
+                    @VisibleForTesting
+                    public String getExternalState() {
+                         return externalState;
+                    }
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+
+                    @VisibleForTesting
+                    public String internalState;
+                    public String externalState;
+
+                    @VisibleForTesting
+                    public String getInternalState() {
+                        return internalState;
+                    }
+
+                    public String getExternalState() {
+                         return externalState;
+                    }
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        String variableOne = production.externalState;
+                        String variableTwo = production.getExternalState();
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                            String variableOne = production.externalState;
+                            String variableTwo = production.getExternalState();
+                            String variableThree = production.internalState;
+                            String variableFour = production.getInternalState();
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void fieldAccess() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public String internalState;
+                    @VisibleForTesting
+                    public String externalState;
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public String internalState;
+                    public String externalState;
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        String variableOne = production.externalState;
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                            String variableOne = production.externalState;
+                            String variableTwo = production.internalState;
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void fieldsAccess() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public String externalState1, externalState2;
+                    @VisibleForTesting
+                    public String internalState1, externalState3;
+                    @VisibleForTesting
+                    public String internalState2, internalState3;
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    public String externalState1, externalState2;
+                    public String internalState1, externalState3;
+                    @VisibleForTesting
+                    public String internalState2, internalState3;
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        String variableOne = production.externalState1;
+                        String variableTwo = production.externalState2;
+                        String variableThree = production.externalState3;
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                package com.example.test;
+
+                import com.example.domain.Production;
+
+                class ProductionTest {
+                    void test(Production production) {
+                        String variableOne = production.externalState1;
+                        String variableTwo = production.externalState2;
+                        String variableThree = production.externalState3;
+                        String variableFour = production.internalState1;
+                        String variableFive = production.internalState2;
+                        String variableSix = production.internalState3;
+                    }
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void methodInvocation() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public void internalCall(){}
+                    @VisibleForTesting
+                    public void externalCall(){}
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public void internalCall(){}
+                    public void externalCall(){}
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        production.externalCall();
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                            production.internalCall();
+                            production.externalCall();
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void constructor() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public Production(){}
+                    @VisibleForTesting
+                    public Production(int debugLevel) {}
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    public Production(){}
+                    @VisibleForTesting
+                    public Production(int debugLevel) {}
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call() {
+                        new Production();
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                            new Production();
+                            new Production(1);
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void referenceStaticInnerClass() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static class InternalInner {
+                        @VisibleForTesting
+                        public static String internalState;
+                    }
+
+                    @VisibleForTesting
+                    public static class ExternalInner {
+                        @VisibleForTesting
+                        public static String externalState;
+                    }
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static class InternalInner {
+                        @VisibleForTesting
+                        public static String internalState;
+                    }
+
+                    public static class ExternalInner {
+                        public static String externalState;
+                    }
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        String variableOne = Production.ExternalInner.externalState;
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                package com.example.test;
+
+                import com.example.domain.Production;
+
+                class ProductionTest {
+                    void test(Production production) {
+                        String variableOne = Production.ExternalInner.externalState;
+                        String variableTwo = Production.InternalInner.internalState;
+                    }
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void instantiateStaticInnerClass() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static class InternalInner {}
+
+                    @VisibleForTesting
+                    public static class ExternalInner {}
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static class InternalInner {}
+
+                    public static class ExternalInner {}
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        new Production.ExternalInner();
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                            new Production.InternalInner();
+                            new Production.ExternalInner();
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void referenceConstant() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static final long INTERNAL_CONSTANT = 1L;
+                    @VisibleForTesting
+                    public static final long EXTERNAL_CONSTANT = 2L;
+                }
+                """,
+              """
+                package com.example.domain;
+
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+                    @VisibleForTesting
+                    public static final long INTERNAL_CONSTANT = 1L;
+                    public static final long EXTERNAL_CONSTANT = 2L;
+                }
+                """
+            ),
+            java(
+              """
+                package com.example.caller;
+
+                import com.example.domain.Production;
+
+                class ProductionCaller {
+                    void call(Production production) {
+                        long variableOne = Production.EXTERNAL_CONSTANT;
+                    }
+                }
+                """)
+          ),
+          srcTestJava(
+            java(
+              """
+                    package com.example.test;
+
+                    import com.example.domain.Production;
+
+                    class ProductionTest {
+                        void test(Production production) {
+                             long variableOne = Production.INTERNAL_CONSTANT;
+                             long variableTwo = Production.EXTERNAL_CONSTANT;
+                        }
+                    }
+                """
+            )
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -158,6 +158,39 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
     }
 
     @Test
+    void leaveImport() {
+        //language=java
+        rewriteRun(
+              srcMainJava(
+                    java(
+                          """
+                            import org.jetbrains.annotations.VisibleForTesting;
+
+                            public class Production {
+
+                                @VisibleForTesting
+                                public String getExternalState() {
+                                     return "foo";
+                                }
+                            }
+                            """
+                    )
+              ),
+              srcTestJava(
+                    java(
+                          """
+                            class ProductionTest {
+                                void test(Production production) {
+                                    production.getExternalState();
+                                }
+                            }
+                            """
+                    )
+              )
+        );
+    }
+
+    @Test
     void constructor() {
         //language=java
         rewriteRun(
@@ -209,7 +242,7 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                 import com.example.domain.Production;
 
                 class ProductionTest {
-                    void test(Production production) {
+                    void test() {
                         new Production();
                         new Production(1);
                     }

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -442,8 +442,8 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
         );
     }
 
-
-    void genericMethodInvocation() {
+    @Test
+    void methodInvocationWithParametersWithGenericTypeAndReturnTypeWithGenericType() {
         //language=java
         rewriteRun(
           srcMainJava(
@@ -452,23 +452,41 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                 package com.example.domain;
 
                 import org.jetbrains.annotations.VisibleForTesting;
+                import java.util.List;
+                import java.util.ArrayList;
 
                 public class Production {
                     @VisibleForTesting
-                    public <T> void internalCall(T param){}
+                    public List<?> internalCallWithParamAndReturnType(List<?> list){ return list; }
                     @VisibleForTesting
-                    public <T> void externalCall(T param){}
+                    public void internalCallWithParam(List<?> list){}
+                    @VisibleForTesting
+                    public List<?> internalCallWithReturnType(){ return new ArrayList<>(); }
+                    @VisibleForTesting
+                    public List<?> externalCallWithParamAndReturnType(List<?> list){ return list; }
+                    @VisibleForTesting
+                    public void externalCallWithParam(List<?> list){}
+                    @VisibleForTesting
+                    public List<?> externalCallWithReturnType(){ return  new ArrayList<>(); }
                 }
                 """,
               """
                 package com.example.domain;
 
                 import org.jetbrains.annotations.VisibleForTesting;
+                import java.util.List;
+                import java.util.ArrayList;
 
                 public class Production {
                     @VisibleForTesting
-                    public <T> void internalCall(T param){}
-                    public <T> void externalCall(T param){}
+                    public List<?> internalCallWithParamAndReturnType(List<?> list){ return list; }
+                    @VisibleForTesting
+                    public void internalCallWithParam(List<?> list){}
+                    @VisibleForTesting
+                    public List<?> internalCallWithReturnType(){ return new ArrayList<>(); }
+                    public List<?> externalCallWithParamAndReturnType(List<?> list){ return list; }
+                    public void externalCallWithParam(List<?> list){}
+                    public List<?> externalCallWithReturnType(){ return  new ArrayList<>(); }
                 }
                 """
             ),
@@ -477,10 +495,13 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                 package com.example.caller;
 
                 import com.example.domain.Production;
+                import java.util.List;
 
                 class ProductionCaller {
-                    void call(Production production, Object arg) {
-                        production.externalCall(arg);
+                    void call(Production production, List<String> list) {
+                        List<?> listOne = production.externalCallWithParamAndReturnType(list);
+                        production.externalCallWithParam(list);
+                        List<?> listTwo = production.externalCallWithReturnType();
                     }
                 }
                 """
@@ -492,11 +513,16 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                 package com.example.test;
 
                 import com.example.domain.Production;
+                import java.util.List;
 
                 class ProductionTest {
-                    void test(Production production, Object arg) {
-                        production.internalCall(arg);
-                        production.externalCall(arg);
+                    void test(Production production, List<String> list) {
+                        List<?> listOne = production.externalCallWithParamAndReturnType(list);
+                        production.externalCallWithParam(list);
+                        List<?> listTwo = production.externalCallWithReturnType();
+                        List<?> listThree = production.internalCallWithParamAndReturnType(list);
+                        production.internalCallWithParam(list);
+                        List<?> listFour = production.internalCallWithReturnType();
                     }
                 }
                 """

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.java.testing.cleanup;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -158,39 +158,6 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
     }
 
     @Test
-    void leaveImport() {
-        //language=java
-        rewriteRun(
-              srcMainJava(
-                    java(
-                          """
-                            import org.jetbrains.annotations.VisibleForTesting;
-
-                            public class Production {
-
-                                @VisibleForTesting
-                                public String getExternalState() {
-                                     return "foo";
-                                }
-                            }
-                            """
-                    )
-              ),
-              srcTestJava(
-                    java(
-                          """
-                            class ProductionTest {
-                                void test(Production production) {
-                                    production.getExternalState();
-                                }
-                            }
-                            """
-                    )
-              )
-        );
-    }
-
-    @Test
     void constructor() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -94,23 +94,24 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         String variableTwo = production.getExternalState();
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                            String variableOne = production.externalState;
-                            String variableTwo = production.getExternalState();
-                            String variableThree = production.internalState;
-                            String variableFour = production.getInternalState();
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                        String variableOne = production.externalState;
+                        String variableTwo = production.getExternalState();
+                        String variableThree = production.internalState;
+                        String variableFour = production.getInternalState();
                     }
+                }
                 """
             )
           )
@@ -158,21 +159,22 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         String variableOne = production.externalState;
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                            String variableOne = production.externalState;
-                            String variableTwo = production.internalState;
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                        String variableOne = production.externalState;
+                        String variableTwo = production.internalState;
                     }
+                }
                 """
             )
           )
@@ -225,7 +227,8 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         String variableThree = production.externalState3;
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
@@ -291,21 +294,22 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         production.externalCall();
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                            production.internalCall();
-                            production.externalCall();
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                        production.internalCall();
+                        production.externalCall();
                     }
+                }
                 """
             )
           )
@@ -353,21 +357,22 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         new Production();
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                            new Production();
-                            new Production(1);
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                        new Production();
+                        new Production(1);
                     }
+                }
                 """
             )
           )
@@ -428,7 +433,8 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         String variableOne = Production.ExternalInner.externalState;
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
@@ -492,21 +498,22 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         new Production.ExternalInner();
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                            new Production.InternalInner();
-                            new Production.ExternalInner();
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                        new Production.InternalInner();
+                        new Production.ExternalInner();
                     }
+                }
                 """
             )
           )
@@ -554,21 +561,22 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         long variableOne = Production.EXTERNAL_CONSTANT;
                     }
                 }
-                """)
+                """
+            )
           ),
           srcTestJava(
             java(
               """
-                    package com.example.test;
+                package com.example.test;
 
-                    import com.example.domain.Production;
+                import com.example.domain.Production;
 
-                    class ProductionTest {
-                        void test(Production production) {
-                             long variableOne = Production.INTERNAL_CONSTANT;
-                             long variableTwo = Production.EXTERNAL_CONSTANT;
-                        }
+                class ProductionTest {
+                    void test(Production production) {
+                         long variableOne = Production.INTERNAL_CONSTANT;
+                         long variableTwo = Production.EXTERNAL_CONSTANT;
                     }
+                }
                 """
             )
           )

--- a/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/RemoveVisibleForTestingAnnotationWhenUsedInProductionTest.java
@@ -27,8 +27,7 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec
-          .recipe(new RemoveVisibleForTestingAnnotationWhenUsedInProduction());
+        spec.recipe(new RemoveVisibleForTestingAnnotationWhenUsedInProduction());
     }
 
     @DocumentExample
@@ -111,6 +110,45 @@ class RemoveVisibleForTestingAnnotationWhenUsedInProductionTest implements Rewri
                         String variableTwo = production.getExternalState();
                         String variableThree = production.internalState;
                         String variableFour = production.getInternalState();
+                    }
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void removeImport() {
+        //language=java
+        rewriteRun(
+          srcMainJava(
+            java(
+              """
+                import org.jetbrains.annotations.VisibleForTesting;
+
+                public class Production {
+
+                    @VisibleForTesting
+                    public String getExternalState() {
+                         return "foo";
+                    }
+                }
+                """,
+              """
+                public class Production {
+
+                    public String getExternalState() {
+                         return "foo";
+                    }
+                }
+                """
+            ),
+            java(
+              """
+                class ProductionCaller {
+                    void call(Production production) {
+                        String variableTwo = production.getExternalState();
                     }
                 }
                 """


### PR DESCRIPTION
## What's changed?
Added recipe to remove @VisibleForTesting annotation when used from production code

## What's your motivation?
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/224

## Anyone you would like to review specifically?
@jevanlingen 
@Laurens-W 
@greg-at-moderne 