### PR TITLE
Upgrade junit-bom to 6.x in JUnit 5 to 6 migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit6.yml
+++ b/src/main/resources/META-INF/rewrite/junit6.yml
@@ -59,6 +59,10 @@ recipeList:
       groupId: org.junit.jupiter
       artifactId: junit-jupiter-migrationsupport
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.junit
+      artifactId: junit-bom
+      newVersion: 6.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.junit.jupiter
       artifactId: junit-jupiter*
       newVersion: 6.x

--- a/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.junit6;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.javaVersion;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class JUnit5to6MigrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api"))
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.testing.junit6")
+            .build()
+            .activateRecipes("org.openrewrite.java.testing.junit6.JUnit5to6Migration"));
+    }
+
+    @Test
+    void upgradesJunitBomViaVersionProperty() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              class FooTest {
+                  @Test
+                  void bar() {
+                  }
+              }
+              """,
+            spec -> spec.markers(javaVersion(17))
+          ),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <properties>
+                      <junit-jupiter.version>5.14.4</junit-jupiter.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.junit</groupId>
+                              <artifactId>junit-bom</artifactId>
+                              <version>${junit-jupiter.version}</version>
+                              <type>pom</type>
+                              <scope>import</scope>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            spec -> spec.after(actual -> {
+                assertThat(Pattern.compile("<junit-jupiter\\.version>6\\.\\d+\\.\\d+</junit-jupiter\\.version>")
+                  .matcher(actual).find())
+                  .as("junit-jupiter.version property should be upgraded to 6.x; actual:\n%s", actual)
+                  .isTrue();
+                return actual;
+            })
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
@@ -21,8 +21,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-import java.util.regex.Pattern;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.javaVersion;
@@ -77,13 +75,10 @@ class JUnit5to6MigrationTest implements RewriteTest {
                   </dependencyManagement>
               </project>
               """,
-            spec -> spec.after(actual -> {
-                assertThat(Pattern.compile("<junit-jupiter\\.version>6\\.\\d+\\.\\d+</junit-jupiter\\.version>")
-                  .matcher(actual).find())
-                  .as("junit-jupiter.version property should be upgraded to 6.x; actual:\n%s", actual)
-                  .isTrue();
-                return actual;
-            })
+            spec -> spec.after(actual -> assertThat(actual)
+              .as("junit-jupiter.version property should be upgraded to 6.x")
+              .containsPattern("<junit-jupiter\\.version>6\\.\\d+\\.\\d+</junit-jupiter\\.version>")
+              .actual())
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit6/JUnit5to6MigrationTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.testing.junit6;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -36,10 +35,7 @@ class JUnit5to6MigrationTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api"))
-          .recipe(Environment.builder()
-            .scanRuntimeClasspath("org.openrewrite.java.testing.junit6")
-            .build()
-            .activateRecipes("org.openrewrite.java.testing.junit6.JUnit5to6Migration"));
+          .recipeFromResources("org.openrewrite.java.testing.junit6.JUnit5to6Migration");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The `JUnit5to6Migration` recipe upgraded individual `org.junit.jupiter:junit-jupiter*` artifacts to 6.x but never touched the `org.junit:junit-bom` import, leaving Maven POMs that pin the BOM (often via a `junit-jupiter.version` property) on 5.x.
- Added the missing `UpgradeDependencyVersion` step for `org.junit:junit-bom` → `6.x`, mirroring the pattern already used by `UpgradeToJUnit513`/`UpgradeToJUnit514`.
- Added `JUnit5to6MigrationTest` covering the reported scenario where the BOM version is supplied through a property.

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.testing.junit6.*" --tests "org.openrewrite.java.testing.junit5.JUnit5MigrationTest"`