### PR TITLE
Preserve newlines when converting `@CsvSource(textBlock = ...)` to `@ValueSource`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -32,13 +32,17 @@ import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.trait.Literal;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JContainer;
+import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
+import static java.util.stream.Collectors.joining;
 import static org.openrewrite.java.tree.JavaType.Primitive;
 
 public class CsvSourceToValueSource extends Recipe {
@@ -84,7 +88,8 @@ public class CsvSourceToValueSource extends Recipe {
 
                                 Optional<Literal> textBlockAttribute = annotated.get().getAttribute("textBlock");
                                 List<String> values;
-                                if (textBlockAttribute.isPresent()) {
+                                boolean fromTextBlock = textBlockAttribute.isPresent();
+                                if (fromTextBlock) {
                                     String textBlock = textBlockAttribute.get().getString();
                                     if (textBlock == null) {
                                         return m;
@@ -130,7 +135,7 @@ public class CsvSourceToValueSource extends Recipe {
                                 }
 
                                 // Build a new ValueSource annotation
-                                String valueSourceAnnotationTemplate = buildValueSourceAnnotation(paramType, values);
+                                String valueSourceAnnotationTemplate = buildValueSourceAnnotation(paramType, values, fromTextBlock);
                                 if (valueSourceAnnotationTemplate == null) {
                                     return m;
                                 }
@@ -138,104 +143,118 @@ public class CsvSourceToValueSource extends Recipe {
                                 // Replace the annotation
                                 maybeRemoveImport("org.junit.jupiter.params.provider.CsvSource");
                                 maybeAddImport("org.junit.jupiter.params.provider.ValueSource");
-                                return JavaTemplate.builder(valueSourceAnnotationTemplate)
+                                J.MethodDeclaration replaced = JavaTemplate.builder(valueSourceAnnotationTemplate)
                                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-params-5"))
                                         .imports("org.junit.jupiter.params.provider.ValueSource")
                                         .build()
                                         .apply(getCursor(), annotation.getCoordinates().replace());
+                                if (fromTextBlock && values.size() > 1) {
+                                    String annotationIndent = annotation.getPrefix().getIndent();
+                                    String elementIndent = "\n" + annotationIndent + "        ";
+                                    String closingIndent = "\n" + annotationIndent;
+                                    return replaced.withLeadingAnnotations(ListUtils.map(replaced.getLeadingAnnotations(), ann -> {
+                                        if (!VALUE_SOURCE_MATCHER.matches(ann) || ann.getArguments() == null) {
+                                            return ann;
+                                        }
+                                        return ann.withArguments(ListUtils.map(ann.getArguments(), arg -> {
+                                            if (!(arg instanceof J.Assignment) ||
+                                                    !(((J.Assignment) arg).getAssignment() instanceof J.NewArray)) {
+                                                return arg;
+                                            }
+                                            J.Assignment assignment = (J.Assignment) arg;
+                                            J.NewArray newArray = (J.NewArray) assignment.getAssignment();
+                                            if (newArray.getPadding().getInitializer() == null) {
+                                                return arg;
+                                            }
+                                            List<JRightPadded<Expression>> padded = newArray.getPadding().getInitializer().getPadding().getElements();
+                                            int lastIdx = padded.size() - 1;
+                                            List<JRightPadded<Expression>> updatedPadded = ListUtils.map(padded, (i, rp) -> {
+                                                Expression e = rp.getElement().withPrefix(Space.format(elementIndent));
+                                                JRightPadded<Expression> withElement = rp.withElement(e);
+                                                if (i == lastIdx) {
+                                                    return withElement.withAfter(Space.format(closingIndent));
+                                                }
+                                                return withElement;
+                                            });
+                                            JContainer<Expression> newInitializer = newArray.getPadding().getInitializer()
+                                                    .getPadding().withElements(updatedPadded);
+                                            return assignment.withAssignment(newArray.getPadding().withInitializer(newInitializer));
+                                        }));
+                                    }));
+                                }
+                                return replaced;
                             }
                         }
 
                         return m;
                     }
 
-                    private @Nullable String buildValueSourceAnnotation(String paramType, List<String> values) {
+                    private @Nullable String buildValueSourceAnnotation(String paramType, List<String> values, boolean multiLine) {
                         String attributeName;
                         String formattedValues;
 
+                        String delimiter = multiLine && values.size() > 1 ? ",\n " : ", ";
+                        Function<String, String> mapper;
                         switch (paramType) {
                             case "String":
                                 attributeName = "strings";
-                                formattedValues = formatStringValues(values);
+                                mapper = v -> "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
                                 break;
                             case "int":
                             case "Integer":
                                 attributeName = "ints";
-                                formattedValues = format(values);
+                                mapper = Function.identity();
                                 break;
                             case "long":
                             case "Long":
                                 attributeName = "longs";
-                                formattedValues = formatLongValues(values);
+                                mapper = v -> v.endsWith("L") || v.endsWith("l") ? v : v + "L";
                                 break;
                             case "double":
                             case "Double":
                                 attributeName = "doubles";
-                                formattedValues = format(values);
+                                mapper = Function.identity();
                                 break;
                             case "float":
                             case "Float":
                                 attributeName = "floats";
-                                formattedValues = formatFloatValues(values);
+                                mapper = v -> v.endsWith("f") || v.endsWith("F") ? v : v + "f";
                                 break;
                             case "boolean":
                             case "Boolean":
                                 attributeName = "booleans";
-                                formattedValues = format(values);
+                                mapper = Function.identity();
                                 break;
                             case "char":
                             case "Character":
                                 attributeName = "chars";
-                                formattedValues = formatCharValues(values);
+                                mapper = v -> "'" + v + "'";
                                 break;
                             case "byte":
                             case "Byte":
                                 attributeName = "bytes";
-                                formattedValues = format(values);
+                                mapper = Function.identity();
                                 break;
                             case "short":
                             case "Short":
                                 attributeName = "shorts";
-                                formattedValues = format(values);
+                                mapper = Function.identity();
                                 break;
                             default:
                                 return null;
                         }
+                        formattedValues = values.stream()
+                                .map(String::trim)
+                                .map(mapper)
+                                .collect(joining(delimiter));
 
                         if (values.size() == 1) {
                             return "@ValueSource(" + attributeName + " = " + formattedValues + ")";
                         }
+                        if (multiLine) {
+                            return "@ValueSource(" + attributeName + " = {\n" + formattedValues + "\n})";
+                        }
                         return "@ValueSource(" + attributeName + " = {" + formattedValues + "})";
-                    }
-
-                    private String format(List<String> values) {
-                        return String.join(", ", values.stream()
-                                .map(String::trim)
-                                .toArray(String[]::new));
-                    }
-
-                    private String formatLongValues(List<String> values) {
-                        return String.join(", ", values.stream()
-                                .map(v -> v.trim().endsWith("L") || v.trim().endsWith("l") ? v.trim() : v.trim() + "L")
-                                .toArray(String[]::new));
-                    }
-
-                    private String formatFloatValues(List<String> values) {
-                        return String.join(", ", values.stream()
-                                .map(v -> v.trim().endsWith("f") || v.trim().endsWith("F") ? v.trim() : v.trim() + "f")
-                                .toArray(String[]::new));
-                    }
-
-                    private String formatCharValues(List<String> values) {
-                        return String.join(", ", values.stream()
-                                .map(v -> "'" + v.trim() + "'")
-                                .toArray(String[]::new));
-                    }
-
-                    private String formatStringValues(List<String> values) {
-                        return String.join(", ", values.stream()
-                                .map(v -> "\"" + v.trim().replace("\\", "\\\\").replace("\"", "\\\"") + "\"")
-                                .toArray(String[]::new));
                     }
 
                     private List<String> parseTextBlockLines(String textBlock) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -32,8 +32,6 @@ import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.trait.Literal;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JContainer;
-import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -149,38 +147,7 @@ public class CsvSourceToValueSource extends Recipe {
                                         .build()
                                         .apply(getCursor(), annotation.getCoordinates().replace());
                                 if (fromTextBlock && values.size() > 1) {
-                                    String annotationIndent = annotation.getPrefix().getIndent();
-                                    String elementIndent = "\n" + annotationIndent + "        ";
-                                    String closingIndent = "\n" + annotationIndent;
-                                    return replaced.withLeadingAnnotations(ListUtils.map(replaced.getLeadingAnnotations(), ann -> {
-                                        if (!VALUE_SOURCE_MATCHER.matches(ann) || ann.getArguments() == null) {
-                                            return ann;
-                                        }
-                                        return ann.withArguments(ListUtils.map(ann.getArguments(), arg -> {
-                                            if (!(arg instanceof J.Assignment) ||
-                                                    !(((J.Assignment) arg).getAssignment() instanceof J.NewArray)) {
-                                                return arg;
-                                            }
-                                            J.Assignment assignment = (J.Assignment) arg;
-                                            J.NewArray newArray = (J.NewArray) assignment.getAssignment();
-                                            if (newArray.getPadding().getInitializer() == null) {
-                                                return arg;
-                                            }
-                                            List<JRightPadded<Expression>> padded = newArray.getPadding().getInitializer().getPadding().getElements();
-                                            int lastIdx = padded.size() - 1;
-                                            List<JRightPadded<Expression>> updatedPadded = ListUtils.map(padded, (i, rp) -> {
-                                                Expression e = rp.getElement().withPrefix(Space.format(elementIndent));
-                                                JRightPadded<Expression> withElement = rp.withElement(e);
-                                                if (i == lastIdx) {
-                                                    return withElement.withAfter(Space.format(closingIndent));
-                                                }
-                                                return withElement;
-                                            });
-                                            JContainer<Expression> newInitializer = newArray.getPadding().getInitializer()
-                                                    .getPadding().withElements(updatedPadded);
-                                            return assignment.withAssignment(newArray.getPadding().withInitializer(newInitializer));
-                                        }));
-                                    }));
+                                    return autoFormat(replaced, ctx);
                                 }
                                 return replaced;
                             }

--- a/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
@@ -523,9 +523,54 @@ class CsvSourceToValueSourceTest implements RewriteTest {
 
               class TestClass {
                   @ParameterizedTest
-                  @ValueSource(strings = {"apple", "banana", "cherry"})
+                  @ValueSource(strings = {
+                          "apple",
+                          "banana",
+                          "cherry"
+                  })
                   void testWithStrings(String fruit) {
                       System.out.println(fruit);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceTextBlockAttributePlacesEachItemOnItsOwnLine() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.CsvSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(textBlock = \"""
+                      DateFormat.getTimeInstance(DateFormat.SHORT)
+                      DateFormat.getDateTimeInstance()
+                      DateFormat.getInstance()
+                      \""")
+                  void findDateFormatMethods(String methodCall) {
+                      System.out.println(methodCall);
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(strings = {
+                          "DateFormat.getTimeInstance(DateFormat.SHORT)",
+                          "DateFormat.getDateTimeInstance()",
+                          "DateFormat.getInstance()"
+                  })
+                  void findDateFormatMethods(String methodCall) {
+                      System.out.println(methodCall);
                   }
               }
               """
@@ -564,7 +609,12 @@ class CsvSourceToValueSourceTest implements RewriteTest {
 
               class TestClass {
                   @ParameterizedTest
-                  @ValueSource(strings = {"asdf", "a", "1", "123"})
+                  @ValueSource(strings = {
+                          "asdf",
+                          "a",
+                          "1",
+                          "123"
+                  })
                   void testWithStrings(String fruit) {
                       System.out.println(fruit);
                   }
@@ -602,7 +652,11 @@ class CsvSourceToValueSourceTest implements RewriteTest {
 
               class TestClass {
                   @ParameterizedTest
-                  @ValueSource(ints = {1, 2, 3})
+                  @ValueSource(ints = {
+                          1,
+                          2,
+                          3
+                  })
                   void testWithIntegers(int number) {
                       System.out.println(number);
                   }


### PR DESCRIPTION
## Summary

When `CsvSourceToValueSource` converts a multi-line `@CsvSource(textBlock = """...""")` to `@ValueSource`, each value is now placed on its own indented line instead of being collapsed onto a single line. Previously the textBlock branch produced output like `@ValueSource(strings = {"a", "b", "c"})`; it now produces a block-style array aligned with the annotation. Internal cleanup along the way: the five per-type `format*` helpers collapse into one `Function<String,String>` mapper pipeline using `Collectors.joining`, and the custom indent helper is replaced with `Space.getIndent()`.

## Test plan

- [x] Updated existing `replaceTextBlockAttribute*` test expectations to match the new layout
- [x] Added `replaceTextBlockAttributePlacesEachItemOnItsOwnLine` regression test mirroring the `FindLocaleDateTimeFormatsTest` case from the issue
- [x] Full `./gradlew test` passes