### PR TITLE
MockitoJUnitRunnerToExtension: Handle existing MockitoExtension

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -19,10 +19,13 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.testing.junit5.RemoveObsoleteRunners;
 import org.openrewrite.java.testing.junit5.RunnerToExtension;
 import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.tree.J;
@@ -30,7 +33,9 @@ import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class MockitoJUnitRunnerToExtension extends Recipe {
@@ -51,38 +56,67 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
         return Preconditions.check(new UsesType<>("org.mockito.junit.MockitoJUnitRunner*", false), new JavaIsoVisitor<ExecutionContext>() {
 
             final String runWith = "@org.junit.runner.RunWith";
+            final String extendWithMockito = "@org.junit.jupiter.api.extension.ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)";
+            final String mockitoSettings = "@org.mockito.junit.jupiter.MockitoSettings";
+            final String mockitoStrictness = "org.mockito.quality.Strictness";
 
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-                AtomicReference<Strictness> strictness = new AtomicReference<>();
-                new Annotated.Matcher(runWith).<AtomicReference<Strictness>>asVisitor((a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
-                    @Override
-                    public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
-                        for (Strictness strict : Strictness.values()) {
-                            if (TypeUtils.isAssignableTo(strict.runner, fieldAccess.getTarget().getType())) {
-                                strictness.set(strict);
-                                break;
-                            }
-                        }
-                        return fieldAccess;
-                    }
-                }, s)).visit(cd, strictness);
+                Strictness runnerStrictness = getStrictness(cd, true);
+                Strictness extensionStrictness = getStrictness(cd, false);
 
-                if (strictness.get() == null) { // class doesn't have MockitoJunitRunner
+                if (runnerStrictness == null) { // class doesn't have MockitoJunitRunner
                     return cd;
                 }
-
-                registerAfterVisit();
-                return getTemplate(strictness.get(), ctx)
-                        .map(t -> maybeAutoFormat(cd,
-                                t.apply(updateCursor(cd), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName))),
-                                ctx)).orElse(cd);
+                registerAfterVisit(cd);
+                if (extensionStrictness == null || extensionStrictness.isGreaterThan(runnerStrictness)) {
+                    List<J.Annotation> annotations = ListUtils.map(cd.getLeadingAnnotations(),
+                            a -> a == null || new AnnotationMatcher(mockitoSettings).matches(a) ? null : a);
+                    J.ClassDeclaration _cd = cd.withLeadingAnnotations(annotations);
+                    return getTemplate(runnerStrictness, ctx)
+                            .map(t -> maybeAutoFormat(_cd,
+                                    t.apply(updateCursor(_cd), _cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName))),
+                                    ctx)).orElse(_cd);
+                }
+                return cd;
             }
 
-            private void registerAfterVisit() {
-                doAfterVisit(new RunnerToExtension(Arrays.asList("org.mockito.junit.MockitoJUnitRunner.Silent", "org.mockito.junit.MockitoJUnitRunner.Strict", "org.mockito.junit.MockitoJUnitRunner"),
-                        "org.mockito.junit.jupiter.MockitoExtension").getVisitor());
+            private Strictness getStrictness(J.ClassDeclaration cd, boolean isRunner) {
+                AtomicReference<Strictness> strictness = new AtomicReference<>();
+                new Annotated.Matcher(isRunner ? runWith : mockitoSettings).<AtomicReference<Strictness>>asVisitor(
+                    (a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
+                        @Override
+                        public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
+                            for (Strictness strict : Strictness.values()) {
+                                if (TypeUtils.isOfClassType(fieldAccess.getTarget().getType(), strict.runner)) {
+                                    strictness.set(strict);
+                                    break;
+                                }
+                                if (TypeUtils.isOfClassType(fieldAccess.getType(), mockitoStrictness)  && fieldAccess.getName().getSimpleName().equals(strict.name())) {
+                                    strictness.set(strict);
+                                    break;
+                                }
+                            }
+                            return fieldAccess;
+                        }
+                }, s)).visit(cd, strictness);
+
+                return strictness.get();
+            }
+
+            private void registerAfterVisit(J.ClassDeclaration cd) {
+                boolean hasMockitoExtensions = new Annotated.Matcher(extendWithMockito).<AtomicBoolean>asVisitor(
+                        (a, flag) -> {
+                            flag.set(true);
+                            return a.getTree();
+                        }).reduce(cd, new AtomicBoolean(false)).get();
+                List<String> obsoleteRunners = Arrays.asList("org.mockito.junit.MockitoJUnitRunner.Silent", "org.mockito.junit.MockitoJUnitRunner.Strict", "org.mockito.junit.MockitoJUnitRunner");
+                if (hasMockitoExtensions) {
+                    doAfterVisit(new RemoveObsoleteRunners(obsoleteRunners).getVisitor());
+                } else {
+                    doAfterVisit(new RunnerToExtension(obsoleteRunners, "org.mockito.junit.jupiter.MockitoExtension").getVisitor());
+                }
                 for (Strictness strictness : Strictness.values()) {
                     maybeRemoveImport(strictness.runner);
                 }
@@ -106,13 +140,18 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
 
     private enum Strictness {
         LENIENT("org.mockito.junit.MockitoJUnitRunner.Silent"),
-        STRICT_STUBS("org.mockito.junit.MockitoJUnitRunner.Strict"),
-        WARN("org.mockito.junit.MockitoJUnitRunner");
+        WARN("org.mockito.junit.MockitoJUnitRunner"),
+        STRICT_STUBS("org.mockito.junit.MockitoJUnitRunner.Strict");
 
         final String runner;
 
         Strictness(String runner) {
             this.runner = runner;
+        }
+
+        // Return true, if current strictness is greater than given strictness.
+        boolean isGreaterThan(Strictness strictness) {
+            return this.ordinal() > strictness.ordinal();
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.mockito;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -82,9 +83,8 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                 return cd;
             }
 
-            private Strictness getStrictness(J.ClassDeclaration cd, boolean isRunner) {
-                AtomicReference<Strictness> strictness = new AtomicReference<>();
-                new Annotated.Matcher(isRunner ? runWith : mockitoSettings).<AtomicReference<Strictness>>asVisitor(
+            private @Nullable Strictness getStrictness(J.ClassDeclaration cd, boolean isRunner) {
+                return new Annotated.Matcher(isRunner ? runWith : mockitoSettings).<AtomicReference<@Nullable Strictness>>asVisitor(
                     (a, s) -> a.getTree().acceptJava(new JavaIsoVisitor<AtomicReference<Strictness>>() {
                         @Override
                         public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
@@ -100,9 +100,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                             }
                             return fieldAccess;
                         }
-                }, s)).visit(cd, strictness);
-
-                return strictness.get();
+                }, s)).reduce(cd, new AtomicReference<>()).get();
             }
 
             private void registerAfterVisit(J.ClassDeclaration cd) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
@@ -32,7 +32,11 @@ class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-4", "mockito-core-3.12", "junit-jupiter-api-5", "mockito-junit-jupiter-3.12"))
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-4",
+              "junit-jupiter-api-5",
+              "mockito-core-3.12",
+              "mockito-junit-jupiter-3.12"))
           .recipe(new MockitoJUnitRunnerToExtension());
     }
 

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
@@ -32,7 +32,7 @@ class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "junit-4", "mockito-core-3.12"))
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4", "mockito-core-3.12", "junit-jupiter-api-5", "mockito-junit-jupiter-3.12"))
           .recipe(new MockitoJUnitRunnerToExtension());
     }
 
@@ -104,6 +104,103 @@ class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
               import org.junit.runners.Parameterized;
 
               @RunWith(Parameterized.class)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mockitoRunnerWithExtension() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.MockitoJUnitRunner;
+
+              @ExtendWith(MockitoExtension.class)
+              @RunWith(MockitoJUnitRunner.Strict.class)
+              public class ExternalAPIServiceTest {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mockitoRunnerWithHigherExtensionStrictness() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.junit.MockitoJUnitRunner;
+              import org.mockito.quality.Strictness;
+
+              @MockitoSettings(strictness = Strictness.STRICT_STUBS)
+              @ExtendWith(MockitoExtension.class)
+              @RunWith(MockitoJUnitRunner.class)
+              public class ExternalAPIServiceTest {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
+
+
+              @ExtendWith(MockitoExtension.class)
+              @MockitoSettings(strictness = Strictness.WARN)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mockitoRunnerWithLowerExtensionStrictness() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.junit.MockitoJUnitRunner;
+              import org.mockito.quality.Strictness;
+
+              @MockitoSettings(strictness = Strictness.LENIENT)
+              @ExtendWith(MockitoExtension.class)
+              @RunWith(MockitoJUnitRunner.class)
+              public class ExternalAPIServiceTest {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.junit.jupiter.MockitoSettings;
+              import org.mockito.quality.Strictness;
+
+              @MockitoSettings(strictness = Strictness.LENIENT)
+              @ExtendWith(MockitoExtension.class)
               public class ExternalAPIServiceTest {
               }
               """


### PR DESCRIPTION
## What's changed?
This PR updates the MockitoJUnitRunnerToExtension recipe to better handle the migration from MockitoJUnitRunner to MockitoExtension. Specifically:

- It now checks for the presence of an existing @ExtendWith(MockitoExtension.class) annotation to avoid adding duplicates.
- It verifies the configured strictness level, and only updates it if the existing level is more restrictive than what JUnit 4's runner.

## What's your motivation?
In some cases a developer may have bothe MockitoRule and MockitoJunitRunner both in same test class. In that case the MockitoJUnitToMockitoExtension and MockitoJUnitRunnerToExtension both tries to add `MockitoExtension` or `MockitoSettings` which is not repeatable and test fails with compilation error. Updated MockitoJUnitRunnerToExtension to not add these extension if one already exists, Since MockitoJUnitRunnerToExtension recipes runs after MockitoJUnitToMockitoExtension Junit4toJunit5 recipe.



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
