### PR TITLE
Removed redundant checks and added support for JUnit 5 annotations

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -37,13 +37,15 @@ import static org.openrewrite.java.tree.Flag.Static;
 
 public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
-    private static final AnnotationMatcher JUNIT_ANNOTATION = new AnnotationMatcher("org.junit.*");
+    private static final AnnotationMatcher JUNIT_4_ANNOTATION = new AnnotationMatcher("org.junit.*");
+    private static final AnnotationMatcher JUNIT_5_ANNOTATION = new AnnotationMatcher("org.junit.jupiter.api.*");
     private static final AnnotationMatcher TESTNG_ANNOTATION = new AnnotationMatcher("org.testng.annotations.*");
 
     private static final AnnotationMatcher BEFORE = new AnnotationMatcher("org..Before*");
     private static final AnnotationMatcher BEFORE_CLASS = new AnnotationMatcher("org..BeforeClass");
+    private static final AnnotationMatcher BEFORE_ALL = new AnnotationMatcher("org..BeforeAll");
+    private static final AnnotationMatcher BEFORE_PARAM_CLASS_INV = new AnnotationMatcher("org..BeforeParameterizedClassInvocation");
     private static final AnnotationMatcher AFTER = new AnnotationMatcher("org..After*");
-    private static final AnnotationMatcher AFTER_CLASS = new AnnotationMatcher("org..AfterClass");
 
     private static final MethodMatcher MOCKITO_WHEN = new MethodMatcher("org.mockito.Mockito when(..)");
     private static final TypeMatcher MOCKED_STATIC = new TypeMatcher("org.mockito.MockedStatic");
@@ -58,7 +60,9 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
     @Override
     public String getDescription() {
         return "Replace `Mockito.when` on static (non mock) with try-with-resource with MockedStatic as Mockito4 no longer allows this. " +
-                "For JUnit: When `@Before` or `@BeforeClass` is used, a `close` call is added to either the `@After` or `@AfterClass` method. " +
+                "For JUnit 4: When `@Before` or `@BeforeClass` is used, a `close` call is added to either the `@After` or `@AfterClass` method. " +
+                "For JUnit 5: When `@BeforeEach`, `@BeforeAll` or `@BeforeParameterizedClassInvocation` is used, " +
+                "a `close` call is added to a corresponding `@AfterEach`, `@AfterAll` or `@AfterParameterizedClassInvocation` method. " +
                 "For TestNG: When `@BeforeMethod` or `@BeforeClass` is used, a `close` call is added to either the `@AfterMethod` or `@AfterClass` method. " +
                 "This change moves away from implicit bytecode manipulation for static method stubbing, making mocking behavior more explicit and scoped to avoid unintended side effects.";
     }
@@ -68,7 +72,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
         return Preconditions.check(new UsesMethod<>(MOCKITO_WHEN), new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
-                List<Statement> newStatements = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE, BEFORE_CLASS) ?
+                List<Statement> newStatements = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE) ?
                         maybeStatementsToMockedStatic(block, block.getStatements(), ctx) :
                         maybeWrapStatementsInTryWithResourcesMockedStatic(block, block.getStatements(), ctx);
 
@@ -176,7 +180,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
             }
 
             private List<Statement> mockedStatic(J.Block block, J.MethodInvocation statement, String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
-                boolean staticSetup = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE_CLASS);
+                boolean staticSetup = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE_CLASS, BEFORE_ALL, BEFORE_PARAM_CLASS_INV);
                 String variableName = generateVariableName("mock" + className + ++varCounter, updateCursor(block), INCREMENT_NUMBER);
                 Expression thenReturnArg = statement.getArguments().get(0);
 
@@ -195,14 +199,17 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                 .build()
                                 .apply(updateCursor(classDecl), classDecl.getBody().getCoordinates().firstStatement());
 
-                        if (classDecl.getBody().getStatements().stream().noneMatch(it -> isMethodDeclarationWithAnnotation(it, AFTER, AFTER_CLASS))) {
-                            Optional<Statement> beforeMethodJunit = after.getBody().getStatements().stream()
-                                    .filter(it -> isMethodDeclarationWithAnnotation(it, JUNIT_ANNOTATION))
+                        if (classDecl.getBody().getStatements().stream().noneMatch(it -> isMethodDeclarationWithAnnotation(it, AFTER))) {
+                            Optional<Statement> beforeMethodJunit4 = after.getBody().getStatements().stream()
+                                    .filter(it -> isMethodDeclarationWithAnnotation(it, JUNIT_4_ANNOTATION))
+                                    .findFirst();
+                            Optional<Statement> beforeMethodJunit5 = after.getBody().getStatements().stream()
+                                    .filter(it -> isMethodDeclarationWithAnnotation(it, JUNIT_5_ANNOTATION))
                                     .findFirst();
                             Optional<Statement> beforeMethodTestng = after.getBody().getStatements().stream()
                                     .filter(it -> isMethodDeclarationWithAnnotation(it, TESTNG_ANNOTATION))
                                     .findFirst();
-                            if (beforeMethodJunit.isPresent()) {
+                            if (beforeMethodJunit4.isPresent()) {
                                 maybeAddImport("org.junit.AfterClass");
                                 maybeAddImport("org.junit.After");
                                 after = JavaTemplate.builder(String.format(
@@ -211,7 +218,26 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                         .imports("org.junit.AfterClass", "org.junit.After")
                                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-4"))
                                         .build()
-                                        .apply(updateCursor(after), beforeMethodJunit.get().getCoordinates().after());
+                                        .apply(updateCursor(after), beforeMethodJunit4.get().getCoordinates().after());
+                            } else if (beforeMethodJunit5.isPresent()) {
+                                boolean staticForParameterized = isMethodDeclarationWithAnnotation(getCursor().firstEnclosing(J.MethodDeclaration.class), BEFORE_PARAM_CLASS_INV);
+                                maybeAddImport("org.junit.jupiter.api.AfterParameterizedClassInvocation");
+                                maybeAddImport("org.junit.jupiter.api.AfterAll");
+                                maybeAddImport("org.junit.jupiter.api.AfterEach");
+                                String annotatedQualifiers = staticSetup ?
+                                        (staticForParameterized ?
+                                                "@AfterParameterizedClassInvocation public static" :
+                                                "@AfterAll public static") :
+                                        "@AfterEach public";
+                                after = JavaTemplate.builder(String.format("%s void tearDown() {}", annotatedQualifiers))
+                                        .imports(
+                                                "org.junit.jupiter.api.AfterParameterizedClassInvocation",
+                                                "org.junit.jupiter.api.AfterAll",
+                                                "org.junit.jupiter.api.AfterEach"
+                                        )
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                                        .build()
+                                        .apply(updateCursor(after), beforeMethodJunit5.get().getCoordinates().after());
                             } else if (beforeMethodTestng.isPresent()) {
                                 maybeAddImport("org.testng.annotations.AfterClass");
                                 maybeAddImport("org.testng.annotations.AfterMethod");
@@ -233,7 +259,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration methodDecl, ExecutionContext ctx) {
                         J.MethodDeclaration md = super.visitMethodDeclaration(methodDecl, ctx);
 
-                        if (isMethodDeclarationWithAnnotation(md, AFTER, AFTER_CLASS)) {
+                        if (isMethodDeclarationWithAnnotation(md, AFTER)) {
                             return JavaTemplate.builder(variableName + ".close();")
                                     .contextSensitive()
                                     .build()


### PR DESCRIPTION
## What's changed?
- First commit is for adding support for recognizing JUnit 5's annotations (as the names have changed vs JUnit 4).
- Second commit is adding tests that fail that showcase that the logic for writing the `close()` method invocation need to be refined to ensure that we're not adding the call into a method where it would cause failures.

## What's your motivation?
We were only handling JUnit 4 and very recently TestNG, but not JUnit 5 annotations.

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
