### PR TITLE
xmlunit 2.10.3

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
@@ -60,7 +60,7 @@ class UseXMLUnitLegacyTest implements RewriteTest {
                     <dependency>
                       <groupId>org.xmlunit</groupId>
                       <artifactId>xmlunit-legacy</artifactId>
-                      <version>2.10.2</version>
+                      <version>2.10.3</version>
                     </dependency>
                   </dependencies>
                 </project>


### PR DESCRIPTION
## What's changed?

Bumping the xmlunit-legacy version to `2.10.3` in one of the tests.

## What's your motivation?

CI is failing:
```
UseXMLUnitLegacyTest > shouldMigrateMavenDependency() FAILED
```
after https://central.sonatype.com/artifact/org.xmlunit/xmlunit-legacy/2.10.3 got released.
