### PR TITLE
Fix Incorrect Migration of TemporaryFolder.newFile in TemporaryFolderToTmpDir Recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -195,10 +195,10 @@ class AddNewFolderOrFileMethod extends JavaIsoVisitor<ExecutionContext> {
                 .map(J.MethodDeclaration.class::cast)
                 .filter(m -> {
                     List<Statement> params = m.getParameters();
-                    return fileOrFolder.methodName.equals(m.getSimpleName())
-                            && params.size() == 2
-                            && hasClassType(params.get(0), "java.io.File")
-                            && hasClassType(params.get(1), "java.lang.String");
+                    return fileOrFolder.methodName.equals(m.getSimpleName()) &&
+                            params.size() == 2 &&
+                            hasClassType(params.get(0), "java.io.File") &&
+                            hasClassType(params.get(1), "java.lang.String");
                 }).map(J.MethodDeclaration::getMethodType).filter(Objects::nonNull).findAny();
     }
 }

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -2960,14 +2960,23 @@ examples:
       import org.junit.Rule
       import org.junit.rules.TemporaryFolder
 
+      import java.io.File
+      import java.io.IOException
+
       class AbstractIntegrationTest {
           @TempDir
           File temporaryFolder
 
           def setup() {
               projectDir = temporaryFolder.root
-              buildFile = File.createTempFile('build.gradle', null, temporaryFolder)
-              settingsFile = File.createTempFile('settings.gradle', null, temporaryFolder)
+              buildFile = newFile(temporaryFolder, 'build.gradle')
+              settingsFile = newFile(temporaryFolder, 'settings.gradle')
+          }
+
+          private static File newFile(File parent, String child) throws IOException {
+              File result = new File(parent, child)
+              result.createNewFile()
+              return result
           }
       }
     language: groovy
@@ -3383,25 +3392,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      <project>
-        <modelVersion>4.0.0</modelVersion>
-        <groupId>com.example</groupId>
-        <artifactId>demo</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <dependencies>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>3.11.2</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-      </project>
-    path: pom.xml
-    language: xml
-- description: ''
-  sources:
-  - before: |
       plugins {
           id 'java-library'
       }
@@ -3434,6 +3424,25 @@ examples:
           }
       }
     language: java
+- description: ''
+  sources:
+  - before: |
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>demo</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>3.11.2</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+      </project>
+    path: pom.xml
+    language: xml
 ---
 type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.java.testing.mockito.MockitoBestPractices

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDirTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDirTest.java
@@ -66,14 +66,23 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
             import org.junit.Rule
             import org.junit.rules.TemporaryFolder
 
+            import java.io.File
+            import java.io.IOException
+
             class AbstractIntegrationTest {
                 @TempDir
                 File temporaryFolder
 
                 def setup() {
                     projectDir = temporaryFolder.root
-                    buildFile = File.createTempFile('build.gradle', null, temporaryFolder)
-                    settingsFile = File.createTempFile('settings.gradle', null, temporaryFolder)
+                    buildFile = newFile(temporaryFolder, 'build.gradle')
+                    settingsFile = newFile(temporaryFolder, 'settings.gradle')
+                }
+
+                private static File newFile(File parent, String child) throws IOException {
+                    File result = new File(parent, child)
+                    result.createNewFile()
+                    return result
                 }
             }
             """
@@ -476,7 +485,13 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
                   @Test
                   public void newNamedFileIsCreatedUnderRootFolder() throws IOException {
                       final String fileName = "SampleFile.txt";
-                      File f = File.createTempFile(fileName, null, tempFolder);
+                      File f = newFile(tempFolder, fileName);
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """
@@ -531,8 +546,14 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
                   public void newNamedFileIsCreatedUnderRootFolder() throws IOException {
                       final String fileName = "SampleFile.txt";
                       final String otherFileName = "otherText.txt";
-                      File f = File.createTempFile(fileName, null, tempFolder);
-                      File f2 = File.createTempFile(otherFileName, null, tempFolder2);
+                      File f = newFile(tempFolder, fileName);
+                      File f2 = newFile(tempFolder2, otherFileName);
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
The TemporaryFolderToTmpDir recipe incorrectly migrates `temporaryFolder.newFile(fileName)` to `Files.createTempFile(fileName, null, temporaryFolder)`. This approach changes the behavior: instead of creating a file with the exact name fileName, it uses fileName as a prefix and appends random characters as a suffix.

To address this, introduced a new newFile method that correctly replicates the original behavior. This method creates a File instance with `new File(temporaryFolder, fileName)` which is identical to `temporaryFolder.newFile` method.

**Note**: I didn't touch the `temporaryFolder.newFile` without arguments as internally translates to `Files.createTempFile`

Additionally, the migration now updates all occurrences of temporaryFolder.newFile(fileName) to use the new newFile(fileName) method, preserving the original semantics accurately.
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
