### PR TITLE
Revert "Add explicit test scope to AssertJ dependency additions (#903)"

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -527,7 +527,6 @@ recipeList:
       version: 3.x
       onlyIfUsing: org.junit.jupiter.api.Assertions
       acceptTransitive: true
-      scope: test
   - tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes
 
 ---

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -4068,8 +4068,8 @@ examples:
           @Test
           void test() {
               try (MockedConstruction<A> aMockedConstruction = mockConstruction(A.class, (mock, context) -> {
-                       when(mock.method(any())).thenReturn("XYZ");
-                   })) {
+                  when(mock.method(any())).thenReturn("XYZ");
+              })) {
                   A instance = new A();
                   assertEquals("XYZ", instance.method("test"));
               }

--- a/src/main/resources/META-INF/rewrite/hamcrest.yml
+++ b/src/main/resources/META-INF/rewrite/hamcrest.yml
@@ -100,7 +100,6 @@ recipeList:
       version: 3.x
       onlyIfUsing: org.hamcrest.*
       acceptTransitive: true
-      scope: test
 
   # Normalize Hamcrest imports to `org.hamcrest.Matchers` and remove wrapping `is(Matcher)` calls
   - org.openrewrite.java.testing.hamcrest.ConsistentHamcrestMatcherImports

--- a/src/main/resources/META-INF/rewrite/testng.yml
+++ b/src/main/resources/META-INF/rewrite/testng.yml
@@ -32,7 +32,6 @@ recipeList:
       version: 3.x
       onlyIfUsing: org.testng.*
       acceptTransitive: true
-      scope: test
   - tech.picnic.errorprone.refasterrules.TestNGToAssertJRulesRecipes
   - org.openrewrite.java.testing.testng.TestNgAssertEqualsToAssertThat
   - org.openrewrite.java.testing.testng.TestNgAssertNotEqualsToAssertThat

--- a/src/main/resources/META-INF/rewrite/truth.yml
+++ b/src/main/resources/META-INF/rewrite/truth.yml
@@ -33,7 +33,6 @@ recipeList:
       version: 3.x
       onlyIfUsing: com.google.common.truth.*
       acceptTransitive: true
-      scope: test
 
   # Handle Truth's assert_() static method
   - org.openrewrite.java.testing.truth.TruthAssertToAssertThat


### PR DESCRIPTION
This reverts commit 02eba0f40f21d363103d52b12a9a63e61904c7d1 as it has been implemented in a cleaner way upstream.