### PR TITLE
Fix Import of Mockito classes in MockitoRuleToExtension recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/MockitoJUnitToMockitoExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/MockitoJUnitToMockitoExtension.java
@@ -121,12 +121,12 @@ public class MockitoJUnitToMockitoExtension extends Recipe {
                     if (!strictness.contains("STRICT_STUBS")) {
                         cd = JavaTemplate.builder("@MockitoSettings(strictness = " + strictness + ")")
                                 .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "junit-jupiter-api-5", "mockito-junit-jupiter-3.12"))
+                                        .classpathFromResources(ctx, "junit-jupiter-api-5", "mockito-junit-jupiter-3.12", "mockito-core-3.12"))
                                 .imports("org.mockito.junit.jupiter.MockitoSettings", "org.mockito.quality.Strictness")
                                 .build()
                                 .apply(updateCursor(cd), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
-                        maybeAddImport("org.mockito.junit.jupiter.MockitoSettings", false);
-                        maybeAddImport("org.mockito.quality.Strictness", false);
+                        maybeAddImport("org.mockito.junit.jupiter.MockitoSettings");
+                        maybeAddImport("org.mockito.quality.Strictness");
                     }
                 }
             }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitToMockitoExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitToMockitoExtensionTest.java
@@ -664,6 +664,7 @@ class MockitoJUnitToMockitoExtensionTest implements RewriteTest {
               import java.util.List;
 
               import static org.mockito.Mockito.when;
+              import static org.mockito.quality.Strictness.WARN;
 
               @ExtendWith(MockitoExtension.class)
               @MockitoSettings(strictness = Strictness.WARN)


### PR DESCRIPTION
## What's changed?
The MockitoJUnitToMockitoExtension recipe was not importing mockito-core as a resource, which caused missing type attribution for Mockito-related expressions generated by the Java template parser. Previously, tests passed because the maybeAddImport method was used with onlyReferenced = false, masking the issue.

To fix this, imported mockito-core for corresponding JavaTempalteParser.
To verify the fix, updated the maybeAddImport method to use onlyReferenced = true and confirmed that mockito related imports being added. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
