### PR TITLE
Adding functionality to `MockitoWhenOnStaticToMockStatic` for recognizing an existing try-with-resources `MockedStatic<T>` can be reused instead of creating a new one.

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -16,22 +16,15 @@
 package org.openrewrite.java.testing.mockito;
 
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.Preconditions;
-import org.openrewrite.Recipe;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static org.openrewrite.java.VariableNameUtils.GenerationStrategy.INCREMENT_NUMBER;
 import static org.openrewrite.java.VariableNameUtils.generateVariableName;
@@ -100,6 +93,10 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                     if (whenArg != null) {
                         String className = getClassName(whenArg);
                         if (className != null) {
+                            Optional<String> nameOfWrappingMockedStatic = tryGetMatchedWrappingResourceName(getCursor(), className);
+                            if (nameOfWrappingMockedStatic.isPresent()) {
+                                return reuseMockedStatic(block, (J.MethodInvocation) statement, nameOfWrappingMockedStatic.get(), whenArg, ctx);
+                            }
                             restInTry.set(true);
                             return tryWithMockedStatic(block, statements, index, (J.MethodInvocation) statement, className, whenArg, ctx);
                         }
@@ -155,7 +152,13 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                         .withPrefix(statement.getPrefix());
             }
 
-            private List<Statement> mockedStatic(J.Block block, J.MethodInvocation statement,  String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
+            private Statement reuseMockedStatic(J.Block block, J.MethodInvocation statement, String variableName, J.MethodInvocation whenArg, ExecutionContext ctx) {
+                return javaTemplateMockStatic(String.format("%1$s.when(() -> #{any()}).thenReturn(#{any()});", variableName), ctx)
+                        .<J.Block>apply(getCursor(), block.getCoordinates().firstStatement(), whenArg, statement.getArguments().get(0))
+                        .getStatements().get(0);
+            }
+
+            private List<Statement> mockedStatic(J.Block block, J.MethodInvocation statement, String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
                 boolean staticSetup = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE_CLASS);
                 String variableName = generateVariableName("mock" + className + ++varCounter, updateCursor(block), INCREMENT_NUMBER);
                 Expression thenReturnArg = statement.getArguments().get(0);
@@ -225,6 +228,34 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                         .build();
             }
         });
+    }
+
+    private static List<J.Try.Resource> getMatchingFilteredResources(@Nullable List<J.Try.Resource> resources, String className) {
+        if (resources != null) {
+            return resources.stream().filter(res -> {
+                J.VariableDeclarations vds = (J.VariableDeclarations) res.getVariableDeclarations();
+                return TypeUtils.isAssignableTo("org.mockito.MockedStatic<" + className + ">", vds.getTypeAsFullyQualified());
+            }).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    private static Optional<String> tryGetMatchedWrappingResourceName(Cursor cursor, String className) {
+        try {
+            Cursor foundParentCursor = cursor.dropParentUntil(val -> {
+                if (val instanceof J.Try) {
+                    List<J.Try.Resource> filteredResources = getMatchingFilteredResources(((J.Try) val).getResources(), className);
+                    return !filteredResources.isEmpty();
+                }
+                return false;
+            });
+            return getMatchingFilteredResources(((J.Try) foundParentCursor.getValue()).getResources(), className)
+                    .stream()
+                    .findFirst()
+                    .map(res -> ((J.VariableDeclarations) res.getVariableDeclarations()).getVariables().get(0).getSimpleName());
+        } catch (IllegalStateException e) {
+            return Optional.empty();
+        }
     }
 
     private static boolean isMethodDeclarationWithAnnotation(@Nullable Statement statement, AnnotationMatcher... matchers) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -28,12 +28,24 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
     //language=java
     public static final SourceSpecs CLASS_A = java(
       """
-      public class A {
-          public static Integer getNumber() {
-              return 42;
-         }
-      }
-      """,
+        public class A {
+            public static Integer getNumber() {
+                return 42;
+           }
+        }
+        """,
+      SourceSpec::skip
+    );
+
+    //language=java
+    public static final SourceSpecs CLASS_B = java(
+      """
+        public class B {
+            public static String getString() {
+                return "";
+           }
+        }
+        """,
       SourceSpec::skip
     );
 
@@ -80,6 +92,56 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
                       try (MockedStatic<A> mockA1 = mockStatic(A.class)) {
                           mockA1.when(() -> A.getNumber()).thenReturn(-1);
                           assertEquals(A.getNumber(), -1);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldOptForUsageOfMockedStatic_WhenAlreadyScopedInside() {
+        //language=java
+        rewriteRun(
+          spec -> spec.afterTypeValidationOptions(TypeValidation.builder().identifiers(false).build()),
+          CLASS_A,
+          CLASS_B,
+          java(
+            """
+              import org.mockito.MockedStatic;
+
+              import static org.junit.Assert.assertEquals;
+              import static org.mockito.Mockito.*;
+
+              class Test {
+                  void test() {
+                      try (MockedStatic<A> mockA = mockStatic(A.class)) {
+                          try (MockedStatic<B> mockB = mockStatic(B.class)) {
+                              when(A.getNumber()).thenReturn(-1);
+                              when(B.getString()).thenReturn("hi there");
+                              assertEquals(A.getNumber(), -1);
+                              assertEquals(B.getString(), "hi there");
+                          }
+                      }
+                  }
+              }
+              """,
+            """
+              import org.mockito.MockedStatic;
+
+              import static org.junit.Assert.assertEquals;
+              import static org.mockito.Mockito.*;
+
+              class Test {
+                  void test() {
+                      try (MockedStatic<A> mockA = mockStatic(A.class)) {
+                          try (MockedStatic<B> mockB = mockStatic(B.class)) {
+                              mockA.when(() -> A.getNumber()).thenReturn(-1);
+                              mockB.when(() -> B.getString()).thenReturn("hi there");
+                              assertEquals(A.getNumber(), -1);
+                              assertEquals(B.getString(), "hi there");
+                          }
                       }
                   }
               }


### PR DESCRIPTION
## What's changed?
Allow for reuse of already in scope `MockedStatic<T>` from eventual parent try-with-resources.

If you have a situation like
```java
//...
try (MockedStatic<A> mockA = mockStatic(A.class)) {
  when(A.staticMethod()).thenReturn(null);
  //...
}
//...
```
with this change you would get this _new_ behaviour
```java
//...
try (MockedStatic<A> mockA = mockStatic(A.class)) {
  mockA.when(() -> A.staticMethod()).thenReturn(null);
  //...
}
//...
```
rather than the _existing_ behaviour
```java
//...
try (MockedStatic<A> mockA = mockStatic(A.class)) {
  try (MockedStatic<A> mockA1 = mockStatic(A.class)) {
    mockA1.when(() -> A.staticMethod()).thenReturn(null);
    //...
  }
}
//...
```

Parent traversing code has also been added to allow for multiple layers of try-with-resources until it either finds an applicable one or reverts to the existing behaviour of replacing a `when(..)` with a try-with-resources and a `<mock>.when(..)` inside.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
