### PR TITLE
Recipe to replace @Rule Timeout to JUnit 5 Timeout annotation

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -59,12 +59,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         return Preconditions.check(new UsesType<>("org.junit.rules.ExpectedException", false), new ExpectedExceptionToAssertThrowsVisitor());
     }
 
-    public static class ExpectedExceptionToAssertThrowsVisitor extends JavaIsoVisitor<ExecutionContext> {
-
-        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            return JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3");
-        }
+    private static class ExpectedExceptionToAssertThrowsVisitor extends JavaIsoVisitor<ExecutionContext> {
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
@@ -157,7 +152,8 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             String templateString = expectedExceptionParam instanceof String ? "#{}assertThrows(#{}, () -> #{any()});" : "#{}assertThrows(#{any()}, () -> #{any()});";
             m = JavaTemplate.builder(templateString)
                     .contextSensitive()
-                    .javaParser(javaParser(ctx))
+                    .javaParser(JavaParser.fromJavaVersion()
+                            .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
                     .staticImports("org.junit.jupiter.api.Assertions.assertThrows")
                     .build()
                     .apply(
@@ -182,7 +178,8 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             if (expectMessageMethodInvocation != null && !isExpectMessageArgAMatcher && m.getBody() != null) {
                 m = JavaTemplate.builder("assertTrue(exception.getMessage().contains(#{any(java.lang.String)}));")
                         .contextSensitive()
-                        .javaParser(javaParser(ctx))
+                        .javaParser(JavaParser.fromJavaVersion()
+                                .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
                         .staticImports("org.junit.jupiter.api.Assertions.assertTrue")
                         .build()
                         .apply(
@@ -195,7 +192,8 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
 
             JavaTemplate assertThatTemplate = JavaTemplate.builder("assertThat(#{}, #{any()});")
                     .contextSensitive()
-                    .javaParser(javaParser(ctx))
+                    .javaParser(JavaParser.fromJavaVersion()
+                            .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
                     .staticImports("org.hamcrest.MatcherAssert.assertThat")
                     .build();
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.junit5;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -62,15 +61,9 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
 
     public static class ExpectedExceptionToAssertThrowsVisitor extends JavaIsoVisitor<ExecutionContext> {
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+            return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3");
-            }
-            return javaParser;
-
         }
 
         @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -176,15 +176,9 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
      */
     private static class ParametersNoArgsImplicitMethodSource extends JavaIsoVisitor<ExecutionContext> {
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+                return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3", "junit-jupiter-params-5");
-            }
-            return javaParser;
-
         }
 
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -55,7 +55,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
 
     @Override
     public String getDisplayName() {
-        return "Pragmatists @RunWith(JUnitParamsRunner.class) to JUnit Jupiter Parameterized Tests";
+        return "Pragmatists `@RunWith(JUnitParamsRunner.class)` to JUnit Jupiter `@Parameterized` tests";
     }
 
     @Override
@@ -176,12 +176,6 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
      */
     private static class ParametersNoArgsImplicitMethodSource extends JavaIsoVisitor<ExecutionContext> {
 
-        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                return JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3", "junit-jupiter-params-5");
-        }
-
-
         private final Set<String> initMethods;
         private final Set<String> unsupportedConversions;
         private final Map<String, String> initMethodReferences;
@@ -196,16 +190,18 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             this.unsupportedConversions = unsupportedConversions;
 
             // build @ParameterizedTest template
+            JavaParser.Builder<?, ?> javaParser = JavaParser.fromJavaVersion()
+                    .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3", "junit-jupiter-params-5");
             this.parameterizedTestTemplate = JavaTemplate.builder("@ParameterizedTest")
-                    .javaParser(javaParser(ctx))
+                    .javaParser(javaParser)
                     .imports("org.junit.jupiter.params.ParameterizedTest").build();
             // build @ParameterizedTest(#{}) template
             this.parameterizedTestTemplateWithName = JavaTemplate.builder("@ParameterizedTest(name = \"#{}\")")
-                    .javaParser(javaParser(ctx))
+                    .javaParser(javaParser)
                     .imports("org.junit.jupiter.params.ParameterizedTest").build();
             // build @MethodSource("...") template
             this.methodSourceTemplate = JavaTemplate.builder("@MethodSource(#{})")
-                    .javaParser(javaParser(ctx))
+                    .javaParser(javaParser)
                     .imports("org.junit.jupiter.params.provider.MethodSource").build();
         }
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -150,11 +150,6 @@ public class TemporaryFolderToTempDir extends Recipe {
     private static class AddNewFolderMethod extends JavaIsoVisitor<ExecutionContext> {
         private final J.MethodInvocation methodInvocation;
 
-        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                return JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "junit-jupiter-api-5");
-        }
-
         public AddNewFolderMethod(J.MethodInvocation methodInvocation) {
             this.methodInvocation = methodInvocation;
         }
@@ -206,7 +201,8 @@ public class TemporaryFolderToTempDir extends Recipe {
                                 "}")
                         .contextSensitive()
                         .imports("java.io.File", "java.io.IOException")
-                        .javaParser(javaParser(ctx))
+                        .javaParser(JavaParser.fromJavaVersion()
+                                .classpathFromResources(ctx, "junit-jupiter-api-5"))
                         .build()
                         .apply(updateCursor(cd), cd.getBody().getCoordinates().lastStatement());
                 newFolderMethodDeclaration = ((J.MethodDeclaration) cd.getBody().getStatements().get(cd.getBody().getStatements().size() - 1)).getMethodType();

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -49,16 +49,9 @@ public class TemporaryFolderToTempDir extends Recipe {
             final AnnotationMatcher classRule = new AnnotationMatcher("@org.junit.ClassRule");
             final AnnotationMatcher rule = new AnnotationMatcher("@org.junit.Rule");
 
-
-            private JavaParser.@Nullable Builder<?, ?> javaParser;
-
             private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                if (javaParser == null) {
-                    javaParser = JavaParser.fromJavaVersion()
+                    return JavaParser.fromJavaVersion()
                             .classpathFromResources(ctx, "junit-jupiter-api-5");
-                }
-                return javaParser;
-
             }
 
             @Override
@@ -157,16 +150,9 @@ public class TemporaryFolderToTempDir extends Recipe {
     private static class AddNewFolderMethod extends JavaIsoVisitor<ExecutionContext> {
         private final J.MethodInvocation methodInvocation;
 
-
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+                return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
-            return javaParser;
-
         }
 
         public AddNewFolderMethod(J.MethodInvocation methodInvocation) {
@@ -236,16 +222,9 @@ public class TemporaryFolderToTempDir extends Recipe {
             J.MethodInvocation methodScope;
             JavaType.Method newMethodType;
 
-
-            private JavaParser.@Nullable Builder<?, ?> javaParser;
-
             private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                if (javaParser == null) {
-                    javaParser = JavaParser.fromJavaVersion()
+                    return JavaParser.fromJavaVersion()
                             .classpathFromResources(ctx, "junit-jupiter-api-5");
-                }
-                return javaParser;
-
             }
 
             public TranslateNewFolderMethodInvocation(J.MethodInvocation method, JavaType.Method newMethodType) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
@@ -54,14 +54,9 @@ public class TestRuleToTestInfo extends Recipe {
         private static final AnnotationMatcher JUNIT_BEFORE_MATCHER = new AnnotationMatcher("@org.junit.Before");
         private static final AnnotationMatcher JUPITER_BEFORE_EACH_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.BeforeEach");
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+                return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
-            return javaParser;
         }
 
         @Override
@@ -161,14 +156,9 @@ public class TestRuleToTestInfo extends Recipe {
         private final J.VariableDeclarations varDecls;
         private final String testMethodStatement;
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+                return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
-            return javaParser;
         }
 
         public BeforeMethodToTestInfoVisitor(J.MethodDeclaration beforeMethod, J.VariableDeclarations varDecls, String testMethodStatement) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
@@ -54,11 +54,6 @@ public class TestRuleToTestInfo extends Recipe {
         private static final AnnotationMatcher JUNIT_BEFORE_MATCHER = new AnnotationMatcher("@org.junit.Before");
         private static final AnnotationMatcher JUPITER_BEFORE_EACH_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.BeforeEach");
 
-        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                return JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "junit-jupiter-api-5");
-        }
-
         @Override
         public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
             J.CompilationUnit compilationUnit = super.visitCompilationUnit(cu, ctx);
@@ -129,7 +124,8 @@ public class TestRuleToTestInfo extends Recipe {
                                "public void setup(TestInfo testInfo) {" + testMethodStatement + "}";
                     cd = JavaTemplate.builder(t)
                             .contextSensitive()
-                            .javaParser(javaParser(ctx))
+                            .javaParser(JavaParser.fromJavaVersion()
+                                    .classpathFromResources(ctx, "junit-jupiter-api-5"))
                             .imports("org.junit.jupiter.api.TestInfo",
                                     "org.junit.jupiter.api.BeforeEach",
                                     "java.util.Optional",

--- a/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
@@ -27,7 +27,6 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Statement;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Comparator;

--- a/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
@@ -89,7 +89,7 @@ public class TimeoutRuleToClassAnnotation extends Recipe {
             private J.ClassDeclaration insertTimeoutAnnotation(Expression ex, J.ClassDeclaration cd, ExecutionContext ctx) {
                 String template;
                 Object[] params;
-                if (ex instanceof J.NewClass) {
+                if (TIMEOUT_CONSTRUCTOR_MATCHER.matches(ex)) {
                     List<Expression> arguments = ((J.NewClass) ex).getArguments();
                     if (arguments.size() == 2) {
                         template = "@Timeout(value = #{any(long)}, unit = #{any(TimeUnit)})";
@@ -98,7 +98,7 @@ public class TimeoutRuleToClassAnnotation extends Recipe {
                         template = "@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS)";
                         params = new Object[]{arguments.get(0)};
                     }
-                } else if (ex instanceof J.MethodInvocation) {
+                } else if (MILLIS_SECONDS_MATCHER.matches(ex)) {
                     String simpleName = ((J.MethodInvocation) ex).getSimpleName();
                     String units = simpleName.equals("millis") ? "MILLISECONDS" : "SECONDS";
                     template = "@Timeout(value = #{any(long)}, unit = TimeUnit." + units + ")";
@@ -114,13 +114,10 @@ public class TimeoutRuleToClassAnnotation extends Recipe {
                                 .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
                         .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
                         .build()
-                        .apply(
-                                updateCursor(cd),
+                        .apply(updateCursor(cd),
                                 cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)),
-                                params
-                        );
+                                params);
             }
         });
     }
-
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.junit5;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -47,83 +46,70 @@ public class TimeoutRuleToClassAnnotation extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>("org.junit.rules.Timeout", false), new TimeoutRuleToClassAnnotationVisitor());
-    }
+        return Preconditions.check(new UsesType<>("org.junit.rules.Timeout", false), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
 
-    public static class TimeoutRuleToClassAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+                AtomicReference<Expression> initializer = new AtomicReference<>();
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
-        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
-                        .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3");
-            }
-            return javaParser;
-
-        }
-
-        @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-
-            AtomicReference<Expression> initializer = new AtomicReference<>();
-
-            cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
-                if (statement instanceof J.VariableDeclarations) {
-                    //noinspection ConstantConditions
-                    if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
-                            "org.junit.rules.Timeout")) {
-                        List<J.VariableDeclarations.NamedVariable> variables = ((J.VariableDeclarations) statement).getVariables();
-                        if (!variables.isEmpty()) {
-                            initializer.set(variables.get(0).getInitializer());
+                cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
+                    if (statement instanceof J.VariableDeclarations) {
+                        //noinspection ConstantConditions
+                        if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
+                                "org.junit.rules.Timeout")) {
+                            List<J.VariableDeclarations.NamedVariable> variables = ((J.VariableDeclarations) statement).getVariables();
+                            if (!variables.isEmpty()) {
+                                initializer.set(variables.get(0).getInitializer());
+                            }
+                            return null;
                         }
-                        return null;
                     }
-                }
-                return statement;
-            })));
+                    return statement;
+                })));
 
-            if (initializer.get() != null) {
-                cd = insertTimeoutAnnotation(initializer.get(), cd, ctx);
-                maybeRemoveImport("org.junit.Rule");
-                maybeRemoveImport("org.junit.rules.Timeout");
-            }
-            return cd;
-        }
-
-        private J.ClassDeclaration insertTimeoutAnnotation(Expression ex, J.ClassDeclaration cd, ExecutionContext ctx) {
-            JavaTemplate.Builder builder;
-            Object[] params;
-            if (ex instanceof J.NewClass) {
-                List<Expression> arguments = ((J.NewClass) ex).getArguments();
-                if (arguments.size() == 2) {
-                    builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = #{any(TimeUnit)})");
-                    params = new Object[]{arguments.get(0), arguments.get(1)};
-                } else {
-                    builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS)");
-                    params = new Object[]{arguments.get(0)};
+                if (initializer.get() != null) {
+                    maybeRemoveImport("org.junit.Rule");
+                    maybeRemoveImport("org.junit.rules.Timeout");
+                    return insertTimeoutAnnotation(initializer.get(), cd, ctx);
                 }
-            } else if (ex instanceof J.MethodInvocation) {
-                String simpleName = ((J.MethodInvocation) ex).getName().getSimpleName();
-                String units = simpleName.equals("millis") ? "MILLISECONDS" : "SECONDS";
-                builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit." + units + ")");
-                params = new Object[]{((J.MethodInvocation) ex).getArguments().get(0)};
-            } else {
                 return cd;
             }
 
-            cd = builder.javaParser(javaParser(ctx))
-                    .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
-                    .build()
-                    .apply(
-                            updateCursor(cd),
-                            cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)),
-                            params
-                    );
-            maybeAddImport("org.junit.jupiter.api.Timeout");
-            maybeAddImport("java.util.concurrent.TimeUnit");
-            return cd;
-        }
+            private J.ClassDeclaration insertTimeoutAnnotation(Expression ex, J.ClassDeclaration cd, ExecutionContext ctx) {
+                JavaTemplate.Builder builder;
+                Object[] params;
+                if (ex instanceof J.NewClass) {
+                    List<Expression> arguments = ((J.NewClass) ex).getArguments();
+                    if (arguments.size() == 2) {
+                        builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = #{any(TimeUnit)})");
+                        params = new Object[]{arguments.get(0), arguments.get(1)};
+                    } else {
+                        builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS)");
+                        params = new Object[]{arguments.get(0)};
+                    }
+                } else if (ex instanceof J.MethodInvocation) {
+                    String simpleName = ((J.MethodInvocation) ex).getName().getSimpleName();
+                    String units = simpleName.equals("millis") ? "MILLISECONDS" : "SECONDS";
+                    builder = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit." + units + ")");
+                    params = new Object[]{((J.MethodInvocation) ex).getArguments().get(0)};
+                } else {
+                    return cd;
+                }
+
+                maybeAddImport("org.junit.jupiter.api.Timeout");
+                maybeAddImport("java.util.concurrent.TimeUnit");
+                return builder.javaParser(JavaParser.fromJavaVersion()
+                                .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
+                        .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
+                        .build()
+                        .apply(
+                                updateCursor(cd),
+                                cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)),
+                                params
+                        );
+            }
+        });
     }
+
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
@@ -25,7 +25,10 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
-import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Comparator;
 import java.util.List;

--- a/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotation.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.*;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TimeoutRuleToClassAnnotation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "JUnit 4 `@Rule Timeout` to JUnit Jupiter's `Timeout`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace usages of JUnit 4's `@Rule Timeout` with JUnit 5 `Timeout` class annotation.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("org.junit.rules.Timeout", false), new TimeoutRuleToClassAnnotationVisitor());
+    }
+
+    public static class TimeoutRuleToClassAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
+
+        private JavaParser.@Nullable Builder<?, ?> javaParser;
+
+        private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
+            if (javaParser == null) {
+                javaParser = JavaParser.fromJavaVersion()
+                        .classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3");
+            }
+            return javaParser;
+
+        }
+
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+
+            AtomicReference<Expression> initializer = new AtomicReference<>();
+
+            cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
+                if (statement instanceof J.VariableDeclarations) {
+                    //noinspection ConstantConditions
+                    if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
+                            "org.junit.rules.Timeout")) {
+                        List<J.VariableDeclarations.NamedVariable> variables = ((J.VariableDeclarations) statement).getVariables();
+                        if (!variables.isEmpty()) {
+                            initializer.set(variables.get(0).getInitializer());
+                        }
+                        return null;
+                    }
+                }
+                return statement;
+            })));
+
+            if (initializer.get() != null) {
+                cd = insertTimeoutAnnotation(initializer.get(), cd, ctx);
+                maybeRemoveImport("org.junit.Rule");
+                maybeRemoveImport("org.junit.rules.Timeout");
+            }
+            return cd;
+        }
+
+        private J.ClassDeclaration insertTimeoutAnnotation(Expression ex, J.ClassDeclaration cd, ExecutionContext ctx) {
+            Expression timeout = null;
+            Expression units = null;
+            if (ex instanceof J.NewClass) {
+                List<Expression> arguments = ((J.NewClass) ex).getArguments();
+                timeout = arguments.get(0);
+                units = arguments.size() == 2 ? arguments.get(1) : buildTimeUnit("MILLISECONDS", cd, ctx);
+            } else if (ex instanceof J.MethodInvocation) {
+
+            }
+
+            cd = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = #{any(TimeUnit)})")
+                    .javaParser(javaParser(ctx))
+                    .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
+                    .build()
+                    .apply(
+                            updateCursor(cd),
+                            cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)),
+                            timeout, units
+                    );
+            maybeAddImport("org.junit.jupiter.api.Timeout");
+            maybeAddImport("java.util.concurrent.TimeUnit");
+            return cd;
+        }
+
+        private Expression buildTimeUnit(String unit, J.ClassDeclaration cd, ExecutionContext ctx) {
+            return JavaTemplate.builder("TimeUnit." + unit + ")")
+                    .contextSensitive()
+                    .javaParser(javaParser(ctx))
+                    .imports("java.util.concurrent.TimeUnit")
+                    .build()
+                    .apply(getCursor(), cd.getCoordinates().replace());
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.junit5;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.AnnotationMatcher;
@@ -70,15 +69,11 @@ public class UpdateMockWebServer extends Recipe {
                         new UsesType<>("okhttp3.mockwebserver.MockWebServer", false)
                 ),
                 new JavaIsoVisitor<ExecutionContext>() {
-                    private JavaParser.@Nullable Builder<?, ?> javaParser;
 
                     private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                        if (javaParser == null) {
-                            javaParser = JavaParser.fromJavaVersion()
+                            return JavaParser.fromJavaVersion()
                                     .classpathFromResources(ctx, "junit-4", "junit-jupiter-api-5", "apiguardian-api-1.1",
                                             "mockwebserver-3.14");
-                        }
-                        return javaParser;
                     }
 
                     @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServer.java
@@ -70,12 +70,6 @@ public class UpdateMockWebServer extends Recipe {
                 ),
                 new JavaIsoVisitor<ExecutionContext>() {
 
-                    private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                            return JavaParser.fromJavaVersion()
-                                    .classpathFromResources(ctx, "junit-4", "junit-jupiter-api-5", "apiguardian-api-1.1",
-                                            "mockwebserver-3.14");
-                    }
-
                     @Override
                     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                         J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
@@ -86,7 +80,9 @@ public class UpdateMockWebServer extends Recipe {
                                 cd = JavaTemplate.builder("@AfterEach\nvoid afterEachTest() throws IOException {#{any(okhttp3.mockwebserver.MockWebServer)}.close();\n}")
                                         .contextSensitive()
                                         .imports(AFTER_EACH_FQN, MOCK_WEB_SERVER_FQN, IO_EXCEPTION_FQN)
-                                        .javaParser(javaParser(ctx))
+                                        .javaParser(JavaParser.fromJavaVersion()
+                                                .classpathFromResources(ctx, "junit-4", "junit-jupiter-api-5", "apiguardian-api-1.1",
+                                                        "mockwebserver-3.14"))
                                         .build()
                                         .apply(
                                                 updateCursor(cd),
@@ -101,7 +97,9 @@ public class UpdateMockWebServer extends Recipe {
                                         cd = JavaTemplate.builder("#{any(okhttp3.mockwebserver.MockWebServer)}.close();")
                                                 .contextSensitive()
                                                 .imports(AFTER_EACH_FQN, MOCK_WEB_SERVER_FQN, IO_EXCEPTION_FQN)
-                                                .javaParser(javaParser(ctx))
+                                                .javaParser(JavaParser.fromJavaVersion()
+                                                        .classpathFromResources(ctx, "junit-4", "junit-jupiter-api-5", "apiguardian-api-1.1",
+                                                                "mockwebserver-3.14"))
                                                 .build()
                                                 .apply(
                                                         updateCursor(cd),

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -55,14 +55,9 @@ public class UpdateTestAnnotation extends Recipe {
     private static class UpdateTestAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
         private static final AnnotationMatcher JUNIT4_TEST = new AnnotationMatcher("@org.junit.Test");
 
-        private JavaParser.@Nullable Builder<?, ?> javaParser;
-
         private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-            if (javaParser == null) {
-                javaParser = JavaParser.fromJavaVersion()
+            return JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5", "apiguardian-api-1.1");
-            }
-            return javaParser;
         }
 
         @Override
@@ -185,14 +180,9 @@ public class UpdateTestAnnotation extends Recipe {
 
             boolean found;
 
-            private JavaParser.@Nullable Builder<?, ?> javaParser;
-
             private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                if (javaParser == null) {
-                    javaParser = JavaParser.fromJavaVersion()
+                   return JavaParser.fromJavaVersion()
                             .classpathFromResources(ctx, "junit-jupiter-api-5", "apiguardian-api-1.1");
-                }
-                return javaParser;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseTestMethodOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseTestMethodOrder.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.junit5;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -45,15 +44,9 @@ public class UseTestMethodOrder extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesType<>("org.junit.FixMethodOrder", false), new JavaIsoVisitor<ExecutionContext>() {
 
-
-            private JavaParser.@Nullable Builder<?, ?> javaParser;
-
             private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                if (javaParser == null) {
-                    javaParser = JavaParser.fromJavaVersion()
+                    return JavaParser.fromJavaVersion()
                             .classpathFromResources(ctx, "junit-jupiter-api-5");
-                }
-                return javaParser;
             }
 
             @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseTestMethodOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseTestMethodOrder.java
@@ -44,11 +44,6 @@ public class UseTestMethodOrder extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesType<>("org.junit.FixMethodOrder", false), new JavaIsoVisitor<ExecutionContext>() {
 
-            private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                    return JavaParser.fromJavaVersion()
-                            .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
-
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration cd = classDecl;
@@ -62,7 +57,8 @@ public class UseTestMethodOrder extends Recipe {
                     maybeRemoveImport("org.junit.runners.MethodSorters");
 
                     cd = JavaTemplate.builder("@TestMethodOrder(MethodName.class)")
-                            .javaParser(javaParser(ctx))
+                            .javaParser(JavaParser.fromJavaVersion()
+                                    .classpathFromResources(ctx, "junit-jupiter-api-5"))
                             .imports("org.junit.jupiter.api.TestMethodOrder",
                                     "org.junit.jupiter.api.MethodOrderer.*")
                             .build()

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.mockito;
 
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -47,14 +46,9 @@ public class MockitoJUnitRunnerSilentToExtension extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesType<>("org.mockito.junit.MockitoJUnitRunner$Silent", false), new JavaIsoVisitor<ExecutionContext>() {
 
-            private JavaParser.@Nullable Builder<?, ?> javaParser;
-
             private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                if (javaParser == null) {
-                    javaParser = JavaParser.fromJavaVersion()
+                 return JavaParser.fromJavaVersion()
                             .classpathFromResources(ctx, "mockito-junit-jupiter-3.12", "mockito-core-3.12");
-                }
-                return javaParser;
             }
 
             final AnnotationMatcher silentRunnerMatcher = new AnnotationMatcher("@org.junit.runner.RunWith(org.mockito.junit.MockitoJUnitRunner.Silent.class)");

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
@@ -46,11 +46,6 @@ public class MockitoJUnitRunnerSilentToExtension extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesType<>("org.mockito.junit.MockitoJUnitRunner$Silent", false), new JavaIsoVisitor<ExecutionContext>() {
 
-            private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                 return JavaParser.fromJavaVersion()
-                            .classpathFromResources(ctx, "mockito-junit-jupiter-3.12", "mockito-core-3.12");
-            }
-
             final AnnotationMatcher silentRunnerMatcher = new AnnotationMatcher("@org.junit.runner.RunWith(org.mockito.junit.MockitoJUnitRunner.Silent.class)");
 
             @Override
@@ -59,7 +54,8 @@ public class MockitoJUnitRunnerSilentToExtension extends Recipe {
                 if (cd.getLeadingAnnotations().stream().anyMatch(silentRunnerMatcher::matches)) {
                     JavaTemplate template = JavaTemplate.builder("@MockitoSettings(strictness = Strictness.LENIENT)")
                             .imports("org.mockito.quality.Strictness", "org.mockito.junit.jupiter.MockitoSettings")
-                            .javaParser(javaParser(ctx))
+                            .javaParser(JavaParser.fromJavaVersion()
+                                    .classpathFromResources(ctx, "mockito-junit-jupiter-3.12", "mockito-core-3.12"))
                             .build();
                     cd = maybeAutoFormat(cd, template.apply(updateCursor(cd), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName))), ctx);
                     doAfterVisit(new RunnerToExtension(Collections.singletonList("org.mockito.junit.MockitoJUnitRunner$Silent"),

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -88,6 +88,7 @@ recipeList:
   - org.openrewrite.java.testing.junit5.TestRuleToTestInfo
   - org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations
   - org.openrewrite.java.testing.junit5.UpdateTestAnnotation
+  - org.openrewrite.java.testing.junit5.TimeoutRuleToClassAnnotation
   - org.openrewrite.java.testing.junit5.AddMissingTestBeforeAfterAnnotations
   - org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized
   - org.openrewrite.java.testing.junit5.JUnitParamsRunnerToParameterized

--- a/src/test/java/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.java
@@ -174,6 +174,54 @@ class EnclosedToNestedTest implements RewriteTest {
     }
 
     @Test
+    void recognizesTestAnnotationWithTimeoutRuleAndArguments() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import org.junit.experimental.runners.Enclosed;
+              import org.junit.runner.RunWith;
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+
+              @RunWith(Enclosed.class)
+              public class RootTest {
+                  public static class InnerTest {
+
+                      @Rule
+                      public Timeout timeout = new Timeout(30);
+
+                      @Test(timeout = 10)
+                      public void test() {
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Nested;
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.Timeout;
+
+              import java.util.concurrent.TimeUnit;
+
+              public class RootTest {
+                  @Nested
+                  @Timeout(value = 30, unit = TimeUnit.MILLISECONDS)
+                  public class InnerTest {
+
+                      @Test
+                      @Timeout(value = 10, unit = TimeUnit.MILLISECONDS)
+                      public void test() {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doesNotAnnotateNonTestInnerClasses() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
@@ -249,4 +249,53 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void notRemoveRulesIfNotInitialized() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = null;
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notRemoveRulesWithBuilder() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = Timeout.builder()
+                                          .withTimeout(2, TimeUnit.SECONDS)
+                                          .withLookingForStuckThread(true)
+                                          .build();
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class TimeoutRuleToClassAnnotationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4", "hamcrest-3"))
+          .recipe(new TimeoutRuleToClassAnnotation());
+    }
+
+    @DocumentExample
+    @Test
+    void defaultTimeUnit() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = new Timeout(30);
+
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 30, unit = TimeUnit.MILLISECONDS)
+              class MyTest {
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withSecondsTimeUnit() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
+
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 30, unit = TimeUnit.SECONDS)
+              class MyTest {
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void withMinutesTimeUnit() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = new Timeout(2, TimeUnit.MINUTES);
+
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 2, unit = TimeUnit.MINUTES)
+              class MyTest {
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void millisBuilder() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = Timeout.millis(30);
+
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 30, unit = TimeUnit.MILLISECONDS)
+              class MyTest {
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void secondsBuilder() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = Timeout.seconds(30);
+
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Timeout;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 30, unit = TimeUnit.SECONDS)
+              class MyTest {
+
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void leavesOtherRulesAlone() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.Timeout;
+              import org.junit.rules.TemporaryFolder;
+              import java.util.concurrent.TimeUnit;
+
+              class MyTest {
+
+                  @Rule
+                  public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
+
+                  @Rule
+                  TemporaryFolder tempDir = new TemporaryFolder();
+              }
+              """,
+            """
+              import org.junit.Rule;
+              import org.junit.jupiter.api.Timeout;
+              import org.junit.rules.TemporaryFolder;
+              import java.util.concurrent.TimeUnit;
+
+              @Timeout(value = 30, unit = TimeUnit.SECONDS)
+              class MyTest {
+
+                  @Rule
+                  TemporaryFolder tempDir = new TemporaryFolder();
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TimeoutRuleToClassAnnotationTest.java
@@ -57,6 +57,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Timeout;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 30, unit = TimeUnit.MILLISECONDS)
@@ -91,6 +92,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Timeout;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 30, unit = TimeUnit.SECONDS)
@@ -125,6 +127,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Timeout;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 2, unit = TimeUnit.MINUTES)
@@ -159,6 +162,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Timeout;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 30, unit = TimeUnit.MILLISECONDS)
@@ -193,6 +197,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Timeout;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 30, unit = TimeUnit.SECONDS)
@@ -215,6 +220,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               import org.junit.Rule;
               import org.junit.rules.Timeout;
               import org.junit.rules.TemporaryFolder;
+
               import java.util.concurrent.TimeUnit;
 
               class MyTest {
@@ -230,6 +236,7 @@ class TimeoutRuleToClassAnnotationTest implements RewriteTest {
               import org.junit.Rule;
               import org.junit.jupiter.api.Timeout;
               import org.junit.rules.TemporaryFolder;
+
               import java.util.concurrent.TimeUnit;
 
               @Timeout(value = 30, unit = TimeUnit.SECONDS)


### PR DESCRIPTION
Created a new recipe for migrating `@Rule Timeout` test class variable to JUnit 5 `@Timeout` class annotation