### PR TITLE
Remove lineSeparator annotation attribute

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit6.yml
+++ b/src/main/resources/META-INF/rewrite/junit6.yml
@@ -51,3 +51,6 @@ recipeList:
       groupId: org.apache.maven.plugins
       artifactId: maven-surefire-plugin
       newVersion: 3.x
+  - org.openrewrite.java.RemoveAnnotationAttribute:
+      annotationType: org.junit.jupiter.params.provider.CsvFileSource
+      attributeName: lineSeparator


### PR DESCRIPTION
From the release notes:
> The lineSeparator attribute in `@CsvFileSource` has been removed. The line separator is now automatically detected, meaning that any of `\r`, `\n`, or `\r\n` is treated as a line separator.