### PR TITLE
Do not ever exclude junit if Testcontainers is used

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -102,21 +102,7 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: junit
       artifactId: junit
-  - org.openrewrite.maven.ExcludeDependency:
-      groupId: junit
-      artifactId: junit
-  # Workaround for https://github.com/testcontainers/testcontainers-java/issues/970:
-  - org.openrewrite.maven.RemoveExclusion:
-      groupId: org.testcontainers
-      artifactId: '*'
-      exclusionGroupId: junit
-      exclusionArtifactId: junit
-  # Similar for https://github.com/openrewrite/rewrite-testing-frameworks/issues/477
-  - org.openrewrite.maven.RemoveExclusion:
-      groupId: org.springframework.boot
-      artifactId: spring-boot-testcontainers
-      exclusionGroupId: junit
-      exclusionArtifactId: junit
+  - org.openrewrite.java.testing.junit5.ExcludeJUnit4IfNoTestcontainers
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.junit.vintage
       artifactId: junit-vintage-engine
@@ -145,7 +131,17 @@ recipeList:
       newFullyQualifiedTypeName: org.jbehave.core.junit.JupiterStories
   - org.openrewrite.java.testing.arquillian.ArquillianJUnit4ToArquillianJUnit5
   - org.openrewrite.java.testing.dbrider.MigrateDbRiderSpringToDbRiderJUnit5
-
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.testing.junit5.ExcludeJUnit4IfNoTestcontainers
+preconditions:
+  - org.openrewrite.maven.search.DoesNotIncludeDependency:
+      groupId: org.testcontainers
+      artifactId: '*'
+recipeList:
+  - org.openrewrite.maven.ExcludeDependency:
+      groupId: junit
+      artifactId: junit
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.UseHamcrestAssertThat

--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -102,7 +102,7 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: junit
       artifactId: junit
-  - org.openrewrite.java.testing.junit5.ExcludeJUnit4IfNoTestcontainers
+  - org.openrewrite.java.testing.junit5.ExcludeJUnit4UnlessUsingTestcontainers
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.junit.vintage
       artifactId: junit-vintage-engine
@@ -133,7 +133,9 @@ recipeList:
   - org.openrewrite.java.testing.dbrider.MigrateDbRiderSpringToDbRiderJUnit5
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: org.openrewrite.java.testing.junit5.ExcludeJUnit4IfNoTestcontainers
+name: org.openrewrite.java.testing.junit5.ExcludeJUnit4UnlessUsingTestcontainers
+displayName: Exclude JUnit 4, unless Testcontainers is used
+description: Excludes JUnit 4, as it ought not to be necessary in a JUnit 5 project, unless Testcontainers is used.
 preconditions:
   - org.openrewrite.maven.search.DoesNotIncludeDependency:
       groupId: org.testcontainers

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -162,157 +162,165 @@ class JUnit5MigrationTest implements RewriteTest {
         // Just using play-test_2.13 as an example because it appears to still depend on junit.
         // In practice, this would probably just break it, I assume.
         //language=xml
-        String before = """
-          <project>
-              <modelVersion>4.0.0</modelVersion>
-              <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.2.1</version>
-                  <relativePath/> <!-- lookup parent from repository -->
-              </parent>
-              <groupId>dev.ted</groupId>
-              <artifactId>needs-exclusion</artifactId>
-              <version>0.0.1</version>
-              <dependencies>
-                  <dependency>
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
                       <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-starter</artifactId>
-                  </dependency>
-                  <dependency>
-                      <groupId>com.typesafe.play</groupId>
-                      <artifactId>play-test_2.13</artifactId>
-                      <version>2.9.6</version>
-                      <scope>test</scope>
-                  </dependency>
-              </dependencies>
-          </project>
-          """;
-        //language=xml
-        String after = """
-          <project>
-              <modelVersion>4.0.0</modelVersion>
-              <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.2.1</version>
-                  <relativePath/> <!-- lookup parent from repository -->
-              </parent>
-              <groupId>dev.ted</groupId>
-              <artifactId>needs-exclusion</artifactId>
-              <version>0.0.1</version>
-              <dependencies>
-                  <dependency>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>3.2.1</version>
+                      <relativePath/> <!-- lookup parent from repository -->
+                  </parent>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>needs-exclusion</artifactId>
+                  <version>0.0.1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter</artifactId>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.typesafe.play</groupId>
+                          <artifactId>play-test_2.13</artifactId>
+                          <version>2.9.6</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
                       <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-starter</artifactId>
-                  </dependency>
-                  <dependency>
-                      <groupId>com.typesafe.play</groupId>
-                      <artifactId>play-test_2.13</artifactId>
-                      <version>2.9.6</version>
-                      <scope>test</scope>
-                      <exclusions>
-                          <exclusion>
-                              <groupId>junit</groupId>
-                              <artifactId>junit</artifactId>
-                          </exclusion>
-                      </exclusions>
-                  </dependency>
-              </dependencies>
-          </project>
-          """;
-        rewriteRun(pomXml(before, after));
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>3.2.1</version>
+                      <relativePath/> <!-- lookup parent from repository -->
+                  </parent>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>needs-exclusion</artifactId>
+                  <version>0.0.1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter</artifactId>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.typesafe.play</groupId>
+                          <artifactId>play-test_2.13</artifactId>
+                          <version>2.9.6</version>
+                          <scope>test</scope>
+                          <exclusions>
+                              <exclusion>
+                                  <groupId>junit</groupId>
+                                  <artifactId>junit</artifactId>
+                              </exclusion>
+                          </exclusions>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
     void dontExcludeJunit4DependencyFromTestcontainers() {
         //language=xml
-        String before = """
-          <project>
-              <modelVersion>4.0.0</modelVersion>
-              <groupId>com.example.jackson</groupId>
-              <artifactId>test-plugins</artifactId>
-              <version>1.0.0</version>
-              <dependencies>
-                  <dependency>
-                      <groupId>org.testcontainers</groupId>
-                      <artifactId>testcontainers</artifactId>
-                      <version>1.18.3</version>
-                      <scope>test</scope>
-                  </dependency>
-              </dependencies>
-          </project>
-          """;
-        // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.jackson</groupId>
+                  <artifactId>test-plugins</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.testcontainers</groupId>
+                          <artifactId>testcontainers</artifactId>
+                          <version>1.18.3</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
     void dontExcludeJunit4DependencyFromTestcontainersJupiter() {
         //language=xml
-        String before = """
-          <project>
-              <modelVersion>4.0.0</modelVersion>
-              <groupId>com.example.jackson</groupId>
-              <artifactId>test-plugins</artifactId>
-              <version>1.0.0</version>
-              <dependencies>
-                  <dependency>
-                      <groupId>org.testcontainers</groupId>
-                      <artifactId>junit-jupiter</artifactId>
-                      <version>1.18.3</version>
-                      <scope>test</scope>
-                  </dependency>
-              </dependencies>
-          </project>
-          """;
-        // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before));
+        rewriteRun(
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example.jackson</groupId>
+                  <artifactId>test-plugins</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.testcontainers</groupId>
+                          <artifactId>junit-jupiter</artifactId>
+                          <version>1.18.3</version>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/477")
     void dontExcludeJunit4DependencyFromSpringBootTestcontainers() {
-        //language=xml
-        String before = """
-          <project>
-              <modelVersion>4.0.0</modelVersion>
-              <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.2.1</version>
-                  <relativePath/> <!-- lookup parent from repository -->
-              </parent>
-              <groupId>dev.ted</groupId>
-              <artifactId>testcontainer-migrate</artifactId>
-              <version>0.0.1</version>
-              <dependencies>
-                  <dependency>
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
                       <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-starter</artifactId>
-                  </dependency>
-                  <dependency>
-                      <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-starter-test</artifactId>
-                      <scope>test</scope>
-                  </dependency>
-                  <dependency>
-                      <groupId>org.springframework.boot</groupId>
-                      <artifactId>spring-boot-testcontainers</artifactId>
-                      <scope>test</scope>
-                  </dependency>
-                  <dependency>
-                      <groupId>org.testcontainers</groupId>
-                      <artifactId>junit-jupiter</artifactId>
-                      <scope>test</scope>
-                  </dependency>
-              </dependencies>
-          </project>
-          """;
-        // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before));
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>3.2.1</version>
+                      <relativePath/> <!-- lookup parent from repository -->
+                  </parent>
+                  <groupId>dev.ted</groupId>
+                  <artifactId>testcontainer-migrate</artifactId>
+                  <version>0.0.1</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter</artifactId>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-starter-test</artifactId>
+                          <scope>test</scope>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.springframework.boot</groupId>
+                          <artifactId>spring-boot-testcontainers</artifactId>
+                          <scope>test</scope>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.testcontainers</groupId>
+                          <artifactId>junit-jupiter</artifactId>
+                          <scope>test</scope>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """
+          )
+        );
     }
 
     // edge case for deprecated use of assertEquals

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -158,8 +158,75 @@ class JUnit5MigrationTest implements RewriteTest {
     }
 
     @Test
+    void excludeJunit4Dependency() {
+        // Just using play-test_2.13 as an example because it appears to still depend on junit.
+        // In practice, this would probably just break it, I assume.
+        //language=xml
+        String before = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.2.1</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+              </parent>
+              <groupId>dev.ted</groupId>
+              <artifactId>needs-exclusion</artifactId>
+              <version>0.0.1</version>
+              <dependencies>
+                  <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter</artifactId>
+                  </dependency>
+                  <dependency>
+                      <groupId>com.typesafe.play</groupId>
+                      <artifactId>play-test_2.13</artifactId>
+                      <version>2.9.6</version>
+                      <scope>test</scope>
+                  </dependency>
+              </dependencies>
+          </project>
+          """;
+        //language=xml
+        String after = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <parent>
+                  <groupId>org.springframework.boot</groupId>
+                  <artifactId>spring-boot-starter-parent</artifactId>
+                  <version>3.2.1</version>
+                  <relativePath/> <!-- lookup parent from repository -->
+              </parent>
+              <groupId>dev.ted</groupId>
+              <artifactId>needs-exclusion</artifactId>
+              <version>0.0.1</version>
+              <dependencies>
+                  <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter</artifactId>
+                  </dependency>
+                  <dependency>
+                      <groupId>com.typesafe.play</groupId>
+                      <artifactId>play-test_2.13</artifactId>
+                      <version>2.9.6</version>
+                      <scope>test</scope>
+                      <exclusions>
+                          <exclusion>
+                              <groupId>junit</groupId>
+                              <artifactId>junit</artifactId>
+                          </exclusion>
+                      </exclusions>
+                  </dependency>
+              </dependencies>
+          </project>
+          """;
+        rewriteRun(pomXml(before, after));
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
-    void dontExcludeJunit4DependencyfromTestcontainers() {
+    void dontExcludeJunit4DependencyFromTestcontainers() {
         //language=xml
         String before = """
           <project>
@@ -178,12 +245,12 @@ class JUnit5MigrationTest implements RewriteTest {
           </project>
           """;
         // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before, before));
+        rewriteRun(pomXml(before));
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
-    void dontExcludeJunit4DependencyfromTestcontainersJupiter() {
+    void dontExcludeJunit4DependencyFromTestcontainersJupiter() {
         //language=xml
         String before = """
           <project>
@@ -202,12 +269,12 @@ class JUnit5MigrationTest implements RewriteTest {
           </project>
           """;
         // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before, before));
+        rewriteRun(pomXml(before));
     }
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/477")
-    void dontExcludeJunit4DependencyfromSpringBootTestcontainers() {
+    void dontExcludeJunit4DependencyFromSpringBootTestcontainers() {
         //language=xml
         String before = """
           <project>
@@ -245,7 +312,7 @@ class JUnit5MigrationTest implements RewriteTest {
           </project>
           """;
         // Output identical, but we want to make sure we don't exclude junit4 from testcontainers
-        rewriteRun(pomXml(before, before));
+        rewriteRun(pomXml(before));
     }
 
     // edge case for deprecated use of assertEquals


### PR DESCRIPTION
## What's changed?
Instead of adding the JUnit 4 exclusion to all dependencies and then removing it from specific ones that depend on Testcontainers, just don’t add the exclusion when Testcontainers is used.

## What's your motivation?
We have implemented some test libraries that (transitively) depend on Testcontainers. When (indirectly) running the JUnit 5 migration recipe, it always adds the junit exclusion on those, which breaks the build. This forces us to un-exclude JUnit 4 as a followup recipe.

## Have you considered any alternatives or workarounds?
Current workaround is to remove the exclusion explicitly for all dependencies after JUnit 5 migration:
```yml
  - org.openrewrite.maven.RemoveExclusion:
      groupId: '*'
      artifactId: '*'
      exclusionGroupId: junit
      exclusionArtifactId: junit
```

## Any additional context
This makes the recipe more conservative. If a project transitively depends on Testcontainers, it won’t add the exclusion to dependencies that do not depend on Testcontainers (but still depend on JUnit 4) but that’s ok since exclusions have to be added everywhere to work properly.

This provides a more generic solution to #429 and #477.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
