### PR TITLE
Skip Kotlin files in PowerMockitoMockStaticToMockito

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.*;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.staticanalysis.kotlin.KotlinFileChecker;
 
 import java.util.*;
 
@@ -43,9 +44,12 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                Preconditions.or(
-                        new UsesType<>("org.powermock..*", false),
-                        new UsesType<>("org.mockito..*", false)
+                Preconditions.and(
+                        Preconditions.or(
+                                new UsesType<>("org.powermock..*", false),
+                                new UsesType<>("org.mockito..*", false)
+                        ),
+                        Preconditions.not(new KotlinFileChecker<>())
                 ),
                 new PowerMockitoToMockitoVisitor()
         );

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -743,8 +743,11 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1703")
     @Test
-    void shouldRefactorKotlinPowerMockitoToMockito() {
+    void shouldNotModifyKotlinFilesWithMockStatic() {
+        // Kotlin files are skipped because Kotlin's .use { } blocks don't map to J.Try.Resource
+        // in the AST, causing the recipe to incorrectly delete mockStatic() calls
         rewriteRun(
           spec -> spec.typeValidationOptions(TypeValidation.all().methodInvocations(false)),
           //language=kotlin


### PR DESCRIPTION
## Summary
- Skip Kotlin files in PowerMockitoMockStaticToMockito recipe to prevent incorrect code deletion
- Add KotlinFileChecker precondition, consistent with CleanupMockitoImports

## Problem
The recipe was deleting `mockStatic()` calls in Kotlin files that use `.use { }` blocks (Kotlin's equivalent of try-with-resources). The recipe checks if `mockStatic()` is inside `J.Try.Resource` to determine if it's properly scoped, but Kotlin's `.use { }` doesn't produce that AST structure—it's just a method call with a lambda.

**Before (Kotlin code that was being broken):**
```kotlin
mockStatic(LocalDateTime::class.java).use { mockedLocalDateTime ->
    mockedLocalDateTime.`when`<LocalDateTime> { LocalDateTime.now() }.thenReturn(expected)
}
```

**After recipe ran (broken):**
```kotlin
.use { mockedLocalDateTime ->
    mockedLocalDateTime.`when`<LocalDateTime> { LocalDateTime.now() }.thenReturn(expected)
}
```

## Solution
Add `Preconditions.not(new KotlinFileChecker<>())` to skip Kotlin files entirely. This is the same approach used by `CleanupMockitoImports` in this codebase.

## Test plan
- [x] Existing tests pass
- [x] Renamed test to `shouldNotModifyKotlinFilesWithMockStatic` with `@Issue` annotation linking to customer report

- Fixes https://github.com/moderneinc/customer-requests/issues/1703