### PR TITLE
Fix import ambiguity regression by reordering AddImport/RemoveImport

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/easymock/EasyMockVerifyToMockitoVerify.java
+++ b/src/main/java/org/openrewrite/java/testing/easymock/EasyMockVerifyToMockitoVerify.java
@@ -60,8 +60,8 @@ public class EasyMockVerifyToMockitoVerify extends Recipe {
                     return md;
                 }
 
-                maybeAddImport("org.mockito.Mockito", "verify");
                 maybeRemoveImport("org.easymock.EasyMock.verify");
+                maybeAddImport("org.mockito.Mockito", "verify");
 
                 int idx = 0;
                 for (Statement statement : md.getBody().getStatements()) {

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/AssertThatBooleanToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/AssertThatBooleanToAssertJ.java
@@ -47,8 +47,8 @@ public class AssertThatBooleanToAssertJ extends Recipe {
                 if (ASSERT_THAT_MATCHER.matches(mi)) {
                     Expression reasonArgument = mi.getArguments().get(0);
                     Expression booleanArgument = mi.getArguments().get(1);
-                    maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
                     maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+                    maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
                     return JavaTemplate.builder("assertThat(#{any(boolean)}).as(#{any(String)}).isTrue()")
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
                             .staticImports("org.assertj.core.api.Assertions.assertThat")

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToAssertJ.java
@@ -111,12 +111,12 @@ public class HamcrestMatcherToAssertJ extends Recipe {
                             "org.assertj.core.api.Assertions.assertThat",
                             "org.assertj.core.api.Assertions.within")
                     .build();
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
-            maybeAddImport("org.assertj.core.api.Assertions", "within");
             maybeRemoveImport("org.hamcrest.Matchers." + matcher);
             maybeRemoveImport("org.hamcrest.CoreMatchers." + matcher);
             maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+            maybeAddImport("org.assertj.core.api.Assertions", "within");
 
             List<Expression> templateArguments = new ArrayList<>();
             templateArguments.add(actualArgument);

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestNotMatcherToAssertJ.java
@@ -107,13 +107,13 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
                     .staticImports("org.assertj.core.api.Assertions.assertThat")
                     .build();
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers.not");
             maybeRemoveImport("org.hamcrest.Matchers." + notMatcher);
             maybeRemoveImport("org.hamcrest.CoreMatchers.not");
             maybeRemoveImport("org.hamcrest.CoreMatchers." + notMatcher);
             maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
 
             List<Expression> templateArguments = new ArrayList<>();
             templateArguments.add(actualArgument);
@@ -139,11 +139,11 @@ public class HamcrestNotMatcherToAssertJ extends Recipe {
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
                     .staticImports("org.assertj.core.api.Assertions.assertThat")
                     .build();
-            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
             maybeRemoveImport("org.hamcrest.Matchers.not");
             maybeRemoveImport("org.hamcrest.Matchers." + notMatcher);
             maybeRemoveImport("org.hamcrest.MatcherAssert");
             maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
+            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
 
             List<Expression> templateArguments = new ArrayList<>();
             templateArguments.add(actualArgument);

--- a/src/test/java/org/openrewrite/java/testing/easymock/EasyMockVerifyToMockitoVerifyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/easymock/EasyMockVerifyToMockitoVerifyTest.java
@@ -68,8 +68,8 @@ class EasyMockVerifyToMockitoVerifyTest implements RewriteTest {
               """,
             """
               import static org.easymock.EasyMock.expect;
-              import static org.easymock.EasyMock.createNiceMock;
               import static org.mockito.Mockito.verify;
+              import static org.easymock.EasyMock.createNiceMock;
 
               public class ExampleTest {
                   public void testServiceMethod() {
@@ -126,8 +126,8 @@ class EasyMockVerifyToMockitoVerifyTest implements RewriteTest {
               """,
             """
               import static org.easymock.EasyMock.expect;
-              import static org.easymock.EasyMock.createNiceMock;
               import static org.mockito.Mockito.verify;
+              import static org.easymock.EasyMock.createNiceMock;
 
               public class ExampleTest {
                   public void testServiceMethod() {
@@ -167,8 +167,8 @@ class EasyMockVerifyToMockitoVerifyTest implements RewriteTest {
               """,
             """
               import static org.easymock.EasyMock.expect;
-              import static org.easymock.EasyMock.createNiceMock;
               import static org.mockito.Mockito.verify;
+              import static org.easymock.EasyMock.createNiceMock;
 
               public class ExampleTest {
                   public void testServiceMethod() {
@@ -210,8 +210,8 @@ class EasyMockVerifyToMockitoVerifyTest implements RewriteTest {
               """,
             """
               import static org.easymock.EasyMock.expect;
-              import static org.easymock.EasyMock.createNiceMock;
               import static org.mockito.Mockito.verify;
+              import static org.easymock.EasyMock.createNiceMock;
 
               public class ExampleTest {
                   public void testServiceMethod() {

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestOfMatchersToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestOfMatchersToAssertJTest.java
@@ -59,7 +59,6 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
 
-              import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
@@ -67,7 +66,7 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world")
+                      org.assertj.core.api.Assertions.assertThat("hello world")
                               .satisfies(
                                       arg -> assertThat(arg, equalTo("hello world")),
                                       arg -> assertThat(arg, hasLength(12))
@@ -102,7 +101,6 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
 
-              import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
@@ -110,7 +108,7 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world")
+                      org.assertj.core.api.Assertions.assertThat("hello world")
                               .as("reason")
                               .satisfies(
                                       arg -> assertThat(arg, equalTo("hello world")),
@@ -171,7 +169,6 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
 
-              import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
@@ -179,7 +176,7 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world")
+                      org.assertj.core.api.Assertions.assertThat("hello world")
                               .satisfiesAnyOf(
                                       arg -> assertThat(arg, equalTo("hello world")),
                                       arg -> assertThat(arg, hasLength(12))
@@ -214,7 +211,6 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
 
-              import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
@@ -222,7 +218,7 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world")
+                      org.assertj.core.api.Assertions.assertThat("hello world")
                               .satisfiesAnyOf(
                                       arg -> assertThat(arg, equalTo("hello world")),
                                       arg -> assertThat(arg, hasLength(12)),
@@ -285,7 +281,6 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
             """
               import org.junit.jupiter.api.Test;
 
-              import static org.assertj.core.api.Assertions.assertThat;
               import static org.hamcrest.MatcherAssert.assertThat;
               import static org.hamcrest.Matchers.equalTo;
               import static org.hamcrest.Matchers.hasLength;
@@ -293,7 +288,7 @@ class HamcrestOfMatchersToAssertJTest implements RewriteTest {
               class MyTest {
                   @Test
                   void testMethod() {
-                      assertThat("hello world")
+                      org.assertj.core.api.Assertions.assertThat("hello world")
                               .as("reason")
                               .satisfiesAnyOf(
                                       arg -> assertThat(arg, equalTo("hello world")),

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/MigrateHamcrestToAssertJTest.java
@@ -663,8 +663,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
                   }
                   """,
                 """
-                  import static org.assertj.core.api.Assertions.assertThat;
                   import java.math.BigDecimal;
+
+                  import static org.assertj.core.api.Assertions.assertThat;
 
                   class A {
                       void foo() {
@@ -709,9 +710,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               }
               """,
             """
-              import static org.assertj.core.api.Assertions.assertThat;
-
               import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
 
               class DebugTest {
                   class Foo {
@@ -753,9 +754,9 @@ class MigrateHamcrestToAssertJTest implements RewriteTest {
               }
               """,
             """
-              import static org.assertj.core.api.Assertions.assertThat;
-
               import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
 
               class DebugTest {
                   @Test

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -541,7 +541,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
 
               public class MyTest {
-                  @org.junit.jupiter.api.Test
+                  @Test
                   public void feature1() {
                   }
               }
@@ -571,7 +571,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
 
               public class MyTest {
-                  @org.junit.jupiter.api.Test
+                  @Test
                   public void feature1() {
                   }
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
@@ -60,7 +60,7 @@ class UseXMLUnitLegacyTest implements RewriteTest {
                     <dependency>
                       <groupId>org.xmlunit</groupId>
                       <artifactId>xmlunit-legacy</artifactId>
-                      <version>2.10.0</version>
+                      <version>2.10.1</version>
                     </dependency>
                   </dependencies>
                 </project>


### PR DESCRIPTION
## What's changed?
PR [#5439](https://github.com/openrewrite/rewrite/pull/5439) introduced logic to detect and handle import ambiguity when adding imports. However, this caused some tests to fail due to the order in which imports were being added and removed in some recipes. When new imports were added before the old ones were removed, this led to false positives for ambiguity, resulting in the use of fully qualified names.

This PR addresses the issue by reordering the maybeAddImport and maybeRemoveImport call. Now maybeRemoveImport precedes the maybeAddImport, to avoid premature ambiguity detection. 
Additionally, some unit tests contained genuinely ambiguous imports that went undetected earlier. Fixed those test to align with the improved import resolution logic.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
