### PR TITLE
Fix `JUnit4to5Migration` for classes that extend `org.junit.Assert`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertToAssertions.java
@@ -68,6 +68,16 @@ public class AssertToAssertions extends Recipe {
         }
 
         @Override
+        public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+            J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+            if (cd.getExtends() != null && TypeUtils.isOfType(ASSERTION_TYPE, cd.getExtends().getType())) {
+                cd = cd.withExtends(null);
+                maybeRemoveImport("org.junit.Assert");
+            }
+            return cd;
+        }
+
+        @Override
         public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
             if (!isJunitAssertMethod(m)) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -994,10 +994,8 @@ class JUnit5MigrationTest implements RewriteTest {
     }
 
     @Test
-    void extendsAssertWithUnqualifiedAssertionsLeavesBrokenCode() {
-        // `after` is the broken output the recipes currently produce.
+    void extendsAssertWithUnqualifiedAssertions() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           //language=java
           java(
             """
@@ -1013,13 +1011,12 @@ class JUnit5MigrationTest implements RewriteTest {
               }
               """,
             """
-              import org.junit.Assert;
               import org.junit.jupiter.api.Test;
 
               import static org.junit.jupiter.api.Assertions.assertEquals;
               import static org.junit.jupiter.api.Assertions.assertTrue;
 
-              public class MyTest extends Assert {
+              public class MyTest {
                   @Test
                   public void shouldPass() {
                       assertEquals(1, 1, "expected message");

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -992,4 +992,42 @@ class JUnit5MigrationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void extendsAssertWithUnqualifiedAssertionsLeavesBrokenCode() {
+        // `after` is the broken output the recipes currently produce.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          //language=java
+          java(
+            """
+              import org.junit.Assert;
+              import org.junit.Test;
+
+              public class MyTest extends Assert {
+                  @Test
+                  public void shouldPass() {
+                      assertEquals("expected message", 1, 1);
+                      assertTrue(true);
+                  }
+              }
+              """,
+            """
+              import org.junit.Assert;
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              public class MyTest extends Assert {
+                  @Test
+                  public void shouldPass() {
+                      assertEquals(1, 1, "expected message");
+                      assertTrue(true);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
The JUnit 4 to 5 migration produces broken code when a class `extends org.junit.Assert` and uses unqualified inherited assertion methods. The `JUnit4to5Migration` aggregator:

- adds Jupiter static imports for `assertEquals` / `assertTrue`,
- reorders the message argument from JUnit 4 position (first) to Jupiter position (last),
- but leaves `import org.junit.Assert` and `extends Assert` unchanged.

Because inherited methods shadow static imports in Java, the reordered call `assertEquals(1, 1, "expected message")` resolves against JUnit 4's `Assert.assertEquals`, which has no `(int, int, String)` overload, so the migrated code will not compile.

I'm not sure what the proper fix should be, so I'm just submitting a test that demonstrates the broken output. The `after` block reflects what the recipes actually produce today, so the test passes and CI stays green. Happy to help with the fix, but I don't have a clear idea of what it ought to be.