### PR TITLE
Document strictness implication of `RemoveInitMocksIfRunnersSpecified`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveInitMocksIfRunnersSpecified.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveInitMocksIfRunnersSpecified.java
@@ -44,7 +44,10 @@ public class RemoveInitMocksIfRunnersSpecified extends Recipe {
     @Getter
     final String description = "Remove `MockitoAnnotations.initMocks(this)` and `MockitoAnnotations.openMocks(this)` if class-level " +
             "JUnit runners `@RunWith(MockitoJUnitRunner.class)` or `@ExtendWith(MockitoExtension.class)` are specified. " +
-            "These manual initialization calls are redundant when using Mockito's JUnit integration.";
+            "These manual initialization calls are redundant when using Mockito's JUnit integration. " +
+            "Note that the `@Mock` fields will then be initialized by the strict mocking session of the extension or runner; " +
+            "tests that relied on the lenient mocks created by an explicit `openMocks(this)` call inside `@BeforeEach` " +
+            "may surface `UnnecessaryStubbingException`. Add `@MockitoSettings(strictness = Strictness.LENIENT)` to opt out.";
 
     private static final String MOCKITO_EXTENSION = "org.mockito.junit.jupiter.MockitoExtension";
     private static final String MOCKITO_JUNIT_RUNNER = "org.mockito.junit.MockitoJUnitRunner";


### PR DESCRIPTION
## Summary

Removing an explicit `MockitoAnnotations.openMocks(this)` call from a `@BeforeEach` is not strictly behavior-preserving: the `@Mock` fields then come from the extension's strict mocking session instead of the lenient mocks produced by `openMocks`, which can surface `UnnecessaryStubbingException` for previously-tolerated unused stubs.

This updates the recipe description to call out that implication and to point users at `@MockitoSettings(strictness = Strictness.LENIENT)` as an opt-out.

- Refs #987