### PR TITLE
Do not `ChangeMethodTargetToStatic` for AssertJ's `AssertionsFor...Types`

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -60,12 +60,13 @@ tags:
   - testing
   - assertj
 recipeList:
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: "org.assertj.core.api.AssertionsForClassTypes assertThat(..)"
-      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"
-  - org.openrewrite.java.ChangeMethodTargetToStatic:
-      methodPattern: "org.assertj.core.api.AssertionsForInterfaceTypes assertThat(..)"
-      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"
+# https://github.com/openrewrite/rewrite-testing-frameworks/issues/664
+#  - org.openrewrite.java.ChangeMethodTargetToStatic:
+#      methodPattern: "org.assertj.core.api.AssertionsForClassTypes assertThat(..)"
+#      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"
+#  - org.openrewrite.java.ChangeMethodTargetToStatic:
+#      methodPattern: "org.assertj.core.api.AssertionsForInterfaceTypes assertThat(..)"
+#      fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"
   - org.openrewrite.java.ChangeMethodTargetToStatic:
       methodPattern: "org.assertj.core.api.Fail fail(..)"
       fullyQualifiedTargetTypeName: "org.assertj.core.api.Assertions"

--- a/src/test/java/org/openrewrite/java/testing/assertj/StaticImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/StaticImportsTest.java
@@ -16,9 +16,11 @@
 package org.openrewrite.java.testing.assertj;
 
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -41,25 +43,20 @@ class StaticImportsTest implements RewriteTest {
 
     @DocumentExample
     @Test
-    void useAssertionsStaticImport() {
+    void useStaticImports() {
         //language=java
         rewriteRun(
           java(
             """
               import java.util.List;
-              import org.assertj.core.api.AssertionsForClassTypes;
-              import org.assertj.core.api.AssertionsForInterfaceTypes;
-              import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-              import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+              import org.assertj.core.api.Assertions;
               import static org.assertj.core.api.Fail.fail;
 
               public class Test {
                   List<String> exampleList;
                   void method() {
-                      AssertionsForInterfaceTypes.assertThat(exampleList).hasSize(0);
-                      AssertionsForClassTypes.assertThat(true).isTrue();
-                      assertThat(true).isTrue();
-                      assertThat(exampleList).hasSize(0);
+                      Assertions.assertThat(true).isTrue();
+                      Assertions.assertThat(exampleList).hasSize(0);
                       fail("This is a failure");
                   }
               }
@@ -73,11 +70,52 @@ class StaticImportsTest implements RewriteTest {
               public class Test {
                   List<String> exampleList;
                   void method() {
-                      assertThat(exampleList).hasSize(0);
-                      assertThat(true).isTrue();
                       assertThat(true).isTrue();
                       assertThat(exampleList).hasSize(0);
                       fail("This is a failure");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/664")
+    @Test
+    @Disabled("Requires changes in AssertJ to adopt `assertThatClass` and `assertThatInterface`")
+    void assertionsForClassTypes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              import org.assertj.core.api.AssertionsForClassTypes;
+              import org.assertj.core.api.AssertionsForInterfaceTypes;
+              import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+              import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+              public class Test {
+                  List<String> exampleList;
+                  void method() {
+                      AssertionsForInterfaceTypes.assertThat(exampleList).hasSize(0);
+                      AssertionsForClassTypes.assertThat(true).isTrue();
+                      assertThat(true).isTrue();
+                      assertThat(exampleList).hasSize(0);
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              public class Test {
+                  List<String> exampleList;
+                  void method() {
+                      assertThat(exampleList).hasSize(0);
+                      assertThat(true).isTrue();
+                      assertThat(true).isTrue();
+                      assertThat(exampleList).hasSize(0);
                   }
               }
               """


### PR DESCRIPTION
- Fixes https://github.com/openrewrite/rewrite-testing-frameworks/issues/664

Pending the possible adoption of `.assertThatClass` or `.assertThatInterface` in AssertJ.
- https://github.com/openrewrite/rewrite-testing-frameworks/issues/664#issuecomment-2600958012