### PR TITLE
Use KotlinTypeUtils.isKotlinUnit to match Kotlin void return types

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
@@ -26,6 +26,7 @@ import org.openrewrite.kotlin.KotlinVisitor;
 import org.openrewrite.kotlin.marker.KObject;
 import org.openrewrite.kotlin.marker.SingleExpressionBlock;
 import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.kotlin.tree.KotlinTypeUtils;
 import org.openrewrite.marker.Markers;
 
 import static java.util.Collections.emptyList;
@@ -52,7 +53,7 @@ public class KotlinTestMethodsShouldReturnUnit extends Recipe {
 
                 // Skip invalid signatures or already-correct return types
                 JavaType.Method methodType = m.getMethodType();
-                if (m.getBody() == null || methodType == null || TypeUtils.isOfClassType(methodType.getReturnType(), KOTLIN_UNIT.getFullyQualifiedName())) {
+                if (m.getBody() == null || methodType == null || KotlinTypeUtils.isKotlinUnit(methodType.getReturnType())) {
                     return m;
                 }
 

--- a/src/test/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnitTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnitTest.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.java.testing.cleanup;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -309,7 +308,6 @@ class KotlinTestMethodsShouldReturnUnitTest implements RewriteTest {
         );
     }
 
-    @Disabled("flaky on CI but I don't know why")
     @Test
     void doNotChangeAlreadyUnitTestMethods() {
         //language=kotlin


### PR DESCRIPTION
## Summary

- Follow-up to #970, which disabled `doNotChangeAlreadyUnitTestMethods` with comment _"flaky on CI but I don't know why"_.
- Root cause: as of rewrite 8.79.4 ([openrewrite/rewrite#7364](https://github.com/openrewrite/rewrite/pull/7364)), the Kotlin parser maps non-nullable `kotlin.Unit` to `JavaType.Primitive.Void`. `TypeUtils.isOfClassType(type, "kotlin.Unit")` returns false for a primitive, so the recipe no longer skips already-Unit methods and rewrites them unnecessarily — tripping the single-cycle stability check on CI. Locally, stale `rewrite-kotlin` snapshots still carry the pre-change behaviour, which is why the failure was CI-only.
- [CI failure](https://github.com/openrewrite/rewrite-testing-frameworks/actions/runs/24470119694) — `KotlinTestMethodsShouldReturnUnitTest > doNotChangeAlreadyUnitTestMethods() FAILED: Expected recipe to complete in 0 cycle, but took 1 cycle.`

## What this PR does

- Switch `TypeUtils.isOfClassType(type, "kotlin.Unit")` → `KotlinTypeUtils.isKotlinUnit(type)` (helper introduced in rewrite#7364 specifically for this transition — accepts either `Primitive.Void` or the `kotlin.Unit` class form).
- Re-enable `doNotChangeAlreadyUnitTestMethods`.

## Test plan

- [ ] `./gradlew test --tests KotlinTestMethodsShouldReturnUnitTest` passes on CI against rewrite 8.79.4+