### PR TITLE
Fix ParameterizedRunnerToParameterized recipe: Preserve field-dependent setup logic

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -34,6 +34,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
     private static final AnnotationMatcher JUNIT_TEST = new AnnotationMatcher("@org.junit.Test");
     private static final AnnotationMatcher JUPITER_TEST = new AnnotationMatcher("@org.junit.jupiter.api.Test");
     private static final AnnotationMatcher PARAMETERS = new AnnotationMatcher("@org.junit.runners.Parameterized$Parameters");
+    private static final AnnotationMatcher BEFORE = new AnnotationMatcher("@org.junit.Before");
     private static final AnnotationMatcher PARAMETER = new AnnotationMatcher("@org.junit.runners.Parameterized$Parameter");
     private static final AnnotationMatcher PARAMETERIZED_TEST = new AnnotationMatcher("@org.junit.jupiter.params.ParameterizedTest");
 
@@ -41,6 +42,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
     private static final String CONSTRUCTOR_ARGUMENTS = "constructor-args";
     private static final String FIELD_INJECTION_ARGUMENTS = "field-injection-args";
     private static final String PARAMETERS_METHOD_NAME = "parameters-method-name";
+    private static final String BEFORE_METHOD_NAME = "before-method-name";
 
     @Override
     public String getDisplayName() {
@@ -69,16 +71,17 @@ public class ParameterizedRunnerToParameterized extends Recipe {
                 List<Statement> constructorParams = (List<Statement>) params.get(CONSTRUCTOR_ARGUMENTS);
                 Map<Integer, Statement> fieldInjectionParams = (Map<Integer, Statement>) params.get(FIELD_INJECTION_ARGUMENTS);
                 String initMethodName = "init" + cd.getSimpleName();
+                String beforeMethodName = (String) params.getOrDefault(BEFORE_METHOD_NAME, null);
 
                 // Constructor Injected Test
                 if (parametersMethodName != null && constructorParams != null && constructorParams.stream().anyMatch(org.openrewrite.java.tree.J.VariableDeclarations.class::isInstance)) {
-                    doAfterVisit(new ParameterizedRunnerToParameterizedTestsVisitor(classDecl, parametersMethodName, initMethodName, parametersAnnotationArguments, constructorParams, true, ctx));
+                    doAfterVisit(new ParameterizedRunnerToParameterizedTestsVisitor(classDecl, parametersMethodName, initMethodName, parametersAnnotationArguments, constructorParams, true, beforeMethodName,ctx));
                 }
 
                 // Field Injected Test
                 else if (parametersMethodName != null && fieldInjectionParams != null) {
                     List<Statement> fieldParams = new ArrayList<>(fieldInjectionParams.values());
-                    doAfterVisit(new ParameterizedRunnerToParameterizedTestsVisitor(classDecl, parametersMethodName, initMethodName, parametersAnnotationArguments, fieldParams, false, ctx));
+                    doAfterVisit(new ParameterizedRunnerToParameterizedTestsVisitor(classDecl, parametersMethodName, initMethodName, parametersAnnotationArguments, fieldParams, false, beforeMethodName, ctx));
                 }
             }
             return cd;
@@ -88,16 +91,18 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
             Cursor classDeclCursor = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance);
+            Map<String, Object> params = classDeclCursor.computeMessageIfAbsent(((J.ClassDeclaration) classDeclCursor.getValue()).getId().toString(), v -> new HashMap<>());
             if (m.isConstructor()) {
-                Map<String, Object> params = classDeclCursor.computeMessageIfAbsent(((J.ClassDeclaration) classDeclCursor.getValue()).getId().toString(), v -> new HashMap<>());
                 params.put(CONSTRUCTOR_ARGUMENTS, m.getParameters());
             }
             for (J.Annotation annotation : m.getLeadingAnnotations()) {
                 if (PARAMETERS.matches(annotation)) {
-                    Map<String, Object> params = classDeclCursor.computeMessageIfAbsent(((J.ClassDeclaration) classDeclCursor.getValue()).getId().toString(), v -> new HashMap<>());
                     params.put(PARAMETERS_ANNOTATION_ARGUMENTS, annotation.getArguments());
                     params.put(PARAMETERS_METHOD_NAME, method.getSimpleName());
                     break;
+                }
+                if (BEFORE.matches(annotation)) {
+                    params.put(BEFORE_METHOD_NAME, method.getSimpleName());
                 }
             }
             return m;
@@ -161,6 +166,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
                                                               @Nullable List<Expression> parameterizedTestAnnotationParameters,
                                                               List<Statement> parameterizedTestMethodParameters,
                                                               boolean isConstructorInjection,
+                                                              @Nullable String beforeMethodName,
                                                               ExecutionContext ctx) {
             this.scope = scope;
             this.initMethodName = initMethodName;
@@ -217,6 +223,9 @@ public class ParameterizedRunnerToParameterized extends Recipe {
 
                 for (String p : initStatementParams) {
                     initMethodTemplate.append("    this.").append(p).append(" = ").append(p).append(";\n");
+                }
+                if (beforeMethodName != null) {
+                    initMethodTemplate.append("    this.").append(beforeMethodName).append("();\n");
                 }
 
                 initMethodTemplate.append("}");

--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -20,6 +20,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -95,7 +96,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
             if (m.isConstructor()) {
                 params.put(CONSTRUCTOR_ARGUMENTS, m.getParameters());
             }
-            for (J.Annotation annotation : m.getLeadingAnnotations()) {
+            for (J.Annotation annotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
                 if (PARAMETERS.matches(annotation)) {
                     params.put(PARAMETERS_ANNOTATION_ARGUMENTS, annotation.getArguments());
                     params.put(PARAMETERS_METHOD_NAME, method.getSimpleName());
@@ -114,7 +115,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
             Cursor classDeclCursor = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance);
             J.Annotation parameterAnnotation = null;
             Integer position = 0;
-            for (J.Annotation leadingAnnotation : variableDeclarations.getLeadingAnnotations()) {
+            for (J.Annotation leadingAnnotation : service(AnnotationService.class).getAllAnnotations(getCursor())) {
                 if (PARAMETER.matches(leadingAnnotation)) {
                     parameterAnnotation = leadingAnnotation;
                     if (parameterAnnotation.getArguments() != null && !(parameterAnnotation.getArguments().get(0) instanceof J.Empty)) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
@@ -235,6 +235,7 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
           spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(
             """
+              import org.junit.Before;
               import org.junit.Test;
               import org.junit.runner.RunWith;
               import org.junit.runners.Parameterized;
@@ -261,12 +262,16 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
                       return Arrays.asList(new Object[]{124, "Otis", "TheDog", Map.of("toys", "ball", "treats", "bacon")}, new Object[]{126, "Garfield", "TheBoss", Map.of("toys", "yarn", "treats", "fish")});
                   }
 
+                  @Before
+                  public void setUp() {}
+
                   @Test
                   public void checkName() {
                   }
               }
               """,
             """
+              import org.junit.Before;
               import org.junit.jupiter.params.ParameterizedTest;
               import org.junit.jupiter.params.provider.MethodSource;
 
@@ -284,6 +289,9 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
                       return Arrays.asList(new Object[]{124, "Otis", "TheDog", Map.of("toys", "ball", "treats", "bacon")}, new Object[]{126, "Garfield", "TheBoss", Map.of("toys", "yarn", "treats", "fish")});
                   }
 
+                  @Before
+                  public void setUp() {}
+
                   @MethodSource("parameters")
                   @ParameterizedTest(name = "{index}: {0} {1} - {2}")
                   public void checkName(Integer id, String name, String nickName, Map<String, String> stuff) {
@@ -295,6 +303,7 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
                       this.name = name;
                       this.nickName = nickName;
                       this.stuff = stuff;
+                      this.setUp();
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
In JUnit4, parameterized tests populate class fields before executing the @Before method, allowing setup logic to rely on those values. However, in JUnit5, @ParameterizedTest methods receive arguments directly, and the test instance is created before those values are available. As a result, there is no lifecycle hook where the arguments can be injected before @BeforeEach runs.

This mismatch breaks any setup logic that depends on parameter-initialized fields.

To preserve behavior consistent with JUnit4, this change manually invokes the setup method after setting the parameter values to the class fields inside the test method. This ensures any logic in @BeforeEach continues to function correctly with the parameter values in place.

### Possible improvement for future
Invoke the setup method if it references or depends on the parameter values. This avoids unnecessary calls when the setup logic is independent of the test parameters.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
