### PR TITLE
Fix `UpdateMockWebServerDispatcher` classpath lookup

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServerDispatcher.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateMockWebServerDispatcher.java
@@ -98,7 +98,7 @@ public class UpdateMockWebServerDispatcher extends Recipe {
                         }
                         J.MethodInvocation wrapped = JavaTemplate
                                 .builder("#{any(" + OLD_MOCK_RESPONSE_FQN + ")}.build()")
-                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(c, "mockwebserver-4.10", "okhttp-4.10"))
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(c, "mockwebserver-4.10"))
                                 .build()
                                 .apply(new Cursor(getCursor(), expr), expr.getCoordinates().replace(), expr);
                         wrapped = wrapped.withMethodType(buildMethodType)


### PR DESCRIPTION
## Motivation

- `UpdateMockWebServerDispatcher` (added in #972) asks `JavaParser` for the `okhttp-4.10` classpath resource:

```java
.javaParser(JavaParser.fromJavaVersion().classpathFromResources(c, "mockwebserver-4.10", "okhttp-4.10"))
```

That artifact is only declared as a `testParserClasspath` dependency, so it lives in the **test** type table (`src/test/resources/META-INF/rewrite/classpath.tsv.gz`) and is **not** bundled with the published recipe artifact. Local unit tests pass because both type tables are on the classpath; production runs (Moderne CLI, etc.) blow up the moment they hit a `Dispatcher.dispatch()` override:

```
java.lang.IllegalArgumentException: Unable to find classpath resource dependencies beginning with: 'okhttp-4.10' in [..., mockwebserver-4.10.0, ...]
  org.openrewrite.java.JavaParser.dependenciesFromResources(JavaParser.java:171)
  org.openrewrite.java.JavaParser$Builder.classpathFromResources(JavaParser.java:318)
  org.openrewrite.java.testing.junit5.UpdateMockWebServerDispatcher$1$1.visitReturn(UpdateMockWebServerDispatcher.java:101)
```

Caught today across three `rewrite-maven` test files in `openrewrite/rewrite` ([results](https://app.moderne.io/results/e42GKnm5G)).

## Summary

- Drop the unused `"okhttp-4.10"` argument from the `classpathFromResources` call. The template snippet only references `MockResponse` and `.build()` (a 5.x-only method, so the template parser is already tolerating unresolved members); no okhttp type is needed at template-parse time. Sibling recipe `UpdateMockWebServerMockResponse` uses just `"mockwebserver3"` for the same kind of template and works fine.

## Test plan

- [x] Manually verified that `UpdateMockWebServerMockResponseTest` (which exercises the same `Dispatcher.dispatch()` rewrite path via `dispatcherReturnTypeAndGetPathRename`) still passes with only `"mockwebserver-4.10"` requested by the recipe.
- [x] Re-ran `UpgradeOkHttpMockWebServerTest` — green.
- [ ] CI on this PR.

## Reproduction

Run any recipe-execution path that exercises `UpdateMockWebServerDispatcher` against a project whose classpath has `mockwebserver:4.10.x` but does not bundle `okhttp:4.10.x` as a separately-named jar. The cleanest reproducer is the flagship run linked above; the affected files were:

- `rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java`
- `rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java`
- `rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java`