### PR TITLE
Upgrade mockwebserver to latest 5.x version

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -262,7 +262,7 @@ recipeList:
       oldGroupId: com.squareup.okhttp3
       oldArtifactId: mockwebserver
       newArtifactId: mockwebserver3-junit5
-      newVersion: 5.1.0
+      newVersion: 5.x
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.junit5.CleanupAssertions

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -79,21 +80,7 @@ class UpgradeOkHttpMockWebServerTest implements RewriteTest {
                   </dependencies>
                 </project>
                 """,
-              """
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>demo</artifactId>
-                  <version>0.0.1-SNAPSHOT</version>
-                  <dependencies>
-                    <dependency>
-                      <groupId>com.squareup.okhttp3</groupId>
-                      <artifactId>mockwebserver3-junit5</artifactId>
-                      <version>5.1.0</version>
-                    </dependency>
-                  </dependencies>
-                </project>
-                """
+              spec -> spec.after(pom -> assertThat(pom).containsPattern("<version>5\\.(.*)</version>").actual())
             )
           )
         );


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Instead of upgrading `mockwebserver3-junit5` to `5.1.0`, it will upgrade to the latest version of `5.x` availabe.
<!-- A brief description of the changes in this pull request -->

## What's your motivation?
I keep manually upgrading from 5.1.0 to the latest myself.
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
First PR to OpenRewrite, any advice is appreciated.
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
N/A
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
I can keep doing it manually or running a custom recipe after I ran these.
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
N/A
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
