### PR TITLE
Migrate Traits class usage to constructor calls

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/EnvironmentVariables.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/EnvironmentVariables.java
@@ -21,12 +21,12 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
+import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.*;
 
 import static java.util.Comparator.comparing;
 import static org.openrewrite.java.testing.junit5.Junit4Utils.CLASS_RULE;
 import static org.openrewrite.java.testing.junit5.Junit4Utils.RULE;
-import static org.openrewrite.java.trait.Traits.annotated;
 
 /**
  * A recipe to replace JUnit 4's EnvironmentVariables rule from contrib with the JUnit 5-compatible
@@ -97,7 +97,7 @@ public class EnvironmentVariables extends Recipe {
             if (variableDecls.getType() == null || !TypeUtils.isAssignableTo(ENVIRONMENT_VARIABLES, variableDecls.getType())) {
                 return variableDecls;
             }
-            J.VariableDeclarations vd = (J.VariableDeclarations) annotated("@org.junit.*Rule").asVisitor(a ->
+            J.VariableDeclarations vd = (J.VariableDeclarations) new Annotated.Matcher("@org.junit.*Rule").asVisitor(a ->
                             (new JavaIsoVisitor<ExecutionContext>() {
                                 @Override
                                 public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/JUnitParamsRunnerToParameterized.java
@@ -23,7 +23,6 @@ import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.trait.Literal;
-import org.openrewrite.java.trait.Traits;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -111,7 +110,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
             J.Annotation anno = super.visitAnnotation(annotation, ctx);
             Cursor classDeclCursor = getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance);
             if (PARAMETERS_MATCHER.matches(anno)) {
-                Annotated annotated = Traits.annotated(PARAMETERS_MATCHER).require(annotation, getCursor().getParentOrThrow());
+                Annotated annotated = new Annotated.Matcher(PARAMETERS_MATCHER).require(annotation, getCursor().getParentOrThrow());
                 String annotationArgumentValue = getAnnotationArgumentForInitMethod(annotated, "method", "named");
                 classDeclCursor.computeMessageIfAbsent(PARAMETERIZED_TESTS, v -> new HashSet<>())
                         .add(getCursor().firstEnclosing(J.MethodDeclaration.class).getSimpleName());
@@ -135,7 +134,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
                     unsupportedMethods.add(junitParamsDefaultInitMethodName(m.getSimpleName()));
                 }
             } else if (NAMED_PARAMETERS_MATCHER.matches(annotation)) {
-                Annotated annotated = Traits.annotated(NAMED_PARAMETERS_MATCHER).require(annotation, getCursor().getParentOrThrow());
+                Annotated annotated = new Annotated.Matcher(NAMED_PARAMETERS_MATCHER).require(annotation, getCursor().getParentOrThrow());
                 Optional<Literal> value = annotated.getDefaultAttribute("value");
                 if (value.isPresent()) {
                     J.MethodDeclaration m = getCursor().dropParentUntil(J.MethodDeclaration.class::isInstance).getValue();
@@ -143,7 +142,7 @@ public class JUnitParamsRunnerToParameterized extends Recipe {
                     classDeclCursor.computeMessageIfAbsent(INIT_METHODS_MAP, v -> new HashMap<>()).put(value.get().getString(), m.getSimpleName());
                 }
             } else if (TEST_CASE_NAME_MATCHER.matches(anno)) {
-                Annotated annotated = Traits.annotated(TEST_CASE_NAME_MATCHER).require(annotation, getCursor().getParentOrThrow());
+                Annotated annotated = new Annotated.Matcher(TEST_CASE_NAME_MATCHER).require(annotation, getCursor().getParentOrThrow());
                 // test name for ParameterizedTest argument
                 Optional<Literal> value = annotated.getDefaultAttribute("value");
                 if (value.isPresent()) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TemporaryFolderToTempDir.java
@@ -23,6 +23,7 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -34,7 +35,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
-import static org.openrewrite.java.trait.Traits.annotated;
 
 public class TemporaryFolderToTempDir extends Recipe {
 
@@ -89,7 +89,7 @@ class TemporaryFolderToTempDirVisitor extends JavaVisitor<ExecutionContext> {
             return mv;
         }
         mv = mv.withTypeExpression(toFileIdentifier(mv.getTypeExpression()));
-        return (J.VariableDeclarations) annotated("@org.junit.*Rule")
+        return (J.VariableDeclarations) new Annotated.Matcher("@org.junit.*Rule")
                 .asVisitor(a -> JavaTemplate.builder("@TempDir")
                         .imports(TEMP_DIR)
                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))

--- a/src/main/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocks.java
@@ -21,6 +21,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -35,7 +36,6 @@ import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.java.VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER;
 import static org.openrewrite.java.VariableNameUtils.generateVariableName;
-import static org.openrewrite.java.trait.Traits.annotated;
 
 /**
  * Ensures that all mockStatic calls are properly closed.
@@ -100,7 +100,7 @@ public class CloseUnclosedStaticMocks extends Recipe {
         @Override
         public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             Cursor cursor = getCursor();
-            annotated("@org.junit.jupiter.api.*").asVisitor(a -> {
+            new Annotated.Matcher("@org.junit.jupiter.api.*").asVisitor(a -> {
                 String annotationName = a.getTree().getSimpleName();
                 if (annotationName.startsWith("Before")) {
                     cursor.putMessage(MethodType.class.getSimpleName(), MethodType.LIFECYCLE);
@@ -333,7 +333,7 @@ public class CloseUnclosedStaticMocks extends Recipe {
                 return md;
             }
             AnnotationMatcher annotationMatcher = isStatic ? AFTER_ALL_MATCHER : AFTER_EACH_MATCHER;
-            boolean matched = annotated(annotationMatcher).<AtomicBoolean>asVisitor((a, found) -> {
+            boolean matched = new Annotated.Matcher(annotationMatcher).<AtomicBoolean>asVisitor((a, found) -> {
                 found.set(true);
                 return a.getTree();
             }).reduce(md, new AtomicBoolean()).get();

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.testing.junit5.RunnerToExtension;
+import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -31,8 +32,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.openrewrite.java.trait.Traits.annotated;
 
 public class MockitoJUnitRunnerToExtension extends Recipe {
     @Override
@@ -57,7 +56,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 AtomicReference<Strictness> strictness = new AtomicReference<>();
-                annotated(runWith).<AtomicReference<Strictness>>asVisitor((a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
+                new Annotated.Matcher(runWith).<AtomicReference<Strictness>>asVisitor((a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
                     @Override
                     public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
                         for (Strictness strict : Strictness.values()) {


### PR DESCRIPTION
## What's changed?
remove `Traits` factory method usage.

## What's your motivation?
See https://github.com/openrewrite/rewrite-rewrite/pull/16
