### PR TITLE
Update byte buddy to a Java 25 compatible version

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -61,7 +61,7 @@ recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: net.bytebuddy
       artifactId: byte-buddy*
-      newVersion: 1.15.x
+      newVersion: 1.17.x
   - org.openrewrite.maven.RemoveDuplicateDependencies
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoInlineToCoreTest.java
@@ -169,7 +169,7 @@ class MockitoInlineToCoreTest implements RewriteTest {
               </project>
               """.formatted(
               Pattern.compile("<version>(5.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1),
-              Pattern.compile("<version>(1.15.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1)))
+              Pattern.compile("<version>(1.17.+)</version>").matcher(after).results().findFirst().orElseThrow().group(1)))
           )
         );
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The version of byte buddy is now being upgraded further to 1.17.+ which is Java 25 compatible

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Seeing issues in a Java 25 migration

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
