### PR TITLE
throwing ParseError.toException

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/GradleUseJunitJupiter.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/GradleUseJunitJupiter.java
@@ -263,12 +263,7 @@ public class GradleUseJunitJupiter extends Recipe {
             return Optional.empty();
         }
         if (sourceFile instanceof ParseError) {
-            ParseError parseError = (ParseError) sourceFile;
-            throw new IllegalStateException(
-                    "Failed to parse Groovy snippet for useJUnitPlatform(). " +
-                    "Snippet: [" + groovySnippet.replace("\n", "\\n") + "]",
-                    parseError.toException()
-            );
+            throw ((ParseError) sourceFile).toException();
         }
         G.CompilationUnit cu = (G.CompilationUnit) sourceFile;
         return Optional.of((J.MethodInvocation) cu.getStatements().get(1));


### PR DESCRIPTION
## What's changed?

- Continuation of #852.
Attempting to provide more meaningful context to a repeatable, but intermittent issue of Groovy parsing failure.

## What's your motivation?

Have more context to troubleshoot a rare issue.
```
Message:

Failed to parse Groovy snippet for useJUnitPlatform(). Snippet: [plugins {\n    id 'java'\n}\ntasks.withType(Test) {\n    useJUnitPlatform()\n}]
Detail:

java.lang.IllegalStateException: Failed to parse Groovy snippet for useJUnitPlatform(). Snippet: [plugins {\n    id 'java'\n}\ntasks.withType(Test) {\n    useJUnitPlatform()\n}]
  org.openrewrite.java.testing.junit5.GradleUseJunitJupiter.createTaskUseJUnitPlatform(GradleUseJunitJupiter.java:270)
  org.openrewrite.java.testing.junit5.GradleUseJunitJupiter.access$600(GradleUseJunitJupiter.java:45)
```