### PR TITLE
Fix for JUnit test method throws clause preservation

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -585,6 +585,63 @@ class UpdateTestAnnotationTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/754")
+    void preserveThrowsClauseForOtherExceptions() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import java.io.IOException;
+
+              public class MyTest {
+
+                  @Test(expected = IllegalArgumentException.class)
+                  public void testWithMultipleThrows() throws IOException, Exception {
+                      foo();
+                      bar();
+                  }
+
+                  void foo() throws IOException {
+                      // might throw IOException
+                  }
+                  
+                  void bar() throws IllegalArgumentException {
+                      throw new IllegalArgumentException("boom");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import java.io.IOException;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testWithMultipleThrows() throws IOException, Exception {
+                      assertThrows(IllegalArgumentException.class, () -> {
+                          foo();
+                          bar();
+                      });
+                  }
+
+                  void foo() throws IOException {
+                      // might throw IOException
+                  }
+                  
+                  void bar() throws IllegalArgumentException {
+                      throw new IllegalArgumentException("boom");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/563")
     void removeThrowsCheckedException() {
         //language=java


### PR DESCRIPTION
When transforming `@Test(expected = SomeException.class)` to JUnit 5's `assertThrows()`, the recipe now preserves throws clauses for exceptions other than the one being tested.

Changes made:

- Modified `UpdateTestAnnotation` to selectively remove only the exception type being tested from the throws clause
- Added logic to identify and preserve other declared exceptions in the method signature
- Added test case to verify throws clauses are preserved for non-tested exceptions

The fix ensures that methods declaring multiple thrown exceptions maintain proper signatures after transformation.

Fixes:
- #754

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
