### PR TITLE
Add Rewrite Recipe to replace AssertJ hasCauseReference with cause

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/ReplaceHasCauseReferenceWithCause.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/ReplaceHasCauseReferenceWithCause.java
@@ -1,0 +1,52 @@
+package org.openrewrite.java.testing.assertj;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+
+public class ReplaceHasCauseReferenceWithCause extends Recipe {
+
+    private static final MethodMatcher HAS_CAUSE_REFERENCE_MATCHER =
+            new MethodMatcher("org.assertj.core.api.AbstractThrowableAssert hasCauseReference(java.lang.Throwable)");
+
+    @Override
+    public String getDisplayName() {
+        return "Replace AssertJ `hasCauseReference()` with `cause().isEqualTo()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces AssertJ `hasCauseReference(Throwable)` with `cause().isEqualTo(Throwable)` for better chaining.";
+    }
+
+    @Override
+    protected JavaIsoVisitor<ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            private JavaTemplate template(ExecutionContext ctx) {
+                return JavaTemplate.builder(this::getCursor, "cause().isEqualTo(#{any(java.lang.Throwable)})")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
+                    .build();
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if (HAS_CAUSE_REFERENCE_MATCHER.matches(m)) {
+                    if (m.getSelect() == null) {
+                        return m; // Should not happen with AssertJ fluent assertions
+                    }
+                    maybeAddImport("org.assertj.core.api.Assertions");
+                    maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                    m = m.withTemplate(template(ctx),
+                            m.getCoordinates().replace(),
+                            m.getArguments().get(0));
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/assertj/ReplaceHasCauseReferenceWithCauseTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/ReplaceHasCauseReferenceWithCauseTest.java
@@ -1,0 +1,88 @@
+package org.openrewrite.java.testing.assertj;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceHasCauseReferenceWithCauseTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceHasCauseReferenceWithCause())
+            .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "assertj-core-3"));
+    }
+
+    @Test
+    @DocumentExample
+    void replaceHasCauseReference() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class MyTest {
+                  @Test
+                  void test() {
+                      Throwable cause = new RuntimeException("cause");
+                      Throwable actual = new RuntimeException("actual", cause);
+                      assertThat(actual).hasCauseReference(cause);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class MyTest {
+                  @Test
+                  void test() {
+                      Throwable cause = new RuntimeException("cause");
+                      Throwable actual = new RuntimeException("actual", cause);
+                      assertThat(actual).cause().isEqualTo(cause);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceHasCauseReferenceWithNewInstance() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class MyTest {
+                  @Test
+                  void test() {
+                      Throwable actual = new RuntimeException("actual", new RuntimeException("specific cause"));
+                      assertThat(actual).hasCauseReference(new RuntimeException("specific cause"));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.assertj.core.api.Assertions.assertThat;
+              
+              class MyTest {
+                  @Test
+                  void test() {
+                      Throwable actual = new RuntimeException("actual", new RuntimeException("specific cause"));
+                      assertThat(actual).cause().isEqualTo(new RuntimeException("specific cause"));
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
This commit introduces a new OpenRewrite recipe that replaces the AssertJ method `hasCauseReference(Throwable)` with `cause().isEqualTo(Throwable)`.

The `hasCauseReference()` method was deprecated in AssertJ 3.27.1 in favor of using `cause()` for better assertion chaining, as discussed in assertj/assertj#3715.

The recipe includes:
- `ReplaceHasCauseReferenceWithCause.java`: The core recipe logic.
- `ReplaceHasCauseReferenceWithCauseTest.java`: Unit tests to verify the transformation, including a documented example and a case where the expected cause is a new instance.

The recipe correctly handles the transformation and updates imports as necessary.