### PR TITLE
Adjusting recognition of floats and doubles with regards to AssertJ assertions, given `JavaTemplate.Matcher` changes around matching `X.0` style numbers.

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJDoubleRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJDoubleRules.java
@@ -64,7 +64,12 @@ public class AssertJDoubleRules {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double n) {
       return Refaster.anyOf(
-          doubleAssert.isCloseTo(n, offset(0.0)), doubleAssert.isCloseTo(n, withPercentage(0.0)));
+          doubleAssert.isCloseTo(n, offset(0.0)),
+          doubleAssert.isCloseTo(n, offset(0d)),
+          doubleAssert.isCloseTo(n, withPercentage(0)),
+          doubleAssert.isCloseTo(n, withPercentage(0.0)),
+          doubleAssert.isCloseTo(n, withPercentage(0d))
+      );
     }
 
     @AfterTemplate
@@ -82,7 +87,11 @@ public class AssertJDoubleRules {
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double n) {
       return Refaster.anyOf(
           doubleAssert.isNotCloseTo(n, offset(0.0)),
-          doubleAssert.isNotCloseTo(n, withPercentage(0.0)));
+          doubleAssert.isNotCloseTo(n, offset(0d)),
+          doubleAssert.isNotCloseTo(n, withPercentage(0)),
+          doubleAssert.isNotCloseTo(n, withPercentage(0.0)),
+          doubleAssert.isNotCloseTo(n, withPercentage(0d))
+      );
     }
 
     @AfterTemplate
@@ -98,7 +107,11 @@ public class AssertJDoubleRules {
   static final class AbstractDoubleAssertIsZero {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
-      return doubleAssert.isEqualTo(0);
+      return Refaster.anyOf(
+          doubleAssert.isEqualTo(0),
+          doubleAssert.isEqualTo(0.0),
+          doubleAssert.isEqualTo(0d)
+      );
     }
 
     @AfterTemplate
@@ -114,7 +127,11 @@ public class AssertJDoubleRules {
   static final class AbstractDoubleAssertIsNotZero {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
-      return doubleAssert.isNotEqualTo(0);
+      return Refaster.anyOf(
+          doubleAssert.isNotEqualTo(0),
+          doubleAssert.isNotEqualTo(0.0),
+          doubleAssert.isNotEqualTo(0d)
+      );
     }
 
     @AfterTemplate
@@ -130,7 +147,11 @@ public class AssertJDoubleRules {
   static final class AbstractDoubleAssertIsOne {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
-      return doubleAssert.isEqualTo(1);
+      return Refaster.anyOf(
+          doubleAssert.isEqualTo(1),
+          doubleAssert.isEqualTo(1.0),
+          doubleAssert.isEqualTo(1d)
+      );
     }
 
     @AfterTemplate

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJFloatRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJFloatRules.java
@@ -64,7 +64,11 @@ public class AssertJFloatRules {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float n) {
       return Refaster.anyOf(
-          floatAssert.isCloseTo(n, offset(0f)), floatAssert.isCloseTo(n, withPercentage(0)));
+          floatAssert.isCloseTo(n, offset(0f)),
+          floatAssert.isCloseTo(n, withPercentage(0)),
+          floatAssert.isCloseTo(n, withPercentage(0.0)),
+          floatAssert.isCloseTo(n, withPercentage(0d))
+      );
     }
 
     @AfterTemplate
@@ -81,7 +85,11 @@ public class AssertJFloatRules {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float n) {
       return Refaster.anyOf(
-          floatAssert.isNotCloseTo(n, offset(0f)), floatAssert.isNotCloseTo(n, withPercentage(0)));
+          floatAssert.isNotCloseTo(n, offset(0f)),
+          floatAssert.isNotCloseTo(n, withPercentage(0)),
+          floatAssert.isNotCloseTo(n, withPercentage(0.0)),
+          floatAssert.isNotCloseTo(n, withPercentage(0d))
+      );
     }
 
     @AfterTemplate
@@ -97,7 +105,10 @@ public class AssertJFloatRules {
   static final class AbstractFloatAssertIsZero {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
-      return floatAssert.isEqualTo(0);
+      return Refaster.anyOf(
+          floatAssert.isEqualTo(0),
+          floatAssert.isEqualTo(0f)
+      );
     }
 
     @AfterTemplate
@@ -113,7 +124,10 @@ public class AssertJFloatRules {
   static final class AbstractFloatAssertIsNotZero {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
-      return floatAssert.isNotEqualTo(0);
+      return Refaster.anyOf(
+          floatAssert.isNotEqualTo(0),
+          floatAssert.isNotEqualTo(0f)
+      );
     }
 
     @AfterTemplate
@@ -129,7 +143,10 @@ public class AssertJFloatRules {
   static final class AbstractFloatAssertIsOne {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
-      return floatAssert.isEqualTo(1);
+      return Refaster.anyOf(
+          floatAssert.isEqualTo(1),
+          floatAssert.isEqualTo(1f)
+      );
     }
 
     @AfterTemplate

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJDoubleRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJDoubleRulesTest.java
@@ -40,6 +40,7 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isEqualTo(0);
                               Assertions.assertThat(d).isEqualTo(0.0);
                               Assertions.assertThat(d).isEqualTo(0d);
                           }
@@ -50,6 +51,7 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isZero();
                               Assertions.assertThat(d).isZero();
                               Assertions.assertThat(d).isZero();
                           }
@@ -69,7 +71,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isNotEqualTo(0);
                               Assertions.assertThat(d).isNotEqualTo(0.0);
+                              Assertions.assertThat(d).isNotEqualTo(0d);
                           }
                       }
                       """,
@@ -78,6 +82,8 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isNotZero();
+                              Assertions.assertThat(d).isNotZero();
                               Assertions.assertThat(d).isNotZero();
                           }
                       }
@@ -99,6 +105,7 @@ class AssertJDoubleRulesTest implements RewriteTest {
               class A {
                   public void test(double d, double expected) {
                       Assertions.assertThat(d).isEqualTo(expected, offset(0.0));
+                      Assertions.assertThat(d).isEqualTo(expected, offset(0d));
                       Assertions.assertThat(d).isEqualTo(expected, offset(1.0));
                   }
               }
@@ -110,6 +117,7 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d, double expected) {
+                      Assertions.assertThat(d).isEqualTo(expected);
                       Assertions.assertThat(d).isEqualTo(expected);
                       Assertions.assertThat(d).isCloseTo(expected, offset(1.0));
                   }
@@ -133,7 +141,10 @@ class AssertJDoubleRulesTest implements RewriteTest {
               class A {
                   public void test(double d, double expected) {
                       Assertions.assertThat(d).isCloseTo(expected, offset(0.0));
+                      Assertions.assertThat(d).isCloseTo(expected, offset(0d));
                       Assertions.assertThat(d).isCloseTo(expected, withPercentage(0));
+                      Assertions.assertThat(d).isCloseTo(expected, withPercentage(0.0));
+                      Assertions.assertThat(d).isCloseTo(expected, withPercentage(0d));
                   }
               }
               """,
@@ -142,6 +153,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d, double expected) {
+                      Assertions.assertThat(d).isEqualTo(expected);
+                      Assertions.assertThat(d).isEqualTo(expected);
+                      Assertions.assertThat(d).isEqualTo(expected);
                       Assertions.assertThat(d).isEqualTo(expected);
                       Assertions.assertThat(d).isEqualTo(expected);
                   }
@@ -165,7 +179,10 @@ class AssertJDoubleRulesTest implements RewriteTest {
               class A {
                   public void test(double d, double expected) {
                       Assertions.assertThat(d).isNotCloseTo(expected, offset(0.0));
+                      Assertions.assertThat(d).isNotCloseTo(expected, offset(0d));
                       Assertions.assertThat(d).isNotCloseTo(expected, withPercentage(0));
+                      Assertions.assertThat(d).isNotCloseTo(expected, withPercentage(0.0));
+                      Assertions.assertThat(d).isNotCloseTo(expected, withPercentage(0d));
                   }
               }
               """,
@@ -174,6 +191,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d, double expected) {
+                      Assertions.assertThat(d).isNotEqualTo(expected);
+                      Assertions.assertThat(d).isNotEqualTo(expected);
+                      Assertions.assertThat(d).isNotEqualTo(expected);
                       Assertions.assertThat(d).isNotEqualTo(expected);
                       Assertions.assertThat(d).isNotEqualTo(expected);
                   }
@@ -193,7 +213,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d) {
+                      Assertions.assertThat(d).isEqualTo(1);
                       Assertions.assertThat(d).isEqualTo(1.0);
+                      Assertions.assertThat(d).isEqualTo(1d);
                   }
               }
               """,
@@ -202,6 +224,8 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d) {
+                      Assertions.assertThat(d).isOne();
+                      Assertions.assertThat(d).isOne();
                       Assertions.assertThat(d).isOne();
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJFloatRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJFloatRulesTest.java
@@ -40,7 +40,10 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isEqualTo(0);
+                              Assertions.assertThat(f).isEqualTo(0f);
                               Assertions.assertThat(f).isEqualTo(0.0f);
+                              Assertions.assertThat(f).isEqualTo(0F);
                               Assertions.assertThat(f).isEqualTo(0.0F);
                           }
                       }
@@ -50,6 +53,9 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isZero();
+                              Assertions.assertThat(f).isZero();
+                              Assertions.assertThat(f).isZero();
                               Assertions.assertThat(f).isZero();
                               Assertions.assertThat(f).isZero();
                           }
@@ -69,6 +75,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isNotEqualTo(0);
+                              Assertions.assertThat(f).isNotEqualTo(0f);
                               Assertions.assertThat(f).isNotEqualTo(0.0f);
                           }
                       }
@@ -78,6 +86,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isNotZero();
+                              Assertions.assertThat(f).isNotZero();
                               Assertions.assertThat(f).isNotZero();
                           }
                       }
@@ -98,6 +108,7 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f, float expected) {
+                      Assertions.assertThat(f).isEqualTo(expected, offset(0f));
                       Assertions.assertThat(f).isEqualTo(expected, offset(0.0f));
                       Assertions.assertThat(f).isEqualTo(expected, offset(1.0f));
                   }
@@ -110,6 +121,7 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f, float expected) {
+                      Assertions.assertThat(f).isEqualTo(expected);
                       Assertions.assertThat(f).isEqualTo(expected);
                       Assertions.assertThat(f).isCloseTo(expected, offset(1.0f));
                   }
@@ -166,6 +178,8 @@ class AssertJFloatRulesTest implements RewriteTest {
                   public void test(float f, float expected) {
                       Assertions.assertThat(f).isNotCloseTo(expected, offset(0.0f));
                       Assertions.assertThat(f).isNotCloseTo(expected, withPercentage(0));
+                      Assertions.assertThat(f).isNotCloseTo(expected, withPercentage(0.0));
+                      Assertions.assertThat(f).isNotCloseTo(expected, withPercentage(0d));
                   }
               }
               """,
@@ -174,6 +188,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f, float expected) {
+                      Assertions.assertThat(f).isNotEqualTo(expected);
+                      Assertions.assertThat(f).isNotEqualTo(expected);
                       Assertions.assertThat(f).isNotEqualTo(expected);
                       Assertions.assertThat(f).isNotEqualTo(expected);
                   }
@@ -193,6 +209,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f) {
+                      Assertions.assertThat(f).isEqualTo(1);
+                      Assertions.assertThat(f).isEqualTo(1f);
                       Assertions.assertThat(f).isEqualTo(1.0f);
                   }
               }
@@ -202,6 +220,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f) {
+                      Assertions.assertThat(f).isOne();
+                      Assertions.assertThat(f).isOne();
                       Assertions.assertThat(f).isOne();
                   }
               }


### PR DESCRIPTION
This is a fix following the below change in `openrewrite/rewrite`:
- https://github.com/openrewrite/rewrite/pull/6056

## What's changed?
Because `X.0` is no longer matched as `X` in relation to doubles, the Refaster matchers for AssertJ assertions needed to be updated to additionally recognize cases that are supported by AssertJ itself.

## What's your motivation?
Broken tests

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
