### PR TITLE
Support `textBlock` attribute in `CsvSourceToValueSource`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -92,6 +92,10 @@ public class CsvSourceToValueSource extends Recipe {
                                     if (values.isEmpty() || hasMultipleColumns(values)) {
                                         return m;
                                     }
+                                    // Single quotes are CsvSource's default quote char; conversion would change the parsed value
+                                    if (anyContainsSingleQuote(values)) {
+                                        return m;
+                                    }
                                     // Non-String types can't represent values containing whitespace as unquoted literals
                                     if (!"String".equals(paramType) && anyContainsWhitespace(values)) {
                                         return m;
@@ -247,6 +251,10 @@ public class CsvSourceToValueSource extends Recipe {
 
                     private boolean hasMultipleColumns(List<String> values) {
                         return values.stream().anyMatch(v -> v.indexOf(',') >= 0);
+                    }
+
+                    private boolean anyContainsSingleQuote(List<String> values) {
+                        return values.stream().anyMatch(v -> v.indexOf('\'') >= 0);
                     }
 
                     private boolean anyContainsWhitespace(List<String> values) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -22,6 +22,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
@@ -89,15 +90,15 @@ public class CsvSourceToValueSource extends Recipe {
                                         return m;
                                     }
                                     values = parseTextBlockLines(textBlock);
-                                    if (values.isEmpty() || hasMultipleColumns(values)) {
+                                    if (values.isEmpty() || values.stream().anyMatch(v -> v.indexOf(',') >= 0)) {
                                         return m;
                                     }
                                     // Single quotes are CsvSource's default quote char; conversion would change the parsed value
-                                    if (anyContainsSingleQuote(values)) {
+                                    if (values.stream().anyMatch(v -> v.indexOf('\'') >= 0)) {
                                         return m;
                                     }
                                     // Non-String types can't represent values containing whitespace as unquoted literals
-                                    if (!"String".equals(paramType) && anyContainsWhitespace(values)) {
+                                    if (!"String".equals(paramType) && values.stream().anyMatch(StringUtils::containsWhitespace)) {
                                         return m;
                                     }
                                 } else if ("String".equals(paramType)) {
@@ -247,25 +248,6 @@ public class CsvSourceToValueSource extends Recipe {
                             result.add(trimmed);
                         }
                         return result;
-                    }
-
-                    private boolean hasMultipleColumns(List<String> values) {
-                        return values.stream().anyMatch(v -> v.indexOf(',') >= 0);
-                    }
-
-                    private boolean anyContainsSingleQuote(List<String> values) {
-                        return values.stream().anyMatch(v -> v.indexOf('\'') >= 0);
-                    }
-
-                    private boolean anyContainsWhitespace(List<String> values) {
-                        for (String v : values) {
-                            for (int i = 0; i < v.length(); i++) {
-                                if (Character.isWhitespace(v.charAt(i))) {
-                                    return true;
-                                }
-                            }
-                        }
-                        return false;
                     }
 
                     private @Nullable String getParameterType(J.VariableDeclarations param) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -34,6 +34,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,18 +75,29 @@ public class CsvSourceToValueSource extends Recipe {
                         for (J.Annotation annotation : m.getLeadingAnnotations()) {
                             Optional<Annotated> annotated = new Annotated.Matcher(CSV_SOURCE_MATCHER).get(annotation, getCursor());
                             if (annotated.isPresent() && annotation.getArguments() != null && annotation.getArguments().size() == 1) {
-                                // Skip if textBlock attribute is used
-                                if (annotated.get().getAttribute("textBlock").isPresent()) {
-                                    return m;
-                                }
                                 // Get the parameter type
                                 String paramType = getParameterType((J.VariableDeclarations) m.getParameters().get(0));
                                 if (paramType == null) {
                                     return m;
                                 }
 
-                                // For Strings, merely swap out the annotation
-                                if ("String".equals(paramType)) {
+                                Optional<Literal> textBlockAttribute = annotated.get().getAttribute("textBlock");
+                                List<String> values;
+                                if (textBlockAttribute.isPresent()) {
+                                    String textBlock = textBlockAttribute.get().getString();
+                                    if (textBlock == null) {
+                                        return m;
+                                    }
+                                    values = parseTextBlockLines(textBlock);
+                                    if (values.isEmpty() || hasMultipleColumns(values)) {
+                                        return m;
+                                    }
+                                    // Non-String types can't represent values containing whitespace as unquoted literals
+                                    if (!"String".equals(paramType) && anyContainsWhitespace(values)) {
+                                        return m;
+                                    }
+                                } else if ("String".equals(paramType)) {
+                                    // Preserve original argument formatting (e.g. text blocks, custom spacing)
                                     maybeRemoveImport("org.junit.jupiter.params.provider.CsvSource");
                                     maybeAddImport("org.junit.jupiter.params.provider.ValueSource");
                                     Expression templateArg = annotation.getArguments().get(0) instanceof J.Assignment ?
@@ -96,22 +108,20 @@ public class CsvSourceToValueSource extends Recipe {
                                             .imports("org.junit.jupiter.params.provider.ValueSource")
                                             .build()
                                             .apply(getCursor(), annotation.getCoordinates().replace());
-                                    // Retain formatting by swapping in the original argument
                                     return updated.withLeadingAnnotations(ListUtils.map(updated.getLeadingAnnotations(), ann ->
                                             VALUE_SOURCE_MATCHER.matches(ann) ?
                                                     ann.withArguments(ListUtils.map(ann.getArguments(),
                                                             arg -> ((J.Assignment) arg).withAssignment(templateArg.withPrefix(Space.SINGLE_SPACE)))) :
                                                     ann));
-                                }
-
-                                Optional<Literal> valueAttribute = annotated.get().getDefaultAttribute("value");
-                                if (!valueAttribute.isPresent()) {
-                                    return m;
-                                }
-                                List<String> values = valueAttribute.get().getStrings();
-                                // Extract values from CsvSource
-                                if (values.isEmpty()) {
-                                    return m;
+                                } else {
+                                    Optional<Literal> valueAttribute = annotated.get().getDefaultAttribute("value");
+                                    if (!valueAttribute.isPresent()) {
+                                        return m;
+                                    }
+                                    values = valueAttribute.get().getStrings();
+                                    if (values.isEmpty()) {
+                                        return m;
+                                    }
                                 }
 
                                 // Build a new ValueSource annotation
@@ -139,6 +149,10 @@ public class CsvSourceToValueSource extends Recipe {
                         String formattedValues;
 
                         switch (paramType) {
+                            case "String":
+                                attributeName = "strings";
+                                formattedValues = formatStringValues(values);
+                                break;
                             case "int":
                             case "Integer":
                                 attributeName = "ints";
@@ -211,6 +225,39 @@ public class CsvSourceToValueSource extends Recipe {
                         return String.join(", ", values.stream()
                                 .map(v -> "'" + v.trim() + "'")
                                 .toArray(String[]::new));
+                    }
+
+                    private String formatStringValues(List<String> values) {
+                        return String.join(", ", values.stream()
+                                .map(v -> "\"" + v.trim().replace("\\", "\\\\").replace("\"", "\\\"") + "\"")
+                                .toArray(String[]::new));
+                    }
+
+                    private List<String> parseTextBlockLines(String textBlock) {
+                        List<String> result = new ArrayList<>();
+                        for (String line : textBlock.split("\n")) {
+                            String trimmed = line.trim();
+                            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                                continue;
+                            }
+                            result.add(trimmed);
+                        }
+                        return result;
+                    }
+
+                    private boolean hasMultipleColumns(List<String> values) {
+                        return values.stream().anyMatch(v -> v.indexOf(',') >= 0);
+                    }
+
+                    private boolean anyContainsWhitespace(List<String> values) {
+                        for (String v : values) {
+                            for (int i = 0; i < v.length(); i++) {
+                                if (Character.isWhitespace(v.charAt(i))) {
+                                    return true;
+                                }
+                            }
+                        }
+                        return false;
                     }
 
                     private @Nullable String getParameterType(J.VariableDeclarations param) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
@@ -456,7 +456,48 @@ class CsvSourceToValueSourceTest implements RewriteTest {
     }
 
     @Test
-    void skipTextBlock() {
+    void preserveTextBlockAsValue() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(\"""
+                          # Lower-case letters
+                          asdf
+                          a
+                          \""")
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(strings = \"""
+                          # Lower-case letters
+                          asdf
+                          a
+                          \""")
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTextBlockAttribute() {
         rewriteRun(
           //language=java
           java(
@@ -473,6 +514,122 @@ class CsvSourceToValueSourceTest implements RewriteTest {
                       \""")
                   void testWithStrings(String fruit) {
                       System.out.println(fruit);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(strings = {"apple", "banana", "cherry"})
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTextBlockAttributeIgnoringCommentsAndBlankLines() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(textBlock = \"""
+                      # Lower-case letters
+                      asdf
+                      a
+
+                      # Numbers
+                      1
+                      123
+                      \""")
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(strings = {"asdf", "a", "1", "123"})
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTextBlockAttributeForIntegers() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(textBlock = \"""
+                      # numbers
+                      1
+                      2
+                      3
+                      \""")
+                  void testWithIntegers(int number) {
+                      System.out.println(number);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(ints = {1, 2, 3})
+                  void testWithIntegers(int number) {
+                      System.out.println(number);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotReplaceTextBlockWithMultipleColumns() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(textBlock = \"""
+                      apple, 1
+                      banana, 2
+                      cherry, 3
+                      \""")
+                  void testWithMultipleParams(String fruit, int count) {
+                      System.out.println(fruit + ": " + count);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
@@ -613,6 +613,30 @@ class CsvSourceToValueSourceTest implements RewriteTest {
     }
 
     @Test
+    void doNotReplaceTextBlockWithSingleQuotes() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(textBlock = \"""
+                      'apple'
+                      banana
+                      \""")
+                  void testWithStrings(String fruit) {
+                      System.out.println(fruit);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceTextBlockWithMultipleColumns() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
- Convert `@CsvSource(textBlock = """...""")` with a single-column parameter into `@ValueSource(...)`, splitting on newlines and ignoring `#` comments and blank lines per JUnit's textBlock semantics.
- Skip when the text block has multiple CSV columns, or when non-String values contain whitespace that would produce invalid Java.
- Adds a `String` case to the `@ValueSource` builder so text-block-derived values render as `@ValueSource(strings = {...})`.

- Resolves #985

## Test plan
- [x] `./gradlew test --tests CsvSourceToValueSourceTest`
- [x] `./gradlew test --tests "org.openrewrite.java.testing.junit5.*"`