### PR TITLE
Fix `EnclosedToNested` failing with "Expected to find enclosing JavaSourceFile"

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/EnclosedToNested.java
@@ -46,7 +46,7 @@ public class EnclosedToNested extends Recipe {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
                 maybeRemoveImport(ENCLOSED);
                 maybeRemoveImport(RUN_WITH);
-                return (J.ClassDeclaration) new RemoveAnnotationVisitor(new AnnotationMatcher(RUN_WITH_ENCLOSED)).visitNonNull(cd, ctx);
+                return (J.ClassDeclaration) new RemoveAnnotationVisitor(new AnnotationMatcher(RUN_WITH_ENCLOSED)).visitNonNull(cd, ctx, getCursor().getParentTreeCursor());
             }
         });
     }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplacePowerMockitoIntegrationTest.java
@@ -505,6 +505,7 @@ class ReplacePowerMockitoIntegrationTest implements RewriteTest {
                   void tearDownStaticMocks() {
                       mockedStringFilter.closeOnDemand();
                   }
+
                   @Test
                   public void testStaticMock() {
                       mockedStringFilter.when(() -> StringFilter.splitFilterStringValues(anyString())).thenReturn(new String[]{"Fee", "Faa", "Foo"});


### PR DESCRIPTION
## Summary

`EnclosedToNestedTest` is currently failing 5/5 on `main` (see the scheduled CI run on 2026-05-17).

`EnclosedToNested.visitClassDeclaration` invokes the inner `RemoveAnnotationVisitor` via `visitNonNull(cd, ctx)` with no parent cursor. The inner visit therefore walks up an isolated cursor chain that never reaches the enclosing `JavaSourceFile`, and an internal lookup throws `IllegalStateException: Expected to find enclosing JavaSourceFile`.

The fix passes `getCursor().getParentTreeCursor()` so the inner visitor inherits the outer cursor stack — matching how `RemoveDuplicateTestTemplates` and `AddParameterizedTestAnnotation` already invoke the same visitor.

## Test plan

- [x] All 5 `EnclosedToNestedTest` cases pass locally:
  - `recognizesTestAnnotationWithArguments`
  - `multipleInnerClasses`
  - `doesNotAnnotateNonTestInnerClasses`
  - `recognizesTestAnnotationWithTimeoutRuleAndArguments`
  - `oneInnerClass`