### PR TITLE
Fix JunitParams to Parameterized by recursively updating referenced method to static

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -358,8 +358,9 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             this.classType = classType;
         }
 
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext executionContext) {
-            if (classDeclaration.getType() != classType) {
+        @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, ctx);
                 return classDeclaration;
             }
             J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, executionContext);
@@ -380,6 +381,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             return m.withModifiers(ListUtils.concat(m.getModifiers(), staticModifier));
         }
 
+        @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             Cursor classCursor = getCursor().dropParentUntil(j -> j instanceof J.ClassDeclaration);
             J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -377,7 +377,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
                 return method;
             }
             J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-            J.Modifier staticModifier = new J.Modifier(Tree.randomId(), Space.format(" "), Markers.EMPTY, null, J.Modifier.Type.Static, new ArrayList<>());
+            J.Modifier staticModifier = new J.Modifier(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY, null, J.Modifier.Type.Static, new ArrayList<>());
             return m.withModifiers(ListUtils.concat(m.getModifiers(), staticModifier));
         }
 

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -359,8 +359,8 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
         }
 
         @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext ctx) {
-            J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, ctx);
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDeclaration, ExecutionContext executionContext) {
+            if (classDeclaration.getType() != classType) {
                 return classDeclaration;
             }
             J.ClassDeclaration cd = super.visitClassDeclaration(classDeclaration, executionContext);

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
@@ -268,28 +268,28 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
         rewriteRun(
           java(
             """
-             import org.junit.Test;
-             import org.junit.runner.RunWith;
-             import junitparams.JUnitParamsRunner;
-             import junitparams.Parameters;
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import junitparams.JUnitParamsRunner;
+              import junitparams.Parameters;
 
-             @RunWith(JUnitParamsRunner.class)
-             class CsvSourceTests {
-                 @Test
-                 @Parameters({"Lav,20", "Katy,25"})
-                 public void csvSource(String name, int age) { }
-             }
-             """,
+              @RunWith(JUnitParamsRunner.class)
+              class CsvSourceTests {
+                  @Test
+                  @Parameters({"Lav,20", "Katy,25"})
+                  public void csvSource(String name, int age) { }
+              }
+              """,
             """
-             import org.junit.jupiter.params.ParameterizedTest;
-             import org.junit.jupiter.params.provider.CsvSource;
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
 
-             class CsvSourceTests {
-                 @ParameterizedTest
-                 @CsvSource({"Lav,20", "Katy,25"})
-                 public void csvSource(String name, int age) { }
-             }
-             """
+              class CsvSourceTests {
+                  @ParameterizedTest
+                  @CsvSource({"Lav,20", "Katy,25"})
+                  public void csvSource(String name, int age) { }
+              }
+              """
           )
         );
     }
@@ -300,28 +300,28 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
         rewriteRun(
           java(
             """
-             import org.junit.Test;
-             import org.junit.runner.RunWith;
-             import junitparams.JUnitParamsRunner;
-             import junitparams.Parameters;
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import junitparams.JUnitParamsRunner;
+              import junitparams.Parameters;
 
-             @RunWith(JUnitParamsRunner.class)
-             class CsvSourceTests {
-                 @Test
-                 @Parameters(value = {"Lav,20", "Katy,25"})
-                 public void csvSource(String name, int age) { }
-             }
-             """,
+              @RunWith(JUnitParamsRunner.class)
+              class CsvSourceTests {
+                  @Test
+                  @Parameters(value = {"Lav,20", "Katy,25"})
+                  public void csvSource(String name, int age) { }
+              }
+              """,
             """
-             import org.junit.jupiter.params.ParameterizedTest;
-             import org.junit.jupiter.params.provider.CsvSource;
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
 
-             class CsvSourceTests {
-                 @ParameterizedTest
-                 @CsvSource(value = {"Lav,20", "Katy,25"})
-                 public void csvSource(String name, int age) { }
-             }
-             """
+              class CsvSourceTests {
+                  @ParameterizedTest
+                  @CsvSource(value = {"Lav,20", "Katy,25"})
+                  public void csvSource(String name, int age) { }
+              }
+              """
           )
         );
     }
@@ -332,38 +332,38 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
         rewriteRun(
           java(
             """
-             import org.junit.Test;
-             import org.junit.runner.RunWith;
-             import java.util.Date;
-             import junitparams.converters.Param;
-             import junitparams.JUnitParamsRunner;
-             import junitparams.Parameters;
-             import junitparams.converters.NullableConverter;
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import java.util.Date;
+              import junitparams.converters.Param;
+              import junitparams.JUnitParamsRunner;
+              import junitparams.Parameters;
+              import junitparams.converters.NullableConverter;
 
-             @RunWith(JUnitParamsRunner.class)
-             class CsvSourceTests {
-                 @Test
-                 @Parameters({"01.12.2012"})
-                 public void csvSource(@Param(converter = NullableConverter.class) Date date) { }
-             }
-             """,
+              @RunWith(JUnitParamsRunner.class)
+              class CsvSourceTests {
+                  @Test
+                  @Parameters({"01.12.2012"})
+                  public void csvSource(@Param(converter = NullableConverter.class) Date date) { }
+              }
+              """,
             """
-             import org.junit.Test;
-             import org.junit.runner.RunWith;
-             import java.util.Date;
-             import junitparams.converters.Param;
-             import junitparams.JUnitParamsRunner;
-             import junitparams.Parameters;
-             import junitparams.converters.NullableConverter;
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import java.util.Date;
+              import junitparams.converters.Param;
+              import junitparams.JUnitParamsRunner;
+              import junitparams.Parameters;
+              import junitparams.converters.NullableConverter;
 
-             @RunWith(JUnitParamsRunner.class)
-             class CsvSourceTests {
-                 @Test
-                 // JunitParamsRunnerToParameterized conversion not supported
-                 @Parameters({"01.12.2012"})
-                 public void csvSource(@Param(converter = NullableConverter.class) Date date) { }
-             }
-             """
+              @RunWith(JUnitParamsRunner.class)
+              class CsvSourceTests {
+                  @Test
+                  // JunitParamsRunnerToParameterized conversion not supported
+                  @Parameters({"01.12.2012"})
+                  public void csvSource(@Param(converter = NullableConverter.class) Date date) { }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterizedTest.java
@@ -198,6 +198,71 @@ class JUnitParamsRunnerToParameterizedTest implements RewriteTest {
     }
 
     @Test
+    void methodSourceWithInstanceAccess() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import java.time.LocalDateTime;
+              import junitparams.JUnitParamsRunner;
+              import junitparams.Parameters;
+              import junitparams.NamedParameters;
+              import junitparams.naming.TestCaseName;
+
+              @RunWith(JUnitParamsRunner.class)
+              public class PersonTests {
+
+                  @Test
+                  @Parameters(method = "youngAdultPersonParams")
+                  public void personIsAdult(int age, boolean valid) {
+                  }
+
+                  private Object[] youngAdultPersonParams() {
+                      return new Object[]{new Object[]{getAge(2000), false}, new Object[]{getAge(2005), false}};
+                  }
+
+                  private int getAge(int birthYear) {
+                      return getCurrentYear() - birthYear;
+                  }
+
+                  private int getCurrentYear() {
+                     return LocalDateTime.now().getYear();
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.MethodSource;
+
+              import java.time.LocalDateTime;
+
+              public class PersonTests {
+
+                  @ParameterizedTest
+                  @MethodSource("youngAdultPersonParams")
+                  public void personIsAdult(int age, boolean valid) {
+                  }
+
+                  private static Object[] youngAdultPersonParams() {
+                      return new Object[]{new Object[]{getAge(2000), false}, new Object[]{getAge(2005), false}};
+                  }
+
+                  private static int getAge(int birthYear) {
+                      return getCurrentYear() - birthYear;
+                  }
+
+                  private static int getCurrentYear() {
+                     return LocalDateTime.now().getYear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void csvSource() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
The JUnitParamsRunnerToParameterized recipe updates the test method to static as required by JUnit 5, but it only updates the source method itself. If that method references other non-static methods, it leads to compilation failures.

This fix recursively identifies and updates all transitive method references that need to be static.

Before fix
```
private static Object[] youngAdultPersonParams() {
    return new Object[]{new Object[]{getAge(2000), false}, new Object[]{getAge(2005), false}};
}

private int getAge(int birthYear) {
    return getCurrentYear() - birthYear;
}

private int getCurrentYear() {
   return LocalDateTime.now().getYear();
}
```
After fix
```
private static Object[] youngAdultPersonParams() {
    return new Object[]{new Object[]{getAge(2000), false}, new Object[]{getAge(2005), false}};
}

private static int getAge(int birthYear) {
    return getCurrentYear() - birthYear;
}

private static int getCurrentYear() {
   return LocalDateTime.now().getYear();
}
```

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
