### PR TITLE
Fix `ClassCastException` for `@PrepareForTest(fullyQualifiedNames = "...")`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -118,7 +118,8 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                                 // case `@PrepareForTest( {Object1.class, Object2.class ...} )`
                                 return ((J.NewArray) a).getInitializer();
                             }
-                            if (a instanceof J.Assignment && ((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer() != null) {
+                            if (a instanceof J.Assignment && ((J.Assignment) a).getAssignment() instanceof J.NewArray &&
+                                    ((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer() != null) {
                                 // case `@PrepareForTest( value = {Object1.class, Object2.class ...} }`
                                 return ((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer();
                             }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockito.java
@@ -113,23 +113,28 @@ public class PowerMockitoMockStaticToMockito extends Recipe {
                 if (PREPARE_FOR_TEST_MATCHER.matches(j)) {
                     List<Expression> arguments = j.getArguments();
                     if (arguments != null && !arguments.isEmpty()) {
-                        mockedStaticClasses.addAll(ListUtils.flatMap(arguments, a -> {
+                        List<Expression> extracted = ListUtils.flatMap(arguments, a -> {
                             if (a instanceof J.NewArray && ((J.NewArray) a).getInitializer() != null) {
                                 // case `@PrepareForTest( {Object1.class, Object2.class ...} )`
-                                return ((J.NewArray) a).getInitializer();
+                                return ListUtils.map(((J.NewArray) a).getInitializer(),
+                                        e -> e instanceof J.FieldAccess ? e : null);
                             }
                             if (a instanceof J.Assignment && ((J.Assignment) a).getAssignment() instanceof J.NewArray &&
                                     ((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer() != null) {
                                 // case `@PrepareForTest( value = {Object1.class, Object2.class ...} }`
-                                return ((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer();
+                                return ListUtils.map(((J.NewArray) ((J.Assignment) a).getAssignment()).getInitializer(),
+                                        e -> e instanceof J.FieldAccess ? e : null);
                             }
                             if (a instanceof J.FieldAccess) {
                                 // case `@PrepareForTest(Object1.class)`
                                 return a;
                             }
                             return null;
-                        }));
-                        doAfterVisit(new RemoveAnnotationVisitor(PREPARE_FOR_TEST_MATCHER));
+                        });
+                        if (!extracted.isEmpty()) {
+                            mockedStaticClasses.addAll(extracted);
+                            doAfterVisit(new RemoveAnnotationVisitor(PREPARE_FOR_TEST_MATCHER));
+                        }
                     }
                 }
             }

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -917,7 +917,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/982")
     @Test
-    void prepareForTestWithFullyQualifiedNamesStringLiteralDoesNotCrash() {
+    void prepareForTestWithFullyQualifiedNamesStringLiteralIsLeftUnchanged() {
         //language=java
         rewriteRun(
           java(
@@ -932,16 +932,6 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
                   public void testSomething() {
                   }
               }
-              """,
-            """
-              import org.junit.Test;
-
-              public class MyTest {
-
-                  @Test
-                  public void testSomething() {
-                  }
-              }
               """
           )
         );
@@ -949,7 +939,7 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/982")
     @Test
-    void prepareForTestWithFullyQualifiedNamesStringArrayDoesNotCrash() {
+    void prepareForTestWithFullyQualifiedNamesStringArrayIsLeftUnchanged() {
         //language=java
         rewriteRun(
           java(
@@ -958,16 +948,6 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
               import org.powermock.core.classloader.annotations.PrepareForTest;
 
               @PrepareForTest(fullyQualifiedNames = {"com.example.Foo", "com.example.Bar"})
-              public class MyTest {
-
-                  @Test
-                  public void testSomething() {
-                  }
-              }
-              """,
-            """
-              import org.junit.Test;
-
               public class MyTest {
 
                   @Test

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockitoMockStaticToMockitoTest.java
@@ -914,4 +914,68 @@ class PowerMockitoMockStaticToMockitoTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/982")
+    @Test
+    void prepareForTestWithFullyQualifiedNamesStringLiteralDoesNotCrash() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import org.powermock.core.classloader.annotations.PrepareForTest;
+
+              @PrepareForTest(fullyQualifiedNames = "com.example.SomeClass")
+              public class MyTest {
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              public class MyTest {
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/982")
+    @Test
+    void prepareForTestWithFullyQualifiedNamesStringArrayDoesNotCrash() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import org.powermock.core.classloader.annotations.PrepareForTest;
+
+              @PrepareForTest(fullyQualifiedNames = {"com.example.Foo", "com.example.Bar"})
+              public class MyTest {
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              public class MyTest {
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add an `instanceof J.NewArray` guard in `extractPrepareForTestClasses` so `PowerMockitoMockStaticToMockito` no longer throws `ClassCastException` when `@PrepareForTest(fullyQualifiedNames = "...")` is used with a single string literal.
- Cover both the single-string and string-array forms of `fullyQualifiedNames` with regression tests.

- Fixes #982

## Test plan
- [x] `./gradlew :test --tests "org.openrewrite.java.testing.mockito.PowerMockitoMockStaticToMockitoTest"`