### PR TITLE
Fix GradleUseJunitJupiter template snippet failing to parse

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/GradleUseJunitJupiter.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/GradleUseJunitJupiter.java
@@ -31,6 +31,7 @@ import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.tree.ParseError;
 
@@ -242,10 +243,7 @@ public class GradleUseJunitJupiter extends Recipe {
     }
 
     private static Optional<J.MethodInvocation> createTaskUseJUnitPlatform(ExecutionContext ctx, boolean forEachInvocation) {
-        String groovySnippet = "plugins {\n" +
-                "    id 'java'\n" +
-                "}\n" +
-                "tasks.withType(Test)" + (forEachInvocation ? ".configureEach" : "") + " {\n" +
+        String groovySnippet = "tasks.withType(Test)" + (forEachInvocation ? ".configureEach" : "") + " {\n" +
                 "    useJUnitPlatform()\n" +
                 "}";
         SourceFile sourceFile = GradleParser.builder()
@@ -260,6 +258,6 @@ public class GradleUseJunitJupiter extends Recipe {
             throw ((ParseError) sourceFile).toException();
         }
         G.CompilationUnit cu = (G.CompilationUnit) sourceFile;
-        return Optional.of((J.MethodInvocation) cu.getStatements().get(1));
+        return Optional.of(((J.MethodInvocation) cu.getStatements().get(0)).withPrefix(Space.format("\n")));
     }
 }


### PR DESCRIPTION
## Motivation

`GradleUseJunitJupiter.createTaskUseJUnitPlatform` synthesizes a small Groovy snippet and parses it to obtain an AST node for the `tasks.withType(Test).configureEach { useJUnitPlatform() }` block it wants to insert. The snippet wrapped the tasks block with a superfluous `plugins { id 'java' }` preamble so the result could be extracted from `statements.get(1)`.

In one of our recipe runs against `spring-projects/spring-integration/build.gradle` the Groovy parser threw while processing the statement boundary between the plugins block and the tasks block:

```
java.lang.IllegalStateException: GroovyParsingException: org.openrewrite.groovy.GroovyParsingException: Failed to parse 193946072155627/build.gradle at cursor position 25. The surrounding characters in the original source are:
plugins {
    id 'java'
}~cursor~>
tasks.withType(Test).configureEach {
    useJUnitPlatform()
}
  org.openrewrite.groovy.GroovyParserVisitor.visit(GroovyParserVisitor.java:223)
  org.openrewrite.tree.ParseError.toException(ParseError.java:121)
  org.openrewrite.java.testing.junit5.GradleUseJunitJupiter.createTaskUseJUnitPlatform(GradleUseJunitJupiter.java:260)
  org.openrewrite.java.testing.junit5.GradleUseJunitJupiter.access$600(GradleUseJunitJupiter.java:45)
  org.openrewrite.java.testing.junit5.GradleUseJunitJupiter$AddUseJUnitPlatform.visitCompilationUnit(GradleUseJunitJupiter.java:149)
```

The preamble is not needed for AST extraction — no type resolution from the plugins block was actually used — and dropping it makes the snippet a single statement that is strictly easier for the Groovy parser to handle.

## Summary

- Strip the `plugins { id 'java' }` preamble from the template snippet and extract `statements.get(0)`.
- Set an explicit leading `\n` prefix on the returned method invocation so that appending it preserves prior formatting.

## Test plan

- [x] `./gradlew test --tests 'org.openrewrite.java.testing.junit5.GradleUseJunitJupiterTest'`
- [x] `./gradlew test --tests '*Gradle*'`