### PR TITLE
Add TestMethodsShouldBeVoid recipe to fix test methods with non-void return types

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/TestMethodsShouldBeVoid.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/TestMethodsShouldBeVoid.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestMethodsShouldBeVoid extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Test methods should have void return type";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Test methods annotated with `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`, `@TestTemplate` " +
+                "should have `void` return type. Non-void return types can cause test discovery issues, " +
+                "especially in JUnit 5.13+. This recipe changes the return type to `void` and removes `return` statements.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+                // Check if method has a test annotation
+                if (!hasTestAnnotation(m)) {
+                    return m;
+                }
+
+                // Check if return type is already void
+                JavaType.Primitive voidType = JavaType.Primitive.Void;
+                if (m.getReturnTypeExpression() != null && TypeUtils.isOfType(m.getReturnTypeExpression().getType(), voidType)) {
+                    return m;
+                }
+
+                // Change return type to void
+                m = m.withReturnTypeExpression(new J.Primitive(
+                        m.getReturnTypeExpression() != null ? m.getReturnTypeExpression().getId() : Tree.randomId(),
+                        m.getReturnTypeExpression() != null ? m.getReturnTypeExpression().getPrefix() : Space.EMPTY,
+                        m.getReturnTypeExpression() != null ? m.getReturnTypeExpression().getMarkers() : org.openrewrite.marker.Markers.EMPTY,
+                        JavaType.Primitive.Void
+                ));
+
+                // Update method type
+                if (m.getMethodType() != null) {
+                    m = m.withMethodType(m.getMethodType().withReturnType(voidType));
+                }
+
+                // Remove return statements that are not in nested classes or lambdas
+                m = m.withBody(removeReturnStatements(m.getBody()));
+
+                return m;
+            }
+
+            private boolean hasTestAnnotation(J.MethodDeclaration method) {
+                for (J.Annotation annotation : method.getLeadingAnnotations()) {
+                    if (TypeUtils.isOfClassType(annotation.getType(), "org.junit.jupiter.api.Test") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.junit.jupiter.params.ParameterizedTest") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.junit.jupiter.api.RepeatedTest") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.junit.jupiter.api.TestFactory") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.junit.jupiter.api.TestTemplate") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.junit.Test") ||
+                            TypeUtils.isOfClassType(annotation.getType(), "org.testng.annotations.Test")) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private J.Block removeReturnStatements(J.Block block) {
+                if (block == null) {
+                    return null;
+                }
+
+                RemoveReturnsVisitor visitor = new RemoveReturnsVisitor();
+                return (J.Block) visitor.visitBlock(block, new InMemoryExecutionContext());
+            }
+        };
+    }
+
+    private static class RemoveReturnsVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private int nestedLevel = 0;
+
+        @Override
+        public J.Lambda visitLambda(J.Lambda lambda, ExecutionContext ctx) {
+            nestedLevel++;
+            J.Lambda result = super.visitLambda(lambda, ctx);
+            nestedLevel--;
+            return result;
+        }
+
+        @Override
+        public J.NewClass visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
+            if (newClass.getBody() != null) {
+                nestedLevel++;
+                J.NewClass result = super.visitNewClass(newClass, ctx);
+                nestedLevel--;
+                return result;
+            }
+            return super.visitNewClass(newClass, ctx);
+        }
+
+        @Override
+        public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+            J.Block b = super.visitBlock(block, ctx);
+            if (nestedLevel == 0) {
+                // Process the statements to remove returns at the top level
+                List<org.openrewrite.java.tree.Statement> newStatements = new ArrayList<>();
+                for (org.openrewrite.java.tree.Statement statement : b.getStatements()) {
+                    if (statement instanceof J.Return) {
+                        J.Return return_ = (J.Return) statement;
+                        // If the return has an expression that's not a literal, keep it as a statement
+                        if (return_.getExpression() != null && !(return_.getExpression() instanceof J.Literal)) {
+                            org.openrewrite.java.tree.Expression expr = return_.getExpression();
+                            // Check if the expression is already a statement (e.g., method invocation)
+                            if (expr instanceof org.openrewrite.java.tree.Statement) {
+                                newStatements.add(((org.openrewrite.java.tree.Statement) expr).withPrefix(statement.getPrefix()));
+                            }
+                            // Otherwise, we can't simply convert it - just remove the return
+                        }
+                        // Otherwise, don't add anything (removes "return;" or "return literal;")
+                    } else {
+                        newStatements.add(statement);
+                    }
+                }
+                return b.withStatements(newStatements);
+            }
+            return b;
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/cleanup/TestMethodsShouldBeVoidTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/TestMethodsShouldBeVoidTest.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class TestMethodsShouldBeVoidTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "junit-jupiter-params-5"))
+          .recipe(new TestMethodsShouldBeVoid());
+    }
+
+    @DocumentExample
+    @Test
+    void changeReturnTypeToVoid() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  int testMethod() {
+                      int i = 42;
+                      return i;
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      int i = 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeReturnStatementOnly() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  String testMethod() {
+                      System.out.println("test");
+                      return "done";
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      System.out.println("test");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveReturnInLambda() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.function.Supplier;
+
+              class ATest {
+                  @Test
+                  int testMethod() {
+                      Supplier<Integer> supplier = () -> {
+                          return 42;
+                      };
+                      return supplier.get();
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.function.Supplier;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      Supplier<Integer> supplier = () -> {
+                          return 42;
+                      };
+                      supplier.get();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveReturnInAnonymousClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  String testMethod() {
+                      Runnable r = new Runnable() {
+                          @Override
+                          public void run() {
+                              System.out.println("running");
+                          }
+
+                          public String getValue() {
+                              return "value";
+                          }
+                      };
+                      r.run();
+                      return "done";
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      Runnable r = new Runnable() {
+                          @Override
+                          public void run() {
+                              System.out.println("running");
+                          }
+
+                          public String getValue() {
+                              return "value";
+                          }
+                      };
+                      r.run();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleParameterizedTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class ATest {
+                  @ParameterizedTest
+                  @ValueSource(strings = {"test1", "test2"})
+                  boolean testMethod(String value) {
+                      System.out.println(value);
+                      return value.length() > 0;
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class ATest {
+                  @ParameterizedTest
+                  @ValueSource(strings = {"test1", "test2"})
+                  void testMethod(String value) {
+                      System.out.println(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleRepeatedTest() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.RepeatedTest;
+
+              class ATest {
+                  @RepeatedTest(3)
+                  String testMethod() {
+                      return "repeated";
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.RepeatedTest;
+
+              class ATest {
+                  @RepeatedTest(3)
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeVoidMethods() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      System.out.println("already void");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNonTestMethods() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class ATest {
+                  int notATestMethod() {
+                      return 42;
+                  }
+
+                  String helperMethod() {
+                      return "helper";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleMultipleReturns() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  int testMethod() {
+                      if (true) {
+                          return 1;
+                      } else {
+                          return 2;
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      if (true) {
+                      } else {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveExpressionFromReturn() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  int testMethod() {
+                      return calculateValue();
+                  }
+
+                  private int calculateValue() {
+                      return 42;
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              class ATest {
+                  @Test
+                  void testMethod() {
+                      calculateValue();
+                  }
+
+                  private int calculateValue() {
+                      return 42;
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Implements recipe to fix test methods with non-void return types (#790)
- Changes return type to void for test methods annotated with `@Test`, `@ParameterizedTest`, `@RepeatedTest`, etc.
- Removes return statements from method bodies while preserving nested lambda/class returns

## Details

Some test methods with non-void return types were not being discovered or run correctly, causing broken test coverage and warnings in JUnit 5.13+. This recipe automatically fixes test method signatures to ensure proper test discovery and execution.

### Changes made:
1. Created `TestMethodsShouldBeVoid` recipe that:
   - Detects test methods with non-void return types
   - Changes the return type to `void`
   - Removes return statements from the method body
   - Preserves return statements in nested lambdas and anonymous classes

2. Added comprehensive test coverage with 10 test cases covering:
   - Simple return type changes
   - Return statement removal
   - Preservation of returns in lambdas
   - Preservation of returns in anonymous classes
   - Parameterized tests
   - Repeated tests
   - Multiple return statements
   - Method invocation preservation

### Example transformation:
```java
// Before
@Test
int testMethod() {
    int i = 42;
    return i;
}

// After
@Test
void testMethod() {
    int i = 42;
}
```

## Test plan
- [x] All 10 unit tests pass
- [x] Recipe correctly handles various test annotations
- [x] Return statements in nested contexts are preserved
- [x] Method invocations are preserved when removing returns

Fixes #790

🤖 Generated with [Claude Code](https://claude.ai/code)