### PR TITLE
Handle non-@Rule TemporaryFolder fields

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -71,11 +71,6 @@ class TemporaryFolderToTempDirVisitor extends JavaVisitor<ExecutionContext> {
             .imports("java.nio.file.Files")
             .build();
 
-    private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-        return JavaParser.fromJavaVersion()
-                .classpathFromResources(ctx, "junit-jupiter-api-5");
-    }
-
     @Override
     public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
         J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
@@ -100,7 +95,10 @@ class TemporaryFolderToTempDirVisitor extends JavaVisitor<ExecutionContext> {
             return mv;
         }
         mv = mv.withTypeExpression(toFileIdentifier(mv.getTypeExpression()));
-        JavaTemplate template = JavaTemplate.builder("@TempDir").imports(tempDir).javaParser(javaParser(ctx)).build();
+        JavaTemplate template = JavaTemplate.builder("@TempDir")
+                .imports(tempDir)
+                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                .build();
         return (J.VariableDeclarations) annotated("@org.junit.*Rule").asVisitor(a ->
                         (new JavaIsoVisitor<ExecutionContext>() {
                             @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.junit5;
 
+import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
@@ -28,8 +29,8 @@ import org.openrewrite.marker.Markers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
@@ -49,268 +50,292 @@ public class TemporaryFolderToTempDir extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>("org.junit.rules.TemporaryFolder", false), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(
+                new UsesType<>("org.junit.rules.TemporaryFolder", false),
+                new TemporaryFolderToTempDirVisitor());
+    }
+}
 
-            final String temporaryFolder = "org.junit.rules.TemporaryFolder";
-            final String tempDir = "org.junit.jupiter.api.io.TempDir";
-            final AnnotationMatcher classRule = new AnnotationMatcher("@org.junit.ClassRule");
-            final AnnotationMatcher rule = new AnnotationMatcher("@org.junit.Rule");
-            final MethodMatcher newTemporaryFolder = new MethodMatcher(temporaryFolder + "<constructor>()");
-            final MethodMatcher newTemporaryFolderWithArg = new MethodMatcher(temporaryFolder + "<constructor>(java.io.File)");
-            final JavaTemplate createTempDirTemplate = JavaTemplate.builder("Files.createTempDirectory(\"junit\").toFile()")
-                    .imports("java.nio.file.Files")
-                    .build();
-            final JavaTemplate createTempDirTemplateWithArg = JavaTemplate.builder("Files.createTempDirectory(#{any(java.io.File)}.toPath(), \"junit\").toFile()")
-                    .imports("java.nio.file.Files")
-                    .build();
+class TemporaryFolderToTempDirVisitor extends JavaVisitor<ExecutionContext> {
 
-            private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                    return JavaParser.fromJavaVersion()
-                            .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
+    final String temporaryFolder = "org.junit.rules.TemporaryFolder";
+    final String tempDir = "org.junit.jupiter.api.io.TempDir";
+    final AnnotationMatcher classRule = new AnnotationMatcher("@org.junit.ClassRule");
+    final AnnotationMatcher rule = new AnnotationMatcher("@org.junit.Rule");
+    final MethodMatcher newTemporaryFolder = new MethodMatcher(temporaryFolder + "<constructor>()");
+    final MethodMatcher newTemporaryFolderWithArg = new MethodMatcher(temporaryFolder + "<constructor>(java.io.File)");
+    final JavaTemplate createTempDirTemplate = JavaTemplate.builder("Files.createTempDirectory(\"junit\").toFile()")
+            .imports("java.nio.file.Files")
+            .build();
+    final JavaTemplate createTempDirTemplateWithArg = JavaTemplate.builder("Files.createTempDirectory(#{any(java.io.File)}.toPath(), \"junit\").toFile()")
+            .imports("java.nio.file.Files")
+            .build();
 
-            @Override
-            public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-                J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
-                if (c != cu) {
-                    c = (J.CompilationUnit) new ChangeType(temporaryFolder, tempDir, true).getVisitor()
-                            .visit(c, ctx);
-                    maybeAddImport("java.io.File");
-                    maybeAddImport("java.nio.file.Files");
-                    maybeAddImport("org.junit.jupiter.api.io.TempDir");
-                    maybeRemoveImport("org.junit.ClassRule");
-                    maybeRemoveImport("org.junit.Rule");
-                    maybeRemoveImport("org.junit.rules.TemporaryFolder");
-                }
-                return c;
-            }
-
-            @Override
-            public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
-                J.VariableDeclarations mv = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-                if (!TypeUtils.isOfClassType(multiVariable.getTypeAsFullyQualified(), temporaryFolder)) {
-                    return mv;
-                }
-                mv = mv.withTypeExpression(toFileIdentifier(mv.getTypeExpression()));
-                JavaTemplate template = JavaTemplate.builder("@TempDir").imports(tempDir).javaParser(javaParser(ctx)).build();
-                return (J.VariableDeclarations) annotated("@org.junit.*Rule").asVisitor(a ->
-                                (new JavaIsoVisitor<ExecutionContext>() {
-                                    @Override
-                                    public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
-                                        return template.apply(updateCursor(annotation), annotation.getCoordinates().replace());
-                                    }
-                                }).visit(a.getTree(), ctx, a.getCursor().getParentOrThrow()))
-                        .visit(mv, ctx, getCursor().getParentOrThrow());
-            }
-
-            @Override
-            public @Nullable J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
-                boolean hasRuleAnnotation = hasRuleAnnotation();
-                if (newTemporaryFolder.matches(newClass)) {
-                    if (hasRuleAnnotation) {
-                        return null;
-                    }
-                    return createTempDirTemplate.apply(getCursor(), newClass.getCoordinates().replace());
-                }
-                if (newTemporaryFolderWithArg.matches(newClass)) {
-                    if (hasRuleAnnotation) {
-                        return null;
-                    }
-                    return createTempDirTemplateWithArg.apply(getCursor(), newClass.getCoordinates().replace(), newClass.getArguments().get(0));
-                }
-                return super.visitNewClass(newClass, ctx);
-            }
-
-            @Override
-            public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                updateCursor(mi);
-                if (mi.getSelect() != null && mi.getMethodType() != null &&
-                    TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), "org.junit.rules.TemporaryFolder")) {
-                    switch (mi.getSimpleName()) {
-                        case "newFile":
-                            return convertToNewFile(mi, ctx);
-                        case "newFolder":
-                            doAfterVisit(new AddNewFolderMethod(mi));
-                            break;
-                        case "create":
-                            //noinspection ConstantConditions
-                            return null;
-                        case "getRoot":
-                            return mi.getSelect().withPrefix(mi.getPrefix());
-                        default:
-                            return mi;
-                    }
-                }
-                return mi;
-            }
-
-            private J.Identifier toFileIdentifier(TypeTree typeTree) {
-                JavaType.ShallowClass fileType = JavaType.ShallowClass.build("java.io.File");
-                return new J.Identifier(randomId(), typeTree.getPrefix(), Markers.EMPTY, emptyList(), fileType.getClassName(), fileType, null);
-            }
-
-            private boolean hasRuleAnnotation() {
-                J.VariableDeclarations vd = getCursor().firstEnclosing(J.VariableDeclarations.class);
-                if (vd == null) {
-                    return false;
-                }
-                return vd.getLeadingAnnotations().stream().anyMatch(anno -> classRule.matches(anno) || rule.matches(anno));
-            }
-
-            private J convertToNewFile(J.MethodInvocation mi, ExecutionContext ctx) {
-                if (mi.getSelect() == null) {
-                    return mi;
-                }
-                J tempDir = mi.getSelect().withType(JavaType.ShallowClass.build("java.io.File"));
-                List<Expression> args = mi.getArguments().stream().filter(arg -> !(arg instanceof J.Empty)).collect(Collectors.toList());
-                if (args.isEmpty()) {
-                    return JavaTemplate.builder("File.createTempFile(\"junit\", null, #{any(java.io.File)})")
-                            .imports("java.io.File")
-                            .javaParser(javaParser(ctx))
-                            .build()
-                            .apply(getCursor(), mi.getCoordinates().replace(), tempDir);
-                } else {
-                    return JavaTemplate.builder("File.createTempFile(#{any(java.lang.String)}, null, #{any(java.io.File)})")
-                            .imports("java.io.File")
-                            .javaParser(javaParser(ctx))
-                            .build()
-                            .apply(getCursor(), mi.getCoordinates().replace(), args.get(0), tempDir);
-                }
-            }
-        });
+    private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
+        return JavaParser.fromJavaVersion()
+                .classpathFromResources(ctx, "junit-jupiter-api-5");
     }
 
-    private static class AddNewFolderMethod extends JavaIsoVisitor<ExecutionContext> {
-        private final J.MethodInvocation methodInvocation;
-
-        public AddNewFolderMethod(J.MethodInvocation methodInvocation) {
-            this.methodInvocation = methodInvocation;
+    @Override
+    public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+        J.CompilationUnit c = (J.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+        if (c != cu) {
+            c = (J.CompilationUnit) new ChangeType(
+                    "org.junit.rules.TemporaryFolder", "java.io.File", true).getVisitor()
+                    .visit(c, ctx);
+            maybeAddImport("java.io.File");
+            maybeAddImport("java.nio.file.Files");
+            maybeAddImport("org.junit.jupiter.api.io.TempDir");
+            maybeRemoveImport("org.junit.ClassRule");
+            maybeRemoveImport("org.junit.Rule");
+            maybeRemoveImport("org.junit.rules.TemporaryFolder");
         }
-
-        private boolean hasClassType(Statement j, @Nullable String classType) {
-            if (classType == null) {
-                return false;
-            }
-
-            if (!(j instanceof J.VariableDeclarations)) {
-                return false;
-            }
-
-            J.VariableDeclarations variable = (J.VariableDeclarations) j;
-
-            if (variable.getTypeExpression() == null) {
-                return false;
-            }
-
-            return TypeUtils.isOfClassType(variable.getTypeExpression().getType(), classType);
-        }
-
-        @Override
-        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-
-            Stream<J.MethodDeclaration> methods = cd.getBody().getStatements().stream()
-                    .filter(J.MethodDeclaration.class::isInstance)
-                    .map(J.MethodDeclaration.class::cast);
-
-            JavaType.Method newFolderMethodDeclaration = methods
-                    .filter(m -> {
-                        List<Statement> params = m.getParameters();
-                        return "newFolder".equals(m.getSimpleName()) &&
-                               params.size() == 2 &&
-                               hasClassType(params.get(0), "java.io.File") &&
-                               hasClassType(params.get(1), "java.lang.String");
-                    }).map(J.MethodDeclaration::getMethodType).filter(Objects::nonNull).findAny().orElse(null);
-
-            if (newFolderMethodDeclaration == null) {
-                cd = JavaTemplate.builder(
-                                "private static File newFolder(File root, String... subDirs) throws IOException {\n" +
-                                "    String subFolder = String.join(\"/\", subDirs);\n" +
-                                "    File result = new File(root, subFolder);\n" +
-                                "    if(!result.mkdirs()) {\n" +
-                                "        throw new IOException(\"Couldn't create folders \" + root);\n" +
-                                "    }\n" +
-                                "    return result;\n" +
-                                "}")
-                        .contextSensitive()
-                        .imports("java.io.File", "java.io.IOException")
-                        .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "junit-jupiter-api-5"))
-                        .build()
-                        .apply(updateCursor(cd), cd.getBody().getCoordinates().lastStatement());
-                newFolderMethodDeclaration = ((J.MethodDeclaration) cd.getBody().getStatements().get(cd.getBody().getStatements().size() - 1)).getMethodType();
-                maybeAddImport("java.io.File");
-                maybeAddImport("java.io.IOException");
-            }
-            assert (newFolderMethodDeclaration != null);
-            doAfterVisit(new TranslateNewFolderMethodInvocation(methodInvocation, newFolderMethodDeclaration));
-            return cd;
-        }
-
-        private static class TranslateNewFolderMethodInvocation extends JavaVisitor<ExecutionContext> {
-            J.MethodInvocation methodScope;
-            JavaType.Method newMethodType;
-
-            private JavaParser.Builder<?, ?> javaParser(ExecutionContext ctx) {
-                    return JavaParser.fromJavaVersion()
-                            .classpathFromResources(ctx, "junit-jupiter-api-5");
-            }
-
-            public TranslateNewFolderMethodInvocation(J.MethodInvocation method, JavaType.Method newMethodType) {
-                this.methodScope = method;
-                this.newMethodType = newMethodType;
-            }
-
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                if (!mi.isScope(methodScope)) {
-                    return mi;
-                }
-                if (mi.getSelect() != null) {
-                    J tempDir = mi.getSelect().withType(JavaType.ShallowClass.build("java.io.File"));
-                    List<Expression> args = mi.getArguments().stream().filter(arg -> !(arg instanceof J.Empty)).collect(Collectors.toList());
-                    if (args.isEmpty()) {
-                        mi = JavaTemplate.builder("newFolder(#{any(java.io.File)}, \"junit\")")
-                                .imports("java.io.File")
-                                .javaParser(javaParser(ctx))
-                                .build()
-                                .apply(updateCursor(mi), mi.getCoordinates().replace(), tempDir);
-                    } else if (args.size() == 1) {
-                        mi = JavaTemplate.builder("newFolder(#{any(java.io.File)}, #{any(java.lang.String)})")
-                                .imports("java.io.File")
-                                .javaParser(javaParser(ctx))
-                                .build()
-                                .apply(
-                                        updateCursor(mi),
-                                        mi.getCoordinates().replace(),
-                                        tempDir,
-                                        args.get(0)
-                                );
-                    } else {
-                        final StringBuilder sb = new StringBuilder("newFolder(#{any(java.io.File)}");
-                        args.forEach(arg -> sb.append(", #{any(java.lang.String)}"));
-                        sb.append(")");
-                        List<Object> templateArgs = new ArrayList<>(args);
-                        templateArgs.add(0, tempDir);
-                        mi = JavaTemplate.builder(sb.toString())
-                                .contextSensitive()
-                                .imports("java.io.File")
-                                .javaParser(javaParser(ctx))
-                                .build()
-                                .apply(
-                                        updateCursor(mi),
-                                        mi.getCoordinates().replace(),
-                                        templateArgs.toArray()
-                                );
-                    }
-                    mi = mi.withMethodType(newMethodType);
-                    J.ClassDeclaration parentClass = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).getValue();
-                    mi = mi.withName(mi.getName().withType(parentClass.getType()));
-                }
-                return mi;
-            }
-        }
+        return c;
     }
+
+    @Override
+    public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+        J.VariableDeclarations mv = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+        if (!TypeUtils.isOfClassType(multiVariable.getTypeAsFullyQualified(), temporaryFolder)) {
+            return mv;
+        }
+        mv = mv.withTypeExpression(toFileIdentifier(mv.getTypeExpression()));
+        JavaTemplate template = JavaTemplate.builder("@TempDir").imports(tempDir).javaParser(javaParser(ctx)).build();
+        return (J.VariableDeclarations) annotated("@org.junit.*Rule").asVisitor(a ->
+                        (new JavaIsoVisitor<ExecutionContext>() {
+                            @Override
+                            public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                                return template.apply(updateCursor(annotation), annotation.getCoordinates().replace());
+                            }
+                        }).visit(a.getTree(), ctx, a.getCursor().getParentOrThrow()))
+                .visit(mv, ctx, getCursor().getParentOrThrow());
+    }
+
+    @Override
+    public @Nullable J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+        boolean hasRuleAnnotation = hasRuleAnnotation();
+        if (newTemporaryFolder.matches(newClass)) {
+            if (hasRuleAnnotation) {
+                return null;
+            }
+            return createTempDirTemplate.apply(getCursor(), newClass.getCoordinates().replace());
+        }
+        if (newTemporaryFolderWithArg.matches(newClass)) {
+            if (hasRuleAnnotation) {
+                return null;
+            }
+            return createTempDirTemplateWithArg.apply(getCursor(), newClass.getCoordinates().replace(), newClass.getArguments().get(0));
+        }
+        return super.visitNewClass(newClass, ctx);
+    }
+
+    @Override
+    public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+        updateCursor(mi);
+        if (mi.getSelect() != null && mi.getMethodType() != null &&
+                TypeUtils.isOfClassType(mi.getMethodType().getDeclaringType(), "org.junit.rules.TemporaryFolder")) {
+            switch (mi.getSimpleName()) {
+                case "newFile":
+                    return convertToNewFile(mi, ctx);
+                case "newFolder":
+                    doAfterVisit(new AddNewFolderOrFileMethod(mi, FileOrFolder.FOLDER));
+                    break;
+                case "create":
+                    //noinspection ConstantConditions
+                    return null;
+                case "getRoot":
+                    return mi.getSelect().withPrefix(mi.getPrefix());
+                default:
+                    return mi;
+            }
+        }
+        return mi;
+    }
+
+    private J.Identifier toFileIdentifier(TypeTree typeTree) {
+        JavaType.ShallowClass fileType = JavaType.ShallowClass.build("java.io.File");
+        return new J.Identifier(randomId(), typeTree.getPrefix(), Markers.EMPTY, emptyList(), fileType.getClassName(), fileType, null);
+    }
+
+    private boolean hasRuleAnnotation() {
+        J.VariableDeclarations vd = getCursor().firstEnclosing(J.VariableDeclarations.class);
+        if (vd == null) {
+            return false;
+        }
+        return vd.getLeadingAnnotations().stream().anyMatch(anno -> classRule.matches(anno) || rule.matches(anno));
+    }
+
+    private J convertToNewFile(J.MethodInvocation mi, ExecutionContext ctx) {
+        if (mi.getSelect() == null) {
+            return mi;
+        }
+        List<Expression> args = mi.getArguments().stream().filter(arg -> !(arg instanceof J.Empty)).collect(Collectors.toList());
+        if (args.isEmpty()) {
+            J tempDir = mi.getSelect().withType(JavaType.ShallowClass.build("java.io.File"));
+            return JavaTemplate.builder("File.createTempFile(\"junit\", null, #{any(java.io.File)})")
+                    .imports("java.io.File")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                    .build()
+                    .apply(getCursor(), mi.getCoordinates().replace(), tempDir);
+        }
+
+        doAfterVisit(new AddNewFolderOrFileMethod(mi, FileOrFolder.FILE));
+        return mi;
+    }
+}
+
+@RequiredArgsConstructor
+class AddNewFolderOrFileMethod extends JavaIsoVisitor<ExecutionContext> {
+    private final J.MethodInvocation methodInvocation;
+    private final FileOrFolder fileOrFolder;
+
+    private boolean hasClassType(Statement j, @Nullable String classType) {
+        if (classType == null) {
+            return false;
+        }
+
+        if (!(j instanceof J.VariableDeclarations)) {
+            return false;
+        }
+
+        J.VariableDeclarations variable = (J.VariableDeclarations) j;
+
+        if (variable.getTypeExpression() == null) {
+            return false;
+        }
+
+        return TypeUtils.isOfClassType(variable.getTypeExpression().getType(), classType);
+    }
+
+    @Override
+    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+        JavaType.Method newMethodDeclaration = getMethodDeclaration(cd, fileOrFolder).orElse(null);
+
+        if (newMethodDeclaration == null) {
+            cd = JavaTemplate.builder(fileOrFolder.template)
+                    .contextSensitive()
+                    .imports("java.io.File", "java.io.IOException")
+                    .javaParser(JavaParser.fromJavaVersion()
+                            .classpathFromResources(ctx, "junit-jupiter-api-5"))
+                    .build()
+                    .apply(updateCursor(cd), cd.getBody().getCoordinates().lastStatement());
+            newMethodDeclaration = ((J.MethodDeclaration) cd.getBody().getStatements().get(cd.getBody().getStatements().size() - 1)).getMethodType();
+            maybeAddImport("java.io.File");
+            maybeAddImport("java.io.IOException");
+        }
+        assert (newMethodDeclaration != null);
+        doAfterVisit(new TranslateNewFolderOrFileMethodInvocation(methodInvocation, newMethodDeclaration, fileOrFolder));
+        return cd;
+    }
+
+    private Optional<JavaType.Method> getMethodDeclaration(J.ClassDeclaration cd, FileOrFolder fileOrFolder) {
+        return cd.getBody().getStatements().stream()
+                .filter(J.MethodDeclaration.class::isInstance)
+                .map(J.MethodDeclaration.class::cast)
+                .filter(m -> {
+                    List<Statement> params = m.getParameters();
+                    return fileOrFolder.methodName.equals(m.getSimpleName()) &&
+                            params.size() == 2 &&
+                            hasClassType(params.get(0), "java.io.File") &&
+                            hasClassType(params.get(1), "java.lang.String");
+                }).map(J.MethodDeclaration::getMethodType).filter(Objects::nonNull).findAny();
+    }
+}
+
+@RequiredArgsConstructor
+class TranslateNewFolderOrFileMethodInvocation extends JavaVisitor<ExecutionContext> {
+    final J.MethodInvocation methodScope;
+    final JavaType.Method newMethodType;
+    final FileOrFolder fileOrFolder;
+
+    @Override
+    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+        J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+        if (!mi.isScope(methodScope)) {
+            return mi;
+        }
+        if (mi.getSelect() != null) {
+            mi = fileOrFolder == FileOrFolder.FOLDER ? toNewFolder(mi, ctx) : toNewFile(mi, ctx);
+            mi = mi.withMethodType(newMethodType);
+            J.ClassDeclaration parentClass = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).getValue();
+            mi = mi.withName(mi.getName().withType(parentClass.getType()));
+        }
+        return mi;
+    }
+
+    private J.MethodInvocation toNewFolder(J.MethodInvocation mi, ExecutionContext ctx) {
+        J tempDir = mi.getSelect().withType(JavaType.ShallowClass.build("java.io.File"));
+        List<Expression> args = mi.getArguments().stream().filter(arg -> !(arg instanceof J.Empty)).collect(Collectors.toList());
+        if (args.isEmpty()) {
+            return JavaTemplate.builder("newFolder(#{any(java.io.File)}, \"junit\")")
+                    .imports("java.io.File")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                    .build()
+                    .apply(updateCursor(mi), mi.getCoordinates().replace(), tempDir);
+        }
+
+        if (args.size() == 1) {
+            return JavaTemplate.builder("newFolder(#{any(java.io.File)}, #{any(java.lang.String)})")
+                    .imports("java.io.File")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                    .build()
+                    .apply(
+                            updateCursor(mi),
+                            mi.getCoordinates().replace(),
+                            tempDir,
+                            args.get(0)
+                    );
+        }
+
+        StringBuilder sb = new StringBuilder("newFolder(#{any(java.io.File)}");
+        args.forEach(arg -> sb.append(", #{any(java.lang.String)}"));
+        sb.append(")");
+        List<Object> templateArgs = new ArrayList<>(args);
+        templateArgs.add(0, tempDir);
+        return JavaTemplate.builder(sb.toString())
+                .contextSensitive()
+                .imports("java.io.File")
+                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                .build()
+                .apply(
+                        updateCursor(mi),
+                        mi.getCoordinates().replace(),
+                        templateArgs.toArray()
+                );
+    }
+
+    private J.MethodInvocation toNewFile(J.MethodInvocation mi, ExecutionContext ctx) {
+        J tempDir = mi.getSelect().withType(JavaType.ShallowClass.build("java.io.File"));
+        List<Expression> args = mi.getArguments().stream().filter(arg -> !(arg instanceof J.Empty)).collect(Collectors.toList());
+        if (args.size() != 1) {
+            return mi; // unexpected
+        }
+        return JavaTemplate.builder("newFile(#{any(java.io.File)}, #{any(java.lang.String)})")
+                .imports("java.io.File")
+                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                .build()
+                .apply(updateCursor(mi), mi.getCoordinates().replace(), tempDir, args.get(0));
+    }
+}
+
+@RequiredArgsConstructor
+enum FileOrFolder {
+    FILE("newFile", "private static File newFile(File parent, String child) throws IOException {\n" +
+            "    File result = new File(parent, child);\n" +
+            "    result.createNewFile();\n" +
+            "    return result;\n" +
+            "}"),
+    FOLDER("newFolder", "private static File newFolder(File root, String... subDirs) throws IOException {\n" +
+            "    String subFolder = String.join(\"/\", subDirs);\n" +
+            "    File result = new File(root, subFolder);\n" +
+            "    if(!result.mkdirs()) {\n" +
+            "        throw new IOException(\"Couldn't create folders \" + root);\n" +
+            "    }\n" +
+            "    return result;\n" +
+            "}");
+
+    final String methodName;
+    final String template;
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -16,7 +16,10 @@
 package org.openrewrite.java.testing.junit5;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.*;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -2960,14 +2960,23 @@ examples:
       import org.junit.Rule
       import org.junit.rules.TemporaryFolder
 
+      import java.io.File
+      import java.io.IOException
+
       class AbstractIntegrationTest {
           @TempDir
           File temporaryFolder
 
           def setup() {
               projectDir = temporaryFolder.root
-              buildFile = File.createTempFile('build.gradle', null, temporaryFolder)
-              settingsFile = File.createTempFile('settings.gradle', null, temporaryFolder)
+              buildFile = newFile(temporaryFolder, 'build.gradle')
+              settingsFile = newFile(temporaryFolder, 'settings.gradle')
+          }
+
+          private static File newFile(File parent, String child) throws IOException {
+              File result = new File(parent, child)
+              result.createNewFile()
+              return result
           }
       }
     language: groovy
@@ -3383,25 +3392,6 @@ examples:
 - description: ''
   sources:
   - before: |
-      <project>
-        <modelVersion>4.0.0</modelVersion>
-        <groupId>com.example</groupId>
-        <artifactId>demo</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
-        <dependencies>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>3.11.2</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-      </project>
-    path: pom.xml
-    language: xml
-- description: ''
-  sources:
-  - before: |
       plugins {
           id 'java-library'
       }
@@ -3434,6 +3424,25 @@ examples:
           }
       }
     language: java
+- description: ''
+  sources:
+  - before: |
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>com.example</groupId>
+        <artifactId>demo</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>3.11.2</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+      </project>
+    path: pom.xml
+    language: xml
 ---
 type: specs.openrewrite.org/v1beta/example
 recipeName: org.openrewrite.java.testing.mockito.MockitoBestPractices

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -1008,12 +1008,12 @@ examples:
           }
       }
     after: |
-      import org.junit.jupiter.api.Assertions;
+      import static org.junit.jupiter.api.Assertions.fail;
 
       public class Test {
           void test() {
-              Assertions.fail("assert false true");
-              Assertions.fail("assert true false");
+              fail("assert false true");
+              fail("assert true false");
           }
       }
     language: java

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5BestPracticesTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDirTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDirTest.java
@@ -66,14 +66,23 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
             import org.junit.Rule
             import org.junit.rules.TemporaryFolder
 
+            import java.io.File
+            import java.io.IOException
+
             class AbstractIntegrationTest {
                 @TempDir
                 File temporaryFolder
 
                 def setup() {
                     projectDir = temporaryFolder.root
-                    buildFile = File.createTempFile('build.gradle', null, temporaryFolder)
-                    settingsFile = File.createTempFile('settings.gradle', null, temporaryFolder)
+                    buildFile = newFile(temporaryFolder, 'build.gradle')
+                    settingsFile = newFile(temporaryFolder, 'settings.gradle')
+                }
+
+                private static File newFile(File parent, String child) throws IOException {
+                    File result = new File(parent, child)
+                    result.createNewFile()
+                    return result
                 }
             }
             """
@@ -476,7 +485,13 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
                   @Test
                   public void newNamedFileIsCreatedUnderRootFolder() throws IOException {
                       final String fileName = "SampleFile.txt";
-                      File f = File.createTempFile(fileName, null, tempFolder);
+                      File f = newFile(tempFolder, fileName);
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """
@@ -531,8 +546,14 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
                   public void newNamedFileIsCreatedUnderRootFolder() throws IOException {
                       final String fileName = "SampleFile.txt";
                       final String otherFileName = "otherText.txt";
-                      File f = File.createTempFile(fileName, null, tempFolder);
-                      File f2 = File.createTempFile(otherFileName, null, tempFolder2);
+                      File f = newFile(tempFolder, fileName);
+                      File f2 = newFile(tempFolder2, otherFileName);
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """
@@ -709,12 +730,13 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
           java(
             """
               import java.io.File;
+              import java.io.IOException;
               import org.junit.rules.TemporaryFolder;
               import org.junit.Test;
 
               public class TempDirTest {
                   @Test
-                  void testPath() {
+                  void testPath() throws IOException {
                       TemporaryFolder t = new TemporaryFolder();
                       File f = t.newFile("foo.txt");
                   }
@@ -722,15 +744,22 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
               """,
             """
               import java.io.File;
+              import java.io.IOException;
               import java.nio.file.Files;
 
               import org.junit.Test;
 
               public class TempDirTest {
                   @Test
-                  void testPath() {
+                  void testPath() throws IOException {
                       File t = Files.createTempDirectory("junit").toFile();
-                      File f = File.createTempFile("foo.txt", null, t);
+                      File f = newFile(t, "foo.txt");
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """
@@ -745,12 +774,13 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
           java(
             """
               import java.io.File;
+              import java.io.IOException;
               import org.junit.rules.TemporaryFolder;
               import org.junit.Test;
 
               public class TempDirTest {
                   @Test
-                  void testPath() {
+                  void testPath() throws IOException {
                       TemporaryFolder t = new TemporaryFolder(new File("parent"));
                       t.create();
                       File f = t.newFile("foo.txt");
@@ -759,15 +789,22 @@ class TemporaryFolderToTempDirTest implements RewriteTest {
               """,
             """
               import java.io.File;
+              import java.io.IOException;
               import java.nio.file.Files;
 
               import org.junit.Test;
 
               public class TempDirTest {
                   @Test
-                  void testPath() {
+                  void testPath() throws IOException {
                       File t = Files.createTempDirectory(new File("parent").toPath(), "junit").toFile();
-                      File f = File.createTempFile("foo.txt", null, t);
+                      File f = newFile(t, "foo.txt");
+                  }
+
+                  private static File newFile(File parent, String child) throws IOException {
+                      File result = new File(parent, child);
+                      result.createNewFile();
+                      return result;
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
The TemporaryFolderToTempDir recipe did not correctly handle TemporaryFolder instances that were not annotated with @Rule.
Issue: When the recipe made other changes, the ChangeType incorrectly migrates `new TemporaryFolder()` to `new File()`.

This PR updates the recipe to properly handle TemporaryFolder instances that are not explicitly annotated with @Rule,

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
