### PR TITLE
Preserve mockStatic when returned from helper methods

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -183,9 +183,10 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
 
             determineTestGroups();
 
-            // Remove bare mockStatic() calls that aren't part of a variable declaration, assignment, or try-with-resources
+            // Remove bare mockStatic() calls that aren't part of a variable declaration, assignment, return, or try-with-resources
             if (!getCursor().getPath(o -> o instanceof J.VariableDeclarations ||
                                           o instanceof J.Assignment ||
+                                          o instanceof J.Return ||
                                           o instanceof J.Try.Resource).hasNext()) {
                 //noinspection DataFlowIssue
                 return null;

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -644,6 +644,27 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
         );
     }
 
+    @Test
+    void mockStaticReturnedFromHelperMethodShouldNotBeRemoved() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.mockito.Mockito.mockStatic;
+
+              import org.mockito.MockedStatic;
+
+              class TestClass {
+                  @SuppressWarnings("rawtypes")
+                  private static MockedStatic<String> mockStringStatic() {
+                      return mockStatic(String.class);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/358")
     @Test
     void doesNotExplodeOnTopLevelMethodDeclaration() {


### PR DESCRIPTION
## Summary

`PowerMockitoMockStaticToMockito` removes \"bare\" `Mockito.mockStatic(...)` calls — those whose result isn't captured for later closing. The guard checks the cursor path for `J.VariableDeclarations`, `J.Assignment`, or `J.Try.Resource`, but missed `J.Return`.

When a helper method returns `mockStatic(X.class)` directly, the call gets nullified inside its `J.Return` parent, leaving `return;` — a compilation failure against the helper's `MockedStatic<X>` return type:

```java
@SuppressWarnings(\"rawtypes\")
private static MockedStatic<CDI> mockCdiStatic() {
    return mockStatic(CDI.class);  // becomes `return;`
}
```

The fix adds `J.Return` to the ancestor check so a returned `mockStatic` is treated as captured (the caller will close it).

This is reachable from `MockitoBestPractices` → `Mockito1to5Migration` → … → this recipe, on any test file that imports `org.mockito.*` (the recipe's precondition is broad — see follow-up below).

## Follow-up

The recipe's precondition is `UsesType(\"org.powermock..*\") OR UsesType(\"org.mockito..*\")`, so it runs on plain Mockito files with no PowerMockito at all. That's the deeper reason this surfaced for users not migrating PowerMockito. Worth tightening, but out of scope for this fix.

## Test plan

- [x] Added regression test `mockStaticReturnedFromHelperMethodShouldNotBeRemoved` in `PowerMockitoMockStaticToMockitoTest`
- [x] Full `PowerMockitoMockStaticToMockitoTest` suite passes