### PR TITLE
Silence javac warnings about unknown API$Status enum constants

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     compileOnly("org.junit.jupiter:junit-jupiter-engine:5.13.3")
     compileOnly("org.assertj:assertj-core:3.27.7")
     compileOnly("junit:junit:4.13.2")
+    compileOnly("org.apiguardian:apiguardian-api:1.1.2")
 
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")


### PR DESCRIPTION
Add `apiguardian-api` as a `compileOnly` dependency so `javac` can resolve `@API(status = ...)` annotation values on class files pulled in via other `compileOnly` deps (notably `junit-jupiter-engine` and `error_prone_core`). Without it, `javac` emits repeated `warning: unknown enum constant API$Status.STABLE/DEPRECATED/MAINTAINED` lines that clutter CI logs. No runtime impact — `compileOnly` keeps it out of the published artifact.