### PR TITLE
Fixed the expectation to be correctly spaced + formatted args

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -360,7 +360,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
                 assert m.getBody() != null;
                 JavaCoordinates newStatementCoordinates = !m.getBody().getStatements().isEmpty() ? m.getBody().getStatements().get(0).getCoordinates().before() : m.getBody().getCoordinates().lastStatement();
                 m = initMethodStatementTemplate.apply(updateCursor(m), newStatementCoordinates, initStatementParamString);
-                m = maybeAutoFormat(m, m.withParameters(parameterizedTestMethodParameters), m.getName(), ctx, getCursor().getParentTreeCursor());
+                m = maybeAutoFormat(m, m.withParameters(parameterizedTestMethodParameters), parameterizedTestMethodParameters.get(parameterizedTestMethodParameters.size() - 1), ctx, getCursor().getParentTreeCursor());
             }
 
             // Change constructor to test init method

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockUpToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitMockUpToMockitoTest.java
@@ -207,7 +207,7 @@ class JMockitMockUpToMockitoTest implements RewriteTest {
                           String echo = invocation.getArgument(0);
                           return "BAR" + echo;
                       }).when(mockBar).getMsg(nullable(String.class));
-                      try (MockedConstruction mockConsFoo = mockConstructionWithAnswer(Foo.class, delegatesTo(mockFoo));MockedConstruction mockConsBar = mockConstructionWithAnswer(Bar.class, delegatesTo(mockBar))) {
+                      try (MockedConstruction mockConsFoo = mockConstructionWithAnswer(Foo.class, delegatesTo(mockFoo)); MockedConstruction mockConsBar = mockConstructionWithAnswer(Bar.class, delegatesTo(mockBar))) {
                           assertEquals("FOO", new Foo().getMsg());
                           assertEquals("FOOecho", new Foo().getMsg("echo"));
                           assertEquals("BAR", new Bar().getMsg());
@@ -374,7 +374,7 @@ class JMockitMockUpToMockitoTest implements RewriteTest {
                           MockUpClass.Save.msg = "mockMsg";
                           return null;
                       }).when(mockMockUpClass).changeMsg();
-                      try (MockedStatic mockStaticMockUpClass = mockStatic(MockUpClass.class);MockedConstruction mockConsMockUpClass = mockConstructionWithAnswer(MockUpClass.class, delegatesTo(mockMockUpClass))) {
+                      try (MockedStatic mockStaticMockUpClass = mockStatic(MockUpClass.class); MockedConstruction mockConsMockUpClass = mockConstructionWithAnswer(MockUpClass.class, delegatesTo(mockMockUpClass))) {
                           mockStaticMockUpClass.when(() -> MockUpClass.changeText(nullable(String.class))).thenAnswer(invocation -> {
                               String text = invocation.getArgument(0);
                               MockUpClass.Save.text = "mockText";


### PR DESCRIPTION
The spaces formatting upstream has been fixed to correctly add spaces between the try resources
We also should call formatting untill the last argument and not untill the method name in order to get correct formatting applied. 