### PR TITLE
`UseXMLUnitLegacyTest` to expect xmlunit 2.10.4

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseXMLUnitLegacyTest.java
@@ -60,7 +60,7 @@ class UseXMLUnitLegacyTest implements RewriteTest {
                     <dependency>
                       <groupId>org.xmlunit</groupId>
                       <artifactId>xmlunit-legacy</artifactId>
-                      <version>2.10.3</version>
+                      <version>2.10.4</version>
                     </dependency>
                   </dependencies>
                 </project>


### PR DESCRIPTION
## What's changed?

Changing the expected version in the `UseXMLUnitLegacyTest` test.
Likely after a new release of said library.

## What's your motivation?

Fix broken CI.
