### PR TITLE
Fix AssertTrueInstanceofToAssertInstanceOf static import

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.junit5;
 import lombok.Getter;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
@@ -25,7 +26,13 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JLeftPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypedTree;
+import org.openrewrite.marker.Markers;
+
+import java.util.Collections;
 
 public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
     @Getter
@@ -92,16 +99,29 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
 
 
                 JavaTemplate template = JavaTemplate
-                    .builder("assertInstanceOf(#{any(java.lang.Object)}.class, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
+                    .builder("assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"))
                     .staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf")
                     .build();
 
                 maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
-                J rawClazz = clazz instanceof J.ParameterizedType ? ((J.ParameterizedType) clazz).getClazz() : clazz;
+                TypedTree rawClazz = clazz instanceof J.ParameterizedType ? (TypedTree) ((J.ParameterizedType) clazz).getClazz() : clazz;
+                Expression classLiteral = toClassLiteral(rawClazz);
                 return reason != null ?
-                    template.apply(getCursor(), mi.getCoordinates().replace(), rawClazz, expression, reason) :
-                    template.apply(getCursor(), mi.getCoordinates().replace(), rawClazz, expression);
+                    template.apply(getCursor(), mi.getCoordinates().replace(), classLiteral, expression, reason) :
+                    template.apply(getCursor(), mi.getCoordinates().replace(), classLiteral, expression);
+            }
+
+            private Expression toClassLiteral(TypedTree clazz) {
+                JavaType clazzType = clazz.getType();
+                JavaType.Parameterized classType = new JavaType.Parameterized(null,
+                    JavaType.ShallowClass.build("java.lang.Class"),
+                    Collections.singletonList(clazzType != null ? clazzType : JavaType.Unknown.getInstance()));
+                J.Identifier classKeyword = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                    Collections.emptyList(), "class", classType, null);
+                Expression target = ((Expression) clazz).withPrefix(Space.EMPTY);
+                return new J.FieldAccess(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+                    target, JLeftPadded.build(classKeyword), classType);
             }
         };
     }


### PR DESCRIPTION
## Summary
- The recipe's template `assertInstanceOf(#{any(java.lang.Object)}.class, ...)` produced invalid Java after substitution (`.class` on an instance expression), so the resulting `assertInstanceOf` invocation had no `JavaType.Method`. Without type info, `maybeAddImport` couldn't see the reference and skipped adding the static import.
- Switched the template parameter to `#{any(java.lang.Class)}` and construct a properly typed `J.FieldAccess` class literal (`Foo.class`) from the type identifier.

## Test plan
- [x] `./gradlew test --tests "org.openrewrite.java.testing.junit5.AssertTrueInstanceofToAssertInstanceOfTest"` — all 6 tests pass