### PR TITLE
Convert JUnit AssertThrows with assigment over to AssertJ

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -148,17 +148,17 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              import static org.junit.jupiter.api.Assertions.assertThrows;
+             import static org.junit.jupiter.api.Assertions.assertThrows;
 
-              public class SimpleExpectedExceptionTest {
-                  public void throwsExceptionWithSpecificType() {
-                      NullPointerException npe = hashCode() == 42
-                        ? new NullPointerException()
-                        : assertThrows(NullPointerException.class, () -> {
-                          throw new NullPointerException();
-                      });
-                  }
-              }
+             public class SimpleExpectedExceptionTest {
+                 public void throwsExceptionWithSpecificType() {
+                     NullPointerException npe = hashCode() == 42
+                       ? new NullPointerException()
+                       : assertThrows(NullPointerException.class, () -> {
+                         throw new NullPointerException();
+                     });
+                 }
+             }
              """,
             """
               import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Allow for JUnit AssertThrows assertions that use the returned value to be converted to the AssertJ equivalent with AssertThatExceptionOfType.

## What's your motivation?

When this conversion was causing an issue, as resolved by #331, the decision was made to ignore conversions of assertions that used the return value due to no functional equivalent being available in AssertJ.  
Since then AssertJ has released [v3.27.0](https://github.com/assertj/assertj/releases/tag/assertj-build-3.27.0) which has introduced the [`actual`](https://www.javadoc.io/doc/org.assertj/assertj-core/3.27.0/org/assertj/core/api/AbstractAssert.html#actual()) method which allows the retrieval of the actual value. This can be used to ensure that functionality can be replicated, although ideally any subsequent assertions of the exception would be using chained assertions from the initial `assertThatExceptionOfType(X.class).isThrownBy(() -> Y())`.

As far as I can tell the [latest version of AssertJ](https://github.com/openrewrite/rewrite-testing-frameworks/blob/b36584a2d6f47d2cdbd3bfc71c314dd14c541d39/src/main/resources/META-INF/rewrite/assertj.yml#L483) is pulled so this method would be available but I'm happy to be corrected on this.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
