### PR TITLE
Skip primitive comparisons in `UseAssertSame`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -67,6 +67,11 @@ public class UseAssertSame extends Recipe {
                     binary.getRight().getType() == JavaType.Primitive.Null) {
                     return mi;
                 }
+                // Skip primitive comparisons — `==` is value equality, not reference equality
+                if (binary.getLeft().getType() instanceof JavaType.Primitive ||
+                    binary.getRight().getType() instanceof JavaType.Primitive) {
+                    return mi;
+                }
                 List<Expression> newArguments = new ArrayList<>();
                 newArguments.add(binary.getLeft());
                 newArguments.add(binary.getRight());

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
@@ -213,6 +213,28 @@ class UseAssertSameTest implements RewriteTest {
     }
 
     @Test
+    void primitiveComparisonShouldNotConvert() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      assertTrue(123L == 123);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void assertFalseNullShouldNotConvert() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
- Fixes #991.

`UseAssertSame` previously converted `assertTrue(123L == 123)` to `assertSame(123L, 123)`, which fails because the boxed `Long` and `Integer` are different objects. The recipe now skips comparisons where either side is a primitive type, since `==` on primitives is value equality rather than reference equality.