### PR TITLE
Adding support for recognizing instantiation of mocked static in TestNG-related `@BeforeMethod` and `@BeforeClass` annotated methods

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -37,10 +37,14 @@ import static org.openrewrite.java.tree.Flag.Static;
 
 public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
-    private static final AnnotationMatcher BEFORE = new AnnotationMatcher("org.junit.Before");
-    private static final AnnotationMatcher BEFORE_CLASS = new AnnotationMatcher("org.junit.BeforeClass");
-    private static final AnnotationMatcher AFTER = new AnnotationMatcher("org.junit.After");
-    private static final AnnotationMatcher AFTER_CLASS = new AnnotationMatcher("org.junit.AfterClass");
+    private static final AnnotationMatcher JUNIT_BEFORE = new AnnotationMatcher("org.junit.Before");
+    private static final AnnotationMatcher JUNIT_BEFORE_CLASS = new AnnotationMatcher("org.junit.BeforeClass");
+    private static final AnnotationMatcher TESTNG_BEFORE_METHOD = new AnnotationMatcher("org.testng.annotations.BeforeMethod");
+    private static final AnnotationMatcher TESTNG_BEFORE_CLASS = new AnnotationMatcher("org.testng.annotations.BeforeClass");
+    private static final AnnotationMatcher JUNIT_AFTER = new AnnotationMatcher("org.junit.After");
+    private static final AnnotationMatcher JUNIT_AFTER_CLASS = new AnnotationMatcher("org.junit.AfterClass");
+    private static final AnnotationMatcher TESTNG_AFTER_METHOD = new AnnotationMatcher("org.testng.annotations.AfterMethod");
+    private static final AnnotationMatcher TESTNG_AFTER_CLASS = new AnnotationMatcher("org.testng.annotations.AfterClass");
     private static final MethodMatcher MOCKITO_WHEN = new MethodMatcher("org.mockito.Mockito when(..)");
     private static final TypeMatcher MOCKED_STATIC = new TypeMatcher("org.mockito.MockedStatic");
 
@@ -54,7 +58,8 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
     @Override
     public String getDescription() {
         return "Replace `Mockito.when` on static (non mock) with try-with-resource with MockedStatic as Mockito4 no longer allows this. " +
-                "When `@Before` or `@BeforeClass` is used, a `close` method is added to either the `@After` or `@AfterClass` method. " +
+                "For JUnit: When `@Before` or `@BeforeClass` is used, a `close` call is added to either the `@After` or `@AfterClass` method. " +
+                "For TestNG: When `@BeforeMethod` or `@BeforeClass` is used, a `close` call is added to either the `@AfterMethod` or `@AfterClass` method. " +
                 "This change moves away from implicit bytecode manipulation for static method stubbing, making mocking behavior more explicit and scoped to avoid unintended side effects.";
     }
 
@@ -63,7 +68,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
         return Preconditions.check(new UsesMethod<>(MOCKITO_WHEN), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
-                List<Statement> newStatements = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE, BEFORE_CLASS) ?
+                List<Statement> newStatements = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), JUNIT_BEFORE, JUNIT_BEFORE_CLASS, TESTNG_BEFORE_METHOD, TESTNG_BEFORE_CLASS) ?
                         maybeStatementsToMockedStatic(block, block.getStatements(), ctx) :
                         maybeWrapStatementsInTryWithResourcesMockedStatic(block, block.getStatements(), ctx);
 
@@ -171,7 +176,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
             }
 
             private List<Statement> mockedStatic(J.Block block, J.MethodInvocation statement, String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
-                boolean staticSetup = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE_CLASS);
+                boolean staticSetup = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), JUNIT_BEFORE_CLASS, TESTNG_BEFORE_CLASS);
                 String variableName = generateVariableName("mock" + className + ++varCounter, updateCursor(block), INCREMENT_NUMBER);
                 Expression thenReturnArg = statement.getArguments().get(0);
 
@@ -190,11 +195,14 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                 .build()
                                 .apply(updateCursor(classDecl), classDecl.getBody().getCoordinates().firstStatement());
 
-                        if (classDecl.getBody().getStatements().stream().noneMatch(it -> isMethodDeclarationWithAnnotation(it, AFTER, AFTER_CLASS))) {
-                            Optional<Statement> beforeMethod = after.getBody().getStatements().stream()
-                                    .filter(it -> isMethodDeclarationWithAnnotation(it, BEFORE, BEFORE_CLASS))
+                        if (classDecl.getBody().getStatements().stream().noneMatch(it -> isMethodDeclarationWithAnnotation(it, JUNIT_AFTER, JUNIT_AFTER_CLASS, TESTNG_AFTER_METHOD, TESTNG_AFTER_CLASS))) {
+                            Optional<Statement> beforeMethodJunit = after.getBody().getStatements().stream()
+                                    .filter(it -> isMethodDeclarationWithAnnotation(it, JUNIT_BEFORE, JUNIT_BEFORE_CLASS))
                                     .findFirst();
-                            if (beforeMethod.isPresent()) {
+                            Optional<Statement> beforeMethodTestng = after.getBody().getStatements().stream()
+                                    .filter(it -> isMethodDeclarationWithAnnotation(it, TESTNG_BEFORE_METHOD, TESTNG_BEFORE_CLASS))
+                                    .findFirst();
+                            if (beforeMethodJunit.isPresent()) {
                                 maybeAddImport("org.junit.AfterClass");
                                 maybeAddImport("org.junit.After");
                                 after = JavaTemplate.builder(String.format(
@@ -203,7 +211,17 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                         .imports(staticSetup ? "org.junit.AfterClass" : "org.junit.After")
                                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-4"))
                                         .build()
-                                        .apply(updateCursor(after), beforeMethod.get().getCoordinates().after());
+                                        .apply(updateCursor(after), beforeMethodJunit.get().getCoordinates().after());
+                            } else if (beforeMethodTestng.isPresent()) {
+                                maybeAddImport("org.testng.annotations.AfterClass");
+                                maybeAddImport("org.testng.annotations.AfterMethod");
+                                after = JavaTemplate.builder(String.format(
+                                                "%s void tearDown() {}", staticSetup ? "@AfterClass public static" : "@AfterMethod public"
+                                        ))
+                                        .imports(staticSetup ? "org.testng.annotations.AfterClass" : "org.testng.annotations.AfterMethod")
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "testng"))
+                                        .build()
+                                        .apply(updateCursor(after), beforeMethodTestng.get().getCoordinates().after());
                             }
                         }
 
@@ -215,7 +233,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
                         J.MethodDeclaration md = super.visitMethodDeclaration(methodDecl, ctx);
 
-                        if (isMethodDeclarationWithAnnotation(md, AFTER, AFTER_CLASS)) {
+                        if (isMethodDeclarationWithAnnotation(md, JUNIT_AFTER, JUNIT_AFTER_CLASS, TESTNG_AFTER_METHOD, TESTNG_AFTER_CLASS)) {
                             return JavaTemplate.builder(variableName + ".close();")
                                     .contextSensitive()
                                     .build()


### PR DESCRIPTION
- Follow-on to https://github.com/openrewrite/rewrite-testing-frameworks/pull/798

## What's changed?
In the same places where `MockitoWhenOnStaticToMockStatic` is detecting `@Before` and `@BeforeClass` for JUnit, it will now be able to detect the equivalent TestNG versions.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
