### PR TITLE
fix: add Mockito.anyObject() alias to Mockito 1-to-3 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -183,3 +183,6 @@ recipeList:
       groupId: net.bytebuddy
       artifactId: byte-buddy*
       newVersion: 1.11.13
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.mockito.Mockito anyObject()
+      newMethodName: any

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
@@ -283,4 +283,71 @@ class Mockito1to3MigrationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void handlesAnyObjectFromMockitoWildCardImport() {
+        rewriteRun(
+          java(
+            """
+            package com.yourorg;
+            import static org.mockito.Mockito.*;
+
+            public class MyTest {
+                void test() {
+                    Object o = anyObject();
+                }
+            }
+            """,
+            """
+            package com.yourorg;
+            import static org.mockito.Mockito.any;
+
+            public class MyTest {
+                void test() {
+                    Object o = any();
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void handlesAnyObjectFromMockitoWildCardImport_keepsWildCardIfManyUsages() {
+        rewriteRun(
+          java(
+            """
+            package com.yourorg;
+            import java.util.List;
+            import static org.mockito.Mockito.*;
+
+            public class MyTest {
+                void test() {
+                    Object o1 = anyObject();
+                    Object o2 = doNothing().when(new Object());
+                    verify(o2, never());
+                    mock(List.class);
+                    spy(new Object());
+                }
+            }
+            """,
+            """
+            package com.yourorg;
+            import java.util.List;
+            import static org.mockito.Mockito.*;
+
+            public class MyTest {
+                void test() {
+                    Object o1 = any();
+                    Object o2 = doNothing().when(new Object());
+                    verify(o2, never());
+                    mock(List.class);
+                    spy(new Object());
+                }
+            }
+            """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
`import static org.mockito.Mockito.*;` causes `anyObject()` to be missed by the current recipe. 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
