### PR TITLE
Changing order of `mockito-all` -> `mockito-core` change vs `org.mockito:*` upgrade, and made the former upgrade to `3.x` at the same time, as there aren't aligned versions between the two.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ recipeDependencies {
     parserClasspath("org.mockito:mockito-all:1.10.19")
     parserClasspath("org.mockito:mockito-core:3.+")
     parserClasspath("org.mockito:mockito-core:5.+")
+    parserClasspath("org.mockito:mockito-junit-jupiter:2.+")
     parserClasspath("org.mockito:mockito-junit-jupiter:3.+")
     parserClasspath("org.mockito:mockito-junit-jupiter:5.+")
     parserClasspath("org.powermock:powermock-api-mockito:1.6.5")

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -170,14 +170,15 @@ recipeList:
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
   - org.openrewrite.java.testing.mockito.RemoveInitMocksIfRunnersSpecified
   - org.openrewrite.java.testing.mockito.ReplacePowerMockito
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.mockito
-      artifactId: "*"
-      newVersion: 3.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.mockito
       oldArtifactId: mockito-all
       newArtifactId: mockito-core
+      newVersion: 3.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.mockito
+      artifactId: "*"
+      newVersion: 3.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
       artifactId: byte-buddy*

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class Mockito1to3MigrationTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api", "mockito-all", "mockito-junit-jupiter")
+            //language=java
+            .dependsOn(
+              """
+                import java.util.List;
+
+                public class A {
+                    public boolean someMethod(Object o, String s, List<String> l) {
+                        return true;
+                    }
+                }
+                """
+            )
+          )
+          .recipeFromResources("org.openrewrite.java.testing.mockito.Mockito1to3Migration");
+    }
+
+    @DocumentExample
+    @Test
+    void migrateSomeMethodsAndDependencies() {
+        rewriteRun(
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                  testImplementation("org.mockito:mockito-all:1.10.19")
+                  testImplementation("org.mockito:mockito-junit-jupiter:2.28.2")
+              }
+              test {
+                  useJUnitPlatform()
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                  testImplementation("org.mockito:mockito-core:3.12.4")
+                  testImplementation("org.mockito:mockito-junit-jupiter:3.12.4")
+              }
+              test {
+                  useJUnitPlatform()
+              }
+              """
+          ),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>some-project</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
+                        <version>5.11.4</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-all</artifactId>
+                        <version>1.10.19</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-junit-jupiter</artifactId>
+                        <version>2.28.2</version>
+                    </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>some-project</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
+                        <version>5.11.4</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>3.12.4</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-junit-jupiter</artifactId>
+                        <version>3.12.4</version>
+                    </dependency>
+                </dependencies>
+              </project>
+              """
+          ),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.BeforeEach;
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              import static org.mockito.Matchers.anyListOf;
+              import static org.mockito.Matchers.anyObject;
+              import static org.mockito.Matchers.anyString;
+              import static org.mockito.Mockito.when;
+
+              class MyTest {
+                  @Mock
+                  Object objectMock;
+
+                  private A subject;
+
+                  @BeforeEach
+                  void setup() {
+                      subject = new A();
+                  }
+
+                  @Test
+                  void someTest() {
+                      when(subject.someMethod(anyObject(), anyString(), anyListOf(String.class))).thenReturn(false);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeEach;
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              import static org.mockito.ArgumentMatchers.anyList;
+              import static org.mockito.ArgumentMatchers.any;
+              import static org.mockito.ArgumentMatchers.anyString;
+              import static org.mockito.Mockito.when;
+
+              class MyTest {
+                  @Mock
+                  Object objectMock;
+
+                  private A subject;
+
+                  @BeforeEach
+                  void setup() {
+                      subject = new A();
+                  }
+
+                  @Test
+                  void someTest() {
+                      when(subject.someMethod(any(), anyString(), anyList())).thenReturn(false);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migratesCorrectlyWhenManagedDependency() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>some-project-parent</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <properties>
+                    <mockito.version>1.10.19</mockito.version>
+                    <mockito-jupiter.version>2.28.2</mockito-jupiter.version>
+                </properties>
+                <dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-api</artifactId>
+                            <version>5.11.4</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-all</artifactId>
+                            <version>${mockito.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.mockito</groupId>
+                            <artifactId>mockito-junit-jupiter</artifactId>
+                            <version>${mockito-jupiter.version}</version>
+                        </dependency>
+                    </dependencies>
+                </dependencyManagement>
+              </project>
+              """,
+            spec -> spec
+              .path("pom.xml")
+              .after(pom -> assertThat(pom)
+                .contains("<artifactId>mockito-core</artifactId>")
+                .doesNotContain("<artifactId>mockito-all</artifactId>")
+                .containsPattern("<mockito.version>3.\\d+.\\d+</mockito.version>")
+                .containsPattern("<mockito-jupiter.version>3.\\d+.\\d+</mockito-jupiter.version>")
+                .actual())
+          ),
+          pomXml(
+            //language=xml
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>some-project</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <parent>
+                    <groupId>org.example</groupId>
+                    <artifactId>some-project-parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <relativePath>../pom.xml</relativePath>
+                </parent>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-all</artifactId>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-junit-jupiter</artifactId>
+                    </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec -> spec
+              .path("child/pom.xml")
+              .after(pom -> assertThat(pom)
+                .contains("<artifactId>mockito-core</artifactId>")
+                .doesNotContain("<artifactId>mockito-all</artifactId>")
+                .actual())
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
- When `org.mockito:mockito-all` is getting changed to `org.mockito:mockito-core`, we also upgrade the version _at the same time_. The reason for this is that there isn't version number alignment between the two and trying to change the dependency only results in something that can't be resolved and so doesn't get picked up by the migration that tries to upgrade `org.mockito:*` to `3.x`
- The migration for `org.mockito:*` to `3.x` happens after the `org.mockito:mockito-all` -> `org.mockito:mockito-core` so that we're in a better state when we try to upgrade a bunch of dependencies.

## What's your motivation?
Prior to this change, when the `org.mockito:mockito-all` dependency was managed, it would only change the dependency name in the child, and not actually upgrade the version number as is needed for it to pull in the `org.mockito:mockito-core` dependency.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
