### PR TITLE
refactor: Adopt `J.Literal.isLiteralValue(expression, null)`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseNullToAssertNotNull.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseNullToAssertNotNull.java
@@ -113,8 +113,8 @@ public class AssertFalseNullToAssertNotNull extends Recipe {
                 if (binary.getOperator() != J.Binary.Type.Equal) {
                     return false;
                 }
-                return binary.getLeft() instanceof J.Literal && ((J.Literal) binary.getLeft()).getValue() == null ||
-                       binary.getRight() instanceof J.Literal && ((J.Literal) binary.getRight()).getValue() == null;
+                return J.Literal.isLiteralValue(binary.getLeft(), null) ||
+                        J.Literal.isLiteralValue(binary.getRight(), null);
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNull.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNull.java
@@ -113,8 +113,8 @@ public class AssertTrueNullToAssertNull extends Recipe {
                 if (binary.getOperator() != J.Binary.Type.Equal) {
                     return false;
                 }
-                return binary.getLeft() instanceof J.Literal && ((J.Literal) binary.getLeft()).getValue() == null ||
-                       binary.getRight() instanceof J.Literal && ((J.Literal) binary.getRight()).getValue() == null;
+                return J.Literal.isLiteralValue(binary.getLeft(), null) ||
+                        J.Literal.isLiteralValue(binary.getRight(), null);
             }
         });
     }


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.recipes.IsLiteralNullRecipe?organizationId=ODQ2MGExMTUtNDg0My00N2EwLTgzMGMtNGE1NGExMTBmZDkw