### PR TITLE
Fix: Don't modify regular test to parameterized test incorrectly

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -105,7 +105,8 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             J.Annotation anno = super.visitAnnotation(annotation, ctx);
             Cursor classDeclCursor = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance);
             if (PARAMETERS_MATCHER.matches(anno)) {
-                classDeclCursor.computeMessageIfAbsent(PARAMETERIZED_TESTS, v -> new HashSet<>()).add(getCursor().firstEnclosing(J.MethodDeclaration.class).getSimpleName());
+                classDeclCursor.computeMessageIfAbsent(PARAMETERIZED_TESTS, v -> new HashSet<>())
+                        .add(getCursor().firstEnclosing(J.MethodDeclaration.class).getSimpleName());
                 String annotationArgumentValue = getAnnotationArgumentForInitMethod(anno, "method", "named");
                 if (annotationArgumentValue != null) {
                     for (String method : annotationArgumentValue.split(",")) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -50,6 +50,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
 
     private static final String INIT_METHOD_REFERENCES = "init-method-references";
     private static final String PARAMETERS_FOR_PREFIX = "parametersFor";
+    private static final String PARAMETERIZED_TESTS = "parameterized-tests";
     private static final String INIT_METHODS_MAP = "named-parameters-map";
     private static final String CONVERSION_NOT_SUPPORTED = "conversion-not-supported";
 
@@ -82,6 +83,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
                 doAfterVisit(new ParametersNoArgsImplicitMethodSource(initMethods,
                         getCursor().computeMessageIfAbsent(INIT_METHODS_MAP, v -> new HashMap<>()),
                         getCursor().computeMessageIfAbsent(CONVERSION_NOT_SUPPORTED, v -> new HashSet<>()),
+                        getCursor().computeMessageIfAbsent(PARAMETERIZED_TESTS, v -> new HashSet<>()),
                         ctx));
             }
             return cd;
@@ -103,6 +105,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             J.Annotation anno = super.visitAnnotation(annotation, ctx);
             Cursor classDeclCursor = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance);
             if (PARAMETERS_MATCHER.matches(anno)) {
+                classDeclCursor.computeMessageIfAbsent(PARAMETERIZED_TESTS, v -> new HashSet<>()).add(getCursor().firstEnclosing(J.MethodDeclaration.class).getSimpleName());
                 String annotationArgumentValue = getAnnotationArgumentForInitMethod(anno, "method", "named");
                 if (annotationArgumentValue != null) {
                     for (String method : annotationArgumentValue.split(",")) {
@@ -178,16 +181,18 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
 
         private final Set<String> initMethods;
         private final Set<String> unsupportedConversions;
+        private final Set<String> parameterizedTests;
         private final Map<String, String> initMethodReferences;
 
         private final JavaTemplate parameterizedTestTemplate;
         private final JavaTemplate parameterizedTestTemplateWithName;
         private final JavaTemplate methodSourceTemplate;
 
-        public ParametersNoArgsImplicitMethodSource(Set<String> initMethods, Map<String, String> initMethodReferences, Set<String> unsupportedConversions, ExecutionContext ctx) {
+        public ParametersNoArgsImplicitMethodSource(Set<String> initMethods, Map<String, String> initMethodReferences, Set<String> unsupportedConversions, Set<String> parameterizedTests, ExecutionContext ctx) {
             this.initMethods = initMethods;
             this.initMethodReferences = initMethodReferences;
             this.unsupportedConversions = unsupportedConversions;
+            this.parameterizedTests = parameterizedTests;
 
             // build @ParameterizedTest template
             JavaParser.Builder<?, ?> javaParser = JavaParser.fromJavaVersion()
@@ -254,6 +259,9 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
 
         private J.Annotation maybeReplaceTestAnnotation(Cursor anno, @Nullable String parameterizedTestArgument) {
             if (JUPITER_TEST_ANNOTATION_MATCHER.matches(anno.getValue()) || JUNIT_TEST_ANNOTATION_MATCHER.matches(anno.getValue())) {
+                if (!parameterizedTests.contains(anno.firstEnclosing(J.MethodDeclaration.class).getSimpleName())) {
+                    return anno.getValue();
+                }
                 if (parameterizedTestArgument == null) {
                     return parameterizedTestTemplate.apply(anno, ((J.Annotation) anno.getValue()).getCoordinates().replace());
                 } else {

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
@@ -67,9 +67,13 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
                   private Object[] parametersForPersonIsChild() {
                       return new Object[]{new Object[]{3, false}, new Object[]{7, false}};
                   }
+
+                  @Test
+                  public void regularTest() {}
               }
               """,
             """
+              import org.junit.Test;
               import org.junit.jupiter.params.ParameterizedTest;
               import org.junit.jupiter.params.provider.MethodSource;
 
@@ -92,6 +96,9 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
                   private static Object[] parametersForPersonIsChild() {
                       return new Object[]{new Object[]{3, false}, new Object[]{7, false}};
                   }
+
+                  @Test
+                  public void regularTest() {}
               }
               """
           )


### PR DESCRIPTION
## What's changed?
Fixed a bug in the JUnitParamsRunnerToParameterized recipe that incorrectly converted regular tests to @ParameterizedTest if the test class contained any @ParameterizedTest annotations.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
