### PR TITLE
Fix ClassCastException in RemoveTimesZeroAndOne

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOne.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOne.java
@@ -59,7 +59,8 @@ public class RemoveTimesZeroAndOne extends Recipe {
                                     .build()
                                     .apply(getCursor(), mi.getCoordinates().replace());
                         }
-                        if (verifyMatcher.matches(mi) && mi.getArguments().size() == 2) {
+                        if (verifyMatcher.matches(mi) && mi.getArguments().size() == 2 &&
+                                mi.getArguments().get(1) instanceof J.MethodInvocation) {
                             J.MethodInvocation times = (J.MethodInvocation) mi.getArguments().get(1);
                             if (timesMatcher.matches(times) && J.Literal.isLiteralValue(times.getArguments().get(0), 1)) {
                                 maybeRemoveImport("org.mockito.Mockito.times");

--- a/src/test/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOneTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOneTest.java
@@ -96,6 +96,27 @@ class RemoveTimesZeroAndOneTest implements RewriteTest {
     }
 
     @Test
+    void retainVerificationModeIdentifier() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import static org.mockito.Mockito.times;
+              import static org.mockito.Mockito.verify;
+              import org.mockito.verification.VerificationMode;
+
+              class MyTest {
+                  void test(Object myObject, VerificationMode verificationMode) {
+                      myObject.wait();
+                      verify(myObject, verificationMode).wait();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainTimesTwo() {
         rewriteRun(
           //language=Java

--- a/src/test/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOneTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/RemoveTimesZeroAndOneTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.testing.mockito;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -96,6 +97,7 @@ class RemoveTimesZeroAndOneTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/968")
     void retainVerificationModeIdentifier() {
         rewriteRun(
           //language=Java


### PR DESCRIPTION
## Summary
- Fixes #968
- Added `instanceof J.MethodInvocation` check before casting the second argument of `verify()` in `RemoveTimesZeroAndOne`, preventing a `ClassCastException` when the argument is an identifier (e.g., a `VerificationMode` variable) rather than a `times()` call
- Added test case for `verify(obj, verificationMode)` where `verificationMode` is a variable

## Test plan
- [x] New test `retainVerificationModeIdentifier` passes
- [x] All existing tests still pass