### PR TITLE
Convert JUnit AssertThrows with description message over to AssertJ

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.assertj;
 
-import java.util.List;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -29,6 +28,8 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.staticanalysis.LambdaBlockToExpression;
+
+import java.util.List;
 
 public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Added support to the `JUnitAssertThrowsToAssertExceptionType` recipe for retaining descriptions.

## What's your motivation?

The `assertThrows` has overloads with 3 parameters, the last parameter being a message to display on failure, which is not currently supported.

## Anything in particular you'd like reviewers to focus on?

I couldn't get the tests to work when I included the types within the `#{any()}` as was done within the existing code, the tests would then fail with an error of the form  
`/*~~(MethodInvocation type is missing or malformed)~~>*/assertThatExceptionOfType(NullPointerException.class).as("message").isThrownBy(() -> foo())`  
that I wasn't knowledgable enough to get to the bottom of.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
