### PR TITLE
Skip wrapper-primitive in `UseAssertSame`; rewrite via `AssertTrueComparisonToAssertEquals`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEquals.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 
 public class AssertTrueComparisonToAssertEquals extends Recipe {
     private static final MethodMatcher ASSERT_TRUE = new MethodMatcher(
@@ -99,14 +100,36 @@ public class AssertTrueComparisonToAssertEquals extends Recipe {
                     return false;
                 }
 
-                // Prevent breaking identity comparison.
-                // Objects that are compared with == should not be compared with `.equals()` instead.
-                // Out of the primitives == is not allowed when both are of type String
-                return binary.getLeft().getType() instanceof JavaType.Primitive &&
-                       binary.getRight().getType() instanceof JavaType.Primitive &&
-                       !(binary.getLeft().getType() == JavaType.Primitive.String &&
-                            binary.getRight().getType() == JavaType.Primitive.String);
+                // Prevent breaking identity comparison: wrapper-wrapper and reference-reference == are
+                // reference equality and belong to UseAssertSame, not assertEquals. We rewrite when:
+                //   - both operands are primitive (excluding String == String, which is reference identity), OR
+                //   - one operand is primitive and the other a numeric wrapper (Java unboxes; == is value).
+                JavaType leftType = binary.getLeft().getType();
+                JavaType rightType = binary.getRight().getType();
+                if (leftType instanceof JavaType.Primitive && rightType instanceof JavaType.Primitive) {
+                    return !(leftType == JavaType.Primitive.String && rightType == JavaType.Primitive.String);
+                }
+                return (isPrimitiveValueType(leftType) && isNumericWrapper(rightType)) ||
+                       (isNumericWrapper(leftType) && isPrimitiveValueType(rightType));
             }
         });
+    }
+
+    private static boolean isPrimitiveValueType(JavaType type) {
+        return type instanceof JavaType.Primitive &&
+               type != JavaType.Primitive.Null &&
+               type != JavaType.Primitive.String &&
+               type != JavaType.Primitive.None;
+    }
+
+    private static boolean isNumericWrapper(JavaType type) {
+        return TypeUtils.isOfClassType(type, "java.lang.Boolean") ||
+               TypeUtils.isOfClassType(type, "java.lang.Byte") ||
+               TypeUtils.isOfClassType(type, "java.lang.Character") ||
+               TypeUtils.isOfClassType(type, "java.lang.Short") ||
+               TypeUtils.isOfClassType(type, "java.lang.Integer") ||
+               TypeUtils.isOfClassType(type, "java.lang.Long") ||
+               TypeUtils.isOfClassType(type, "java.lang.Float") ||
+               TypeUtils.isOfClassType(type, "java.lang.Double");
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UseAssertSame.java
@@ -36,7 +36,8 @@ public class UseAssertSame extends Recipe {
 
     @Getter
     final String description = "Prefers the usage of `assertSame` or `assertNotSame` methods instead of using of vanilla `assertTrue` " +
-            "or `assertFalse` with a boolean comparison.";
+            "or `assertFalse` with a boolean comparison. Only applies when both operands are reference types — " +
+            "primitive operands are handled by `AssertTrueComparisonToAssertEquals`.";
 
     private static final MethodMatcher ASSERT_TRUE_MATCHER = new MethodMatcher("org.junit.jupiter.api.Assertions assertTrue(..)");
     private static final MethodMatcher ASSERT_FALSE_MATCHER = new MethodMatcher("org.junit.jupiter.api.Assertions assertFalse(..)");
@@ -67,9 +68,10 @@ public class UseAssertSame extends Recipe {
                     binary.getRight().getType() == JavaType.Primitive.Null) {
                     return mi;
                 }
-                // Skip primitive comparisons — `==` is value equality, not reference equality
-                if (binary.getLeft().getType() instanceof JavaType.Primitive ||
-                    binary.getRight().getType() instanceof JavaType.Primitive) {
+                // Skip when either operand has value-equality semantics under == (primitives, plus
+                // the wrapper-primitive case where Java unboxes). Defer to AssertTrueComparisonToAssertEquals.
+                if (isPrimitiveValueType(binary.getLeft().getType()) ||
+                    isPrimitiveValueType(binary.getRight().getType())) {
                     return mi;
                 }
                 List<Expression> newArguments = new ArrayList<>();
@@ -109,6 +111,14 @@ public class UseAssertSame extends Recipe {
                         new UsesMethod<>(ASSERT_TRUE_MATCHER),
                         new UsesMethod<>(ASSERT_FALSE_MATCHER)),
                 visitor);
+    }
+
+    // String is a JavaType.Primitive enum value but its == is reference equality (assertSame is correct).
+    private static boolean isPrimitiveValueType(JavaType type) {
+        return type instanceof JavaType.Primitive &&
+               type != JavaType.Primitive.Null &&
+               type != JavaType.Primitive.String &&
+               type != JavaType.Primitive.None;
     }
 
 }

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEqualsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueComparisonToAssertEqualsTest.java
@@ -177,4 +177,57 @@ class AssertTrueComparisonToAssertEqualsTest implements RewriteTest {
         );
     }
 
+    @SuppressWarnings({"NumberEquality", "SimplifiableAssertion"})
+    @Test
+    void onlyRewritesWhenAtLeastOneOperandIsPrimitive() {
+        // Mixed primitive-wrapper rewrites because Java unboxes (== is value equality).
+        // Wrapper-wrapper is reference equality and stays for UseAssertSame to emit assertSame.
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              import java.util.HashMap;
+              import java.util.Map;
+
+              public class Test {
+                  void test() {
+                      Map<String, Double> map = new HashMap<>();
+                      map.put("k", 0.5);
+                      double d = 0.5;
+                      int i = 5;
+                      Integer iBoxed = 5;
+                      Double a = 0.5;
+                      Double b = a;
+                      Assertions.assertTrue(map.get("k") == d);
+                      Assertions.assertTrue(i == iBoxed);
+                      Assertions.assertTrue(a == b);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              import java.util.HashMap;
+              import java.util.Map;
+
+              public class Test {
+                  void test() {
+                      Map<String, Double> map = new HashMap<>();
+                      map.put("k", 0.5);
+                      double d = 0.5;
+                      int i = 5;
+                      Integer iBoxed = 5;
+                      Double a = 0.5;
+                      Double b = a;
+                      Assertions.assertEquals(map.get("k"), d);
+                      Assertions.assertEquals(i, iBoxed);
+                      Assertions.assertTrue(a == b);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UseAssertSameTest.java
@@ -255,4 +255,50 @@ class UseAssertSameTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void onlyConvertsReferenceComparisons() {
+        // Wrappers are reference types so == is reference equality (assertSame).
+        // With a primitive operand Java unboxes, so defer to AssertTrueComparisonToAssertEquals.
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      int primitive = 5;
+                      Integer a = 5;
+                      Integer b = a;
+                      assertTrue(primitive == a);
+                      assertTrue(a == b);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertSame;
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              class MyTest {
+
+                  @Test
+                  public void test() {
+                      int primitive = 5;
+                      Integer a = 5;
+                      Integer b = a;
+                      assertTrue(primitive == a);
+                      assertSame(a, b);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?

For an input like:

```java
Map<String, Double> map = new HashMap<>();
double primitive = 0.5;
assertTrue(map.get("k") == primitive);
```

`UseAssertSame` was rewriting it to:

```java
assertSame(map.get("k"), primitive);
```

It should rewrite to:

```java
assertEquals(map.get("k"), primitive);
```

To get there:

- `UseAssertSame` now skips when either operand is a Java primitive (with `Null` and `String` carved out, since OpenRewrite encodes both as `JavaType.Primitive` enum values but their `==` is reference equality).
- `AssertTrueComparisonToAssertEquals` now also accepts mixed primitive-wrapper operands. Wrapper-wrapper is still rejected.

## What's your motivation?

- PR #992 added a primitive-primitive skip to `UseAssertSame`, which catches `assertTrue(123L == 123)`.

The rewritten `assertSame` fails at runtime because Java's `==` unboxes, but `assertSame` autoboxes the primitive into a fresh wrapper and compares by reference:

```
expected: java.lang.Double@4130a648<0.5>
but was:  java.lang.Double@61ff6a49<0.5>
```

## Anything in particular you'd like reviewers to focus on?

Wrapper-wrapper is left to `UseAssertSame` rather than swept into `AssertTrueComparisonToAssertEquals`, since rewriting `Double == Double` to value equality would silently change semantics on intentional reference checks.

## Anyone you would like to review specifically?

<!-- @mention them here -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files