### PR TITLE
Fix ParameterizedRunnerToParameterized: Remove redundant super call

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -388,7 +388,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         }
 
         @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        public @Nullable J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
             J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
             // remove redundant super call, otherwise it will create compilation error when this constructor is converted to regular method.
@@ -400,8 +400,8 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         }
 
         private static boolean isEmptyArgs(J.MethodInvocation mi) {
-            return mi.getArguments().isEmpty()
-                    || (mi.getArguments().size() == 1 && mi.getArguments().get(0) instanceof J.Empty);
+            return mi.getArguments().isEmpty() ||
+                    (mi.getArguments().size() == 1 && mi.getArguments().get(0) instanceof J.Empty);
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -386,5 +386,22 @@ public class ParameterizedRunnerToParameterized extends Recipe {
             }
             return m;
         }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+            J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
+            // remove redundant super call, otherwise it will create compilation error when this constructor is converted to regular method.
+            // TODO: Handle super call with arguments.
+            if (enclosingMethod != null && enclosingMethod.isConstructor() && mi.getName().getSimpleName().equals("super") && isEmptyArgs(mi)) {
+                return null;
+            }
+            return mi;
+        }
+
+        private static boolean isEmptyArgs(J.MethodInvocation mi) {
+            return mi.getArguments().isEmpty()
+                    || (mi.getArguments().size() == 1 && mi.getArguments().get(0) instanceof J.Empty);
+        }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -388,7 +388,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         }
 
         @Override
-        public @Nullable J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        public J.@Nullable MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
             J.MethodDeclaration enclosingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
             // remove redundant super call, otherwise it will create compilation error when this constructor is converted to regular method.

--- a/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
@@ -590,4 +590,89 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
               """
           ));
     }
+
+    @Test
+    void methodSourceWithSuperCall() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import org.junit.runners.Parameterized;
+              import org.junit.runners.Parameterized.Parameters;
+
+              import java.util.Arrays;
+              import java.util.List;
+
+              @RunWith(Parameterized.class)
+              public class VetTests {
+
+                  private String firstName;
+                  private String lastName;
+                  private Integer id;
+
+                  public VetTests(String firstName, String lastName, Integer id) {
+                      super();
+                      this.firstName = firstName;
+                      this.lastName = lastName;
+                      this.id = id;
+                  }
+
+                  @Test
+                  public void testSerialization() {
+                      Vet vet = new Vet();
+                      vet.setFirstName(firstName);
+                      vet.setLastName(lastName);
+                      vet.setId(id);
+                  }
+
+                  @Parameters
+                  public static List<Object[]> parameters() {
+                      return Arrays.asList(
+                          new Object[] { "Otis", "TheDog", 124 },
+                          new Object[] { "Garfield", "TheBoss", 126 });
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.MethodSource;
+
+              import java.util.Arrays;
+              import java.util.List;
+
+              public class VetTests {
+
+                  private String firstName;
+                  private String lastName;
+                  private Integer id;
+
+                  public void initVetTests(String firstName, String lastName, Integer id) {
+                      this.firstName = firstName;
+                      this.lastName = lastName;
+                      this.id = id;
+                  }
+
+                  @MethodSource("parameters")
+                  @ParameterizedTest
+                  public void testSerialization(String firstName, String lastName, Integer id) {
+                      initVetTests(firstName, lastName, id);
+                      Vet vet = new Vet();
+                      vet.setFirstName(firstName);
+                      vet.setLastName(lastName);
+                      vet.setId(id);
+                  }
+
+                  public static List<Object[]> parameters() {
+                      return Arrays.asList(
+                          new Object[] { "Otis", "TheDog", 124 },
+                          new Object[] { "Garfield", "TheBoss", 126 });
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
@@ -497,7 +497,6 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
                       }
 
                       public void initI1(String path) {
-                          super(path);
                       }
 
                       @MethodSource("data1")


### PR DESCRIPTION
## What's changed?
ParameterizedRunnerToParameterized recipe converts constructor to initMethod but it may have redundant super call, this fix removes that redundant super call.


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
