### PR TITLE
Don't clean up mockito imports for Kotlin

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -286,45 +286,16 @@ class CleanupMockitoImportsTest implements RewriteTest {
     }
 
     @Test
-    void handleKotlinImportsCorrectly() {
-        rewriteRun(
-          //language=kotlin
-          kotlin(
-            """
-              import org.mockito.kotlin.times
-              class Foo {
-                fun bar() {
-                  org.mockito.Mockito.mock(Foo::class.java)
-                }
-              }
-              """,
-            """
-              class Foo {
-                fun bar() {
-                  org.mockito.Mockito.mock(Foo::class.java)
-                }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void handleKotlinWhenever() {
+    void doNotRemoveMockitoImportsForKotlin() {
         rewriteRun(
           //language=kotlin
           kotlin(
             """
               import org.mockito.Mock
-              import org.mockito.kotlin.whenever
+              import org.mockito.kotlin.times
               class Foo {
-                @Mock
-                private lateinit var foo: Foo
-                fun foo() : String {
-                    return "foo"
-                }
-                fun baz() {
-                  whenever(foo.foo()).thenReturn("bar")
+                fun bar() {
+                  org.mockito.Mockito.mock(Foo::class.java)
                 }
               }
               """


### PR DESCRIPTION
## What's changed?
Disabled `CleanupMockitoImports` for Kotlin

## What's your motivation?
There were reports method invocations like `any` and `eq` were not found for Kotlin code, thus it's better to disable the clean up step.

## Any additional context
Later on, we can go back to this recipe to properly enable Kotlin support again. 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
