### PR TITLE
Added support for generic instanceof checks in `AssertTrueInstanceofToAssertInstanceOf` recipe

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -95,15 +95,16 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
 
 
                 JavaTemplate template = JavaTemplate
-                    .builder("assertInstanceOf(#{}.class, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
+                    .builder("assertInstanceOf(#{any(java.lang.Object)}.class, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"))
                     .staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf")
                     .imports(String.valueOf(clazz.getType()))
                     .build();
 
+                J rawClazz = clazz instanceof J.ParameterizedType ? ((J.ParameterizedType) clazz).getClazz() : clazz;
                 J.MethodInvocation methodd = reason != null ?
-                    template.apply(getCursor(), mi.getCoordinates().replace(), clazz.toString(), expression, reason) :
-                    template.apply(getCursor(), mi.getCoordinates().replace(), clazz.toString(), expression);
+                    template.apply(getCursor(), mi.getCoordinates().replace(), rawClazz, expression, reason) :
+                    template.apply(getCursor(), mi.getCoordinates().replace(), rawClazz, expression);
                 maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
                 return methodd;
             }

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -185,4 +185,42 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               """
           ));
     }
+
+    @Test
+    void jUnit4GenericInstanceOf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import static org.junit.Assert.assertTrue;
+
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertTrue(list instanceof List<?>);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  @Test
+                  void testJUnit5() {
+                      List<String> list = new ArrayList<>();
+                      assertInstanceOf(List.class, list);
+                  }
+              }
+              """
+          ));
+    }
 }


### PR DESCRIPTION
## What's changed?
Added support for generic instanceof checks in `AssertTrueInstanceofToAssertInstanceOf` recipe

## What's your motivation?
The recipe threw parsing errors.

## Have you considered any alternatives or workarounds?
I've changed the recipe to support `assertTrue(list instanceof List<?>);` and change it to `assertInstanceOf(List.class, list);`.

Another option would be to ignore the breaking instance check, but I don't think the generic has any functional meaning.
