### PR TITLE
Fix 2 AssertJ migration recipe issues found via large-scale validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/
 *.log
 .vscode/
 src/main/generated/
+working-set*/

--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifyRedundantAssertJChains.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifyRedundantAssertJChains.java
@@ -68,8 +68,7 @@ public class SimplifyRedundantAssertJChains extends Recipe {
             new MethodMatcher("org.assertj.core.api..* isNotPresent()"),
             new MethodMatcher("org.assertj.core.api..* isTrue()"),
             new MethodMatcher("org.assertj.core.api..* isFalse()"),
-            new MethodMatcher("org.assertj.core.api..* isNotEqualTo(..)"),
-            new MethodMatcher("org.assertj.core.api..* isNotSameAs(..)"),
+            // Note: isNotEqualTo and isNotSameAs are NOT here because they pass when actual is null
             new MethodMatcher("org.assertj.core.api..* isInstanceOf(..)"),
             new MethodMatcher("org.assertj.core.api..* hasSameClassAs(..)"),
             new MethodMatcher("org.assertj.core.api..* hasToString(..)"),

--- a/src/main/java/org/openrewrite/java/testing/truth/TruthThrowableAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/truth/TruthThrowableAssertions.java
@@ -33,6 +33,10 @@ public class TruthThrowableAssertions extends Recipe {
     private static final MethodMatcher HAS_MESSAGE_THAT = new MethodMatcher("com.google.common.truth.ThrowableSubject hasMessageThat()");
     private static final MethodMatcher HAS_CAUSE_THAT = new MethodMatcher("com.google.common.truth.ThrowableSubject hasCauseThat()");
     private static final MethodMatcher CONTAINS = new MethodMatcher("com.google.common.truth.StringSubject contains(..)");
+    private static final MethodMatcher CONTAINS_MATCH = new MethodMatcher("com.google.common.truth.StringSubject containsMatch(..)");
+    private static final MethodMatcher DOES_NOT_CONTAIN = new MethodMatcher("com.google.common.truth.StringSubject doesNotContain(..)");
+    private static final MethodMatcher STARTS_WITH = new MethodMatcher("com.google.common.truth.StringSubject startsWith(..)");
+    private static final MethodMatcher ENDS_WITH = new MethodMatcher("com.google.common.truth.StringSubject endsWith(..)");
     private static final MethodMatcher IS_EQUAL_TO = new MethodMatcher("com.google.common.truth.Subject isEqualTo(..)");
     private static final MethodMatcher IS_INSTANCE_OF = new MethodMatcher("com.google.common.truth.Subject isInstanceOf(..)");
 
@@ -66,6 +70,66 @@ public class TruthThrowableAssertions extends Recipe {
                             maybeRemoveImport("com.google.common.truth.Truth.assertThat");
                             maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
                             return JavaTemplate.builder("assertThat(#{any()}).hasMessageContaining(#{any()})")
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
+                                    .staticImports("org.assertj.core.api.Assertions.assertThat")
+                                    .build()
+                                    .apply(getCursor(),
+                                            mi.getCoordinates().replace(),
+                                            assertThat.getArguments().get(0),
+                                            mi.getArguments().get(0));
+                        }
+
+                        // Handle hasMessageThat().containsMatch(regex)
+                        if (CONTAINS_MATCH.matches(mi) && HAS_MESSAGE_THAT.matches(hasMethod)) {
+                            maybeRemoveImport("com.google.common.truth.Truth");
+                            maybeRemoveImport("com.google.common.truth.Truth.assertThat");
+                            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                            return JavaTemplate.builder("assertThat(#{any()}).hasMessageMatching(#{any()})")
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
+                                    .staticImports("org.assertj.core.api.Assertions.assertThat")
+                                    .build()
+                                    .apply(getCursor(),
+                                            mi.getCoordinates().replace(),
+                                            assertThat.getArguments().get(0),
+                                            mi.getArguments().get(0));
+                        }
+
+                        // Handle hasMessageThat().doesNotContain(text)
+                        if (DOES_NOT_CONTAIN.matches(mi) && HAS_MESSAGE_THAT.matches(hasMethod)) {
+                            maybeRemoveImport("com.google.common.truth.Truth");
+                            maybeRemoveImport("com.google.common.truth.Truth.assertThat");
+                            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                            return JavaTemplate.builder("assertThat(#{any()}).hasMessageNotContaining(#{any()})")
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
+                                    .staticImports("org.assertj.core.api.Assertions.assertThat")
+                                    .build()
+                                    .apply(getCursor(),
+                                            mi.getCoordinates().replace(),
+                                            assertThat.getArguments().get(0),
+                                            mi.getArguments().get(0));
+                        }
+
+                        // Handle hasMessageThat().startsWith(prefix)
+                        if (STARTS_WITH.matches(mi) && HAS_MESSAGE_THAT.matches(hasMethod)) {
+                            maybeRemoveImport("com.google.common.truth.Truth");
+                            maybeRemoveImport("com.google.common.truth.Truth.assertThat");
+                            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                            return JavaTemplate.builder("assertThat(#{any()}).hasMessageStartingWith(#{any()})")
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
+                                    .staticImports("org.assertj.core.api.Assertions.assertThat")
+                                    .build()
+                                    .apply(getCursor(),
+                                            mi.getCoordinates().replace(),
+                                            assertThat.getArguments().get(0),
+                                            mi.getArguments().get(0));
+                        }
+
+                        // Handle hasMessageThat().endsWith(suffix)
+                        if (ENDS_WITH.matches(mi) && HAS_MESSAGE_THAT.matches(hasMethod)) {
+                            maybeRemoveImport("com.google.common.truth.Truth");
+                            maybeRemoveImport("com.google.common.truth.Truth.assertThat");
+                            maybeAddImport("org.assertj.core.api.Assertions", "assertThat");
+                            return JavaTemplate.builder("assertThat(#{any()}).hasMessageEndingWith(#{any()})")
                                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
                                     .staticImports("org.assertj.core.api.Assertions.assertThat")
                                     .build()

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifyRedundantAssertJChainsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifyRedundantAssertJChainsTest.java
@@ -282,8 +282,6 @@ class SimplifyRedundantAssertJChainsTest implements RewriteTest {
                       assertThat(obj).isNotNull().isEqualTo(other);
                       assertThat(obj).isNotNull().isSameAs(other);
 
-                      assertThat(obj).isNotNull().isNotEqualTo(other);
-                      assertThat(obj).isNotNull().isNotSameAs(other);
                       assertThat(obj).isNotNull().isInstanceOf(String.class);
                       assertThat(obj).isNotNull().hasSameClassAs(other);
                       assertThat(obj).isNotNull().hasToString("text");
@@ -298,11 +296,30 @@ class SimplifyRedundantAssertJChainsTest implements RewriteTest {
                       assertThat(obj).isNotNull().isEqualTo(other);
                       assertThat(obj).isNotNull().isSameAs(other);
 
-                      assertThat(obj).isNotEqualTo(other);
-                      assertThat(obj).isNotSameAs(other);
                       assertThat(obj).isInstanceOf(String.class);
                       assertThat(obj).hasSameClassAs(other);
                       assertThat(obj).hasToString("text");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotSimplifyIsNotNullBeforeNegatedAssertions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test(Object obj, Object other) {
+                      // isNotEqualTo passes when actual is null, so isNotNull is NOT redundant
+                      assertThat(obj).isNotNull().isNotEqualTo(other);
+                      // isNotSameAs passes when actual is null, so isNotNull is NOT redundant
+                      assertThat(obj).isNotNull().isNotSameAs(other);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/truth/TruthThrowableAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/truth/TruthThrowableAssertionsTest.java
@@ -125,6 +125,122 @@ class TruthThrowableAssertionsTest implements RewriteTest {
     }
 
     @Test
+    void hasMessageThatContainsMatch() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static com.google.common.truth.Truth.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new IllegalArgumentException("Invalid argument provided");
+                      assertThat(e).hasMessageThat().containsMatch("(?i:invalid)");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new IllegalArgumentException("Invalid argument provided");
+                      assertThat(e).hasMessageMatching("(?i:invalid)");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void hasMessageThatDoesNotContain() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static com.google.common.truth.Truth.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageThat().doesNotContain("success");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageNotContaining("success");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void hasMessageThatStartsWith() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static com.google.common.truth.Truth.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageThat().startsWith("Error");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageStartingWith("Error");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void hasMessageThatEndsWith() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static com.google.common.truth.Truth.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageThat().endsWith("occurred");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test() {
+                      Exception e = new RuntimeException("Error occurred");
+                      assertThat(e).hasMessageEndingWith("occurred");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void multipleThrowableAssertions() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary

Fixed two issues discovered by running the AssertJ composite recipe against 12 real-world repositories (generating 4,139 patches):

1. **SimplifyRedundantAssertJChains**: Don't drop `isNotNull()` before `isNotEqualTo()`/`isNotSameAs()` since these assertions pass when actual is null, making the null check not redundant. Found ~107 incorrect transformations in Spring Framework alone.

2. **TruthThrowableAssertions**: Added handlers for 4 additional `hasMessageThat()` chains (`containsMatch`, `doesNotContain`, `startsWith`, `endsWith`) to prevent leaving Truth-only method calls that cause compilation errors.

## Test Plan

- [x] All existing tests pass  
- [x] New regression test prevents dropping `isNotNull()` before negated assertions
- [x] Four new tests validate the added Truth→AssertJ conversions