### PR TITLE
Tighten PowerMockitoMockStaticToMockito precondition to actual PowerMockito usage

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -44,10 +44,7 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 Preconditions.and(
-                        Preconditions.or(
-                                new UsesType<>("org.powermock..*", false),
-                                new UsesType<>("org.mockito..*", false)
-                        ),
+                        new UsesType<>("org.powermock..*", false),
                         Preconditions.not(new KotlinFileChecker<>())
                 ),
                 new PowerMockitoToMockitoVisitor()

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -383,7 +383,9 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
               import org.junit.jupiter.api.Test;
               import org.mockito.MockedStatic;
+              import org.powermock.core.classloader.annotations.PrepareForTest;
 
+              @PrepareForTest({Calendar.class})
               public class MyTest {
 
                   private MockedStatic<Calendar> mockedCalendar;
@@ -461,7 +463,9 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
               import org.junit.jupiter.api.Test;
               import org.mockito.MockedStatic;
+              import org.powermock.core.classloader.annotations.PrepareForTest;
 
+              @PrepareForTest({Currency.class})
               public class MyTest {
 
                   private MockedStatic<Currency> mockedCurrency;
@@ -618,6 +622,31 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
                   @Test
                   public void testStaticMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/980")
+    @Test
+    void mockitoOnlyFileWithoutPowerMockitoIsLeftUntouched() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.mockito.Mockito.mockStatic;
+
+              import java.util.Calendar;
+
+              import org.junit.jupiter.api.Test;
+
+              class MyTest {
+
+                  @Test
+                  void testStaticMethod() {
+                      mockStatic(Calendar.class);
                   }
               }
               """


### PR DESCRIPTION
## Summary

- Restricts `PowerMockitoMockStaticToMockito` to files that actually import PowerMockito, dropping the broad `org.mockito..*` clause. The recipe was reachable via `MockitoBestPractices` and rewriting plain Mockito-only tests, which is the deeper cause of #979.

Two existing tests exercised an intermediate "halfway-migrated" state with no PowerMockito imports; they now start from a realistic `@PrepareForTest` source so the same when()/verify() rewrite logic is covered. Added a regression test that a Mockito-only file with a bare `mockStatic(...)` is left untouched.

- Fixes #980

## Test plan

- [x] `PowerMockitoMockStaticToMockitoTest` passes
- [x] Full mockito package tests pass