### PR TITLE
Implement MockitoJUnitRunner to Extension Recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerSilentToExtension.java
@@ -30,6 +30,10 @@ import org.openrewrite.java.tree.J;
 import java.util.Collections;
 import java.util.Comparator;
 
+/**
+ * @deprecated Use MockitoJUnitRunnerToExtension instead.
+ */
+@Deprecated
 public class MockitoJUnitRunnerSilentToExtension extends Recipe {
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.testing.junit5.RunnerToExtension;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.openrewrite.java.trait.Traits.annotated;
+
+public class MockitoJUnitRunnerToExtension extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Replace JUnit 4 MockitoJUnitRunner with junit-jupiter MockitoExtension";
+    }
+
+
+    @Override
+    public String getDescription() {
+        return "Replace JUnit 4 MockitoJUnitRunner annotations with JUnit 5 `@ExtendWith(MockitoExtension.class)` " +
+                "using the appropriate strictness levels (LENIENT, WARN, STRICT_STUBS).";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new UsesType<>("org.mockito.junit.MockitoJUnitRunner*", false), new JavaIsoVisitor<ExecutionContext>() {
+
+            final String runWith = "@org.junit.runner.RunWith";
+
+            @Override
+            public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+                AtomicReference<Strictness> strictness = new AtomicReference<>();
+                annotated(runWith).<AtomicReference<Strictness>>asVisitor((a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
+                    public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
+                        for (Strictness strict : Strictness.values()) {
+                            if (TypeUtils.isAssignableTo(strict.runner, fieldAccess.getTarget().getType())) {
+                                strictness.set(strict);
+                                break;
+                            }
+                        }
+                        return fieldAccess;
+                    }
+                }, s)).visit(cd, strictness);
+
+                if (strictness.get() == null) { // class doesn't have MockitoJunitRunner
+                    return cd;
+                }
+
+                registerAfterVisit();
+                return getTemplate(strictness.get(), ctx)
+                        .map(t -> maybeAutoFormat(cd,
+                                t.apply(updateCursor(cd), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName))),
+                                ctx)).orElse(cd);
+            }
+
+            private void registerAfterVisit() {
+                doAfterVisit(new RunnerToExtension(Arrays.asList("org.mockito.junit.MockitoJUnitRunner.Silent", "org.mockito.junit.MockitoJUnitRunner.Strict", "org.mockito.junit.MockitoJUnitRunner"),
+                        "org.mockito.junit.jupiter.MockitoExtension").getVisitor());
+                for (Strictness strictness : Strictness.values()) {
+                    maybeRemoveImport(strictness.runner);
+                }
+                maybeAddImport("org.mockito.quality.Strictness");
+                maybeAddImport("org.mockito.junit.jupiter.MockitoSettings");
+            }
+
+            private Optional<JavaTemplate> getTemplate(Strictness strictness, ExecutionContext ctx) {
+                // MockitoExtension defaults to STRICT_STUBS, no need of explicit setting.
+                if (strictness == Strictness.STRICT_STUBS) {
+                    return Optional.empty();
+                }
+                return Optional.of(JavaTemplate.builder("@MockitoSettings(strictness = Strictness." + strictness + ")")
+                        .imports("org.mockito.quality.Strictness", "org.mockito.junit.jupiter.MockitoSettings")
+                        .javaParser(JavaParser.fromJavaVersion()
+                                .classpathFromResources(ctx, "mockito-junit-jupiter-3.12", "mockito-core-3.12"))
+                        .build());
+            }
+        });
+    }
+
+    private enum Strictness {
+        LENIENT("org.mockito.junit.MockitoJUnitRunner.Silent"),
+        STRICT_STUBS("org.mockito.junit.MockitoJUnitRunner.Strict"),
+        WARN("org.mockito.junit.MockitoJUnitRunner");
+
+        final String runner;
+
+        Strictness(String runner) {
+            this.runner = runner;
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -58,6 +58,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 AtomicReference<Strictness> strictness = new AtomicReference<>();
                 annotated(runWith).<AtomicReference<Strictness>>asVisitor((a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
+                    @Override
                     public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
                         for (Strictness strict : Strictness.values()) {
                             if (TypeUtils.isAssignableTo(strict.runner, fieldAccess.getTarget().getType())) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4", "mockito-core-3.12"))
+          .recipe(new MockitoJUnitRunnerToExtension());
+    }
+
+    @DocumentExample
+    @ParameterizedTest
+    @CsvSource({
+      "MockitoJUnitRunner.Silent.class,Strictness.LENIENT",
+      "MockitoJUnitRunner.class,Strictness.WARN"
+    })
+    void mockitoRunnerToExtension(String runnerName, String strictness) {
+        //language=java
+        rewriteRun(
+          java(
+            String.format("""
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.MockitoJUnitRunner;
+
+              @RunWith(%s)
+              public class ExternalAPIServiceTest {
+              }
+              """, runnerName),
+            String.format("""
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
+
+              @MockitoSettings(strictness = %s)
+              @ExtendWith(MockitoExtension.class)
+              public class ExternalAPIServiceTest {
+              }
+              """, strictness)
+          )
+        );
+    }
+
+    @Test
+    void strictMockitoRunnerToExtension() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.MockitoJUnitRunner;
+
+              @RunWith(MockitoJUnitRunner.Strict.class)
+              public class ExternalAPIServiceTest {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noMockitoRunner() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.runner.RunWith;
+              import org.junit.runners.Parameterized;
+
+              @RunWith(Parameterized.class)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
@@ -26,7 +26,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
+class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {


### PR DESCRIPTION
## What's changed?
Created a Recipe to migrate MockitoJUnitRunner to MockitoExtension. 

## What's your motivation?
The previous implementation had few issues:
1. It only handled lenient and warn modes, and incorrectly migrated warn mode to strict mode (while the default for MockitoJUnitRunner is warn, the default for MockitoExtension is strict).
2. Mode-specific handling was split between imperative (for lenient) and declarative (for warn) recipes.

### Changes
1. Consolidated all mode-handling logic (strict, warn, and lenient) into a single imperative recipe.
2. New recipe correctly maps warn mode to maintain expected behavior and also handled strict mode for MockitoJUnitRunner.
3. Marked the previous imperative recipe as deprecated for backward compatibility instead of removing it.

### Followup
I will create a followup PR to update the UseMockitoExtension declarative recipe to leverage this new recipe.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
