### PR TITLE
Recipes to migrate from JUnit 5 to JUnit 6

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit6/package-info.java
+++ b/src/main/java/org/openrewrite/java/testing/junit6/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2025 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/rewrite/junit6.yml
+++ b/src/main/resources/META-INF/rewrite/junit6.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 the original author or authors.
+# Copyright 2025 the original author or authors.
 # <p>
 # Licensed under the Moderne Source Available License (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
The bare minimum version of junit 5 -> 6 to be used as a starting point