### PR TITLE
Reuse `MockedStatic` for consecutive stubbings of the same class

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -81,6 +81,8 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
     private JavaIsoVisitor<ExecutionContext> javaVisitor() {
         return new JavaIsoVisitor<ExecutionContext>() {
+            private final Map<String, String> generatedMocks = new HashMap<>();
+
             @Override
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
                 J.MethodDeclaration containingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
@@ -109,6 +111,11 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
             }
 
             private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.Block block, List<Statement> statements, ExecutionContext ctx) {
+                return maybeWrapStatementsInTryWithResourcesMockedStatic(block, statements, ctx, new HashMap<>());
+            }
+
+            private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.Block block, List<Statement> statements, ExecutionContext ctx,
+                                                                                      Map<String, String> pendingResources) {
                 AtomicBoolean restInTry = new AtomicBoolean(false);
                 return ListUtils.map(statements, (index, statement) -> {
                     if (restInTry.get()) {
@@ -120,7 +127,11 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                     if (whenArg != null) {
                         JavaType.@Nullable Class invokedType = getTypeFromInvocation(whenArg);
                         if (invokedType != null) {
-                            Optional<String> nameOfWrappingMockedStatic = tryGetMatchedWrappingResourceName(getCursor(), invokedType);
+                            String pending = pendingResources.get(invokedType.getFullyQualifiedName());
+                            if (pending != null) {
+                                return reuseMockedStatic(block, (J.MethodInvocation) statement, pending, whenArg, ctx);
+                            }
+                            Optional<String> nameOfWrappingMockedStatic = tryGetMatchedWrappingResourceName(getCursor(), invokedType, generatedMocks);
                             if (nameOfWrappingMockedStatic.isPresent()) {
                                 return reuseMockedStatic(block, (J.MethodInvocation) statement, nameOfWrappingMockedStatic.get(), whenArg, ctx);
                             }
@@ -129,7 +140,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                                 return reuseMockedStatic(block, (J.MethodInvocation) statement, staticMockedVariable, whenArg, ctx);
                             }
                             restInTry.set(true);
-                            return tryWithMockedStatic(block, statements, index, (J.MethodInvocation) statement, invokedType.getClassName(), whenArg, ctx);
+                            return tryWithMockedStatic(block, statements, index, (J.MethodInvocation) statement, invokedType, whenArg, ctx, pendingResources);
                         }
                     }
                     return statement;
@@ -137,7 +148,9 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
             }
 
             private J.Try tryWithMockedStatic(J.Block block, List<Statement> statements, Integer index,
-                                              J.MethodInvocation statement, String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
+                                              J.MethodInvocation statement, JavaType.Class invokedType, J.MethodInvocation whenArg, ExecutionContext ctx,
+                                              Map<String, String> pendingResources) {
+                String className = invokedType.getClassName();
                 String variableName = generateVariableName("mock" + className + ++varCounter, updateCursor(block), INCREMENT_NUMBER);
                 Expression thenReturnArg = statement.getArguments().get(0);
 
@@ -152,9 +165,13 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                 List<Statement> handledStatements = ListUtils.concat(precedingStatements, try_);
                 List<Statement> remainingStatements = statements.subList(index + 1, statements.size());
 
+                Map<String, String> nextPending = new HashMap<>(pendingResources);
+                nextPending.put(invokedType.getFullyQualifiedName(), variableName);
+                generatedMocks.put(variableName, invokedType.getFullyQualifiedName());
+
                 List<Statement> newStatements = ListUtils.concatAll(
                         try_.getBody().getStatements(),
-                        maybeWrapStatementsInTryWithResourcesMockedStatic(block.withStatements(handledStatements), remainingStatements, ctx));
+                        maybeWrapStatementsInTryWithResourcesMockedStatic(block.withStatements(handledStatements), remainingStatements, ctx, nextPending));
 
                 return try_.withBody(try_.getBody().withStatements(newStatements))
                         .withPrefix(statement.getPrefix());
@@ -162,9 +179,11 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
 
             private Statement reuseMockedStatic(J.Block block, J.MethodInvocation statement, Object variable, J.MethodInvocation whenArg, ExecutionContext ctx) {
                 String mockedStaticVariableTemplate = variable instanceof J ? "#{any()}" : "#{}";
-                return javaTemplateMockStatic(mockedStaticVariableTemplate + ".when(() -> #{any()}).thenReturn(#{any()});", ctx)
-                        .<J.Block>apply(getCursor(), block.getCoordinates().firstStatement(), variable, whenArg, statement.getArguments().get(0))
+                J.Block cursorBlock = (J.Block) getCursor().getValue();
+                Statement replacement = javaTemplateMockStatic(mockedStaticVariableTemplate + ".when(() -> #{any()}).thenReturn(#{any()});", ctx)
+                        .<J.Block>apply(getCursor(), cursorBlock.getCoordinates().firstStatement(), variable, whenArg, statement.getArguments().get(0))
                         .getStatements().get(0);
+                return replacement.withPrefix(statement.getPrefix());
             }
 
             private List<Statement> mockedStatic(J.Block block, J.MethodInvocation statement, String className, J.MethodInvocation whenArg, ExecutionContext ctx) {
@@ -375,11 +394,17 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
         return "Any";
     }
 
-    private static List<J.Try.Resource> getMatchingFilteredResources(@Nullable List<J.Try.Resource> resources, JavaType className) {
+    private static List<J.Try.Resource> getMatchingFilteredResources(@Nullable List<J.Try.Resource> resources, JavaType className, Map<String, String> generatedMocks) {
         if (resources == null) {
             return emptyList();
         }
-        return ListUtils.filter(resources,res -> isMockedStaticOfType(className, ((J.VariableDeclarations) res.getVariableDeclarations()).getTypeAsFullyQualified()));
+        JavaType.FullyQualified fq = TypeUtils.asFullyQualified(className);
+        String fqn = fq == null ? null : fq.getFullyQualifiedName();
+        return ListUtils.filter(resources, res -> {
+            J.VariableDeclarations vd = (J.VariableDeclarations) res.getVariableDeclarations();
+            return isMockedStaticOfType(className, vd.getTypeAsFullyQualified()) ||
+                    fqn != null && fqn.equals(generatedMocks.get(vd.getVariables().get(0).getSimpleName()));
+        });
     }
 
     private static boolean isMockedStaticOfType(JavaType mockedType, @Nullable JavaType comparisonType) {
@@ -390,16 +415,16 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
         return false;
     }
 
-    private static Optional<String> tryGetMatchedWrappingResourceName(Cursor cursor, JavaType className) {
+    private static Optional<String> tryGetMatchedWrappingResourceName(Cursor cursor, JavaType className, Map<String, String> generatedMocks) {
         try {
             Cursor foundParentCursor = cursor.dropParentUntil(val -> {
                 if (val instanceof J.Try) {
-                    List<J.Try.Resource> filteredResources = getMatchingFilteredResources(((J.Try) val).getResources(), className);
+                    List<J.Try.Resource> filteredResources = getMatchingFilteredResources(((J.Try) val).getResources(), className, generatedMocks);
                     return !filteredResources.isEmpty();
                 }
                 return false;
             });
-            return getMatchingFilteredResources(((J.Try) foundParentCursor.getValue()).getResources(), className)
+            return getMatchingFilteredResources(((J.Try) foundParentCursor.getValue()).getResources(), className, generatedMocks)
                     .stream()
                     .findFirst()
                     .map(res -> ((J.VariableDeclarations) res.getVariableDeclarations()).getVariables().get(0).getSimpleName());

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStatic.java
@@ -88,7 +88,7 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                 J.MethodDeclaration containingMethod = getCursor().firstEnclosing(J.MethodDeclaration.class);
                 List<Statement> newStatements = isMethodDeclarationWithAnnotation(containingMethod, BEFORE) ?
                         maybeStatementsToMockedStatic(block, block.getStatements(), ctx) :
-                        maybeWrapStatementsInTryWithResourcesMockedStatic(block, block.getStatements(), ctx);
+                        maybeWrapStatementsInTryWithResourcesMockedStatic(block, block.getStatements(), ctx, new HashMap<>());
 
                 J.Block b = super.visitBlock(block.withStatements(newStatements), ctx);
                 return maybeAutoFormat(block, b, ctx);
@@ -108,10 +108,6 @@ public class MockitoWhenOnStaticToMockStatic extends Recipe {
                     }
                 }
                 return list;
-            }
-
-            private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.Block block, List<Statement> statements, ExecutionContext ctx) {
-                return maybeWrapStatementsInTryWithResourcesMockedStatic(block, statements, ctx, new HashMap<>());
             }
 
             private List<Statement> maybeWrapStatementsInTryWithResourcesMockedStatic(J.Block block, List<Statement> statements, ExecutionContext ctx,

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoWhenOnStaticToMockStaticTest.java
@@ -248,24 +248,56 @@ class MockitoWhenOnStaticToMockStaticTest implements RewriteTest {
                           mockA1.when(() -> A.getNumber()).thenReturn(-1);
                           assertEquals(A.getNumber(), -1);
 
-                          try (MockedStatic<A> mockA2 = mockStatic(A.class)) {
-                              mockA2.when(() -> A.getNumber()).thenReturn(-2);
-                              assertEquals(A.getNumber(), -2);
+                          mockA1.when(() -> A.getNumber()).thenReturn(-2);
+                          assertEquals(A.getNumber(), -2);
 
-                              if (true) {
-                                  try (MockedStatic<A> mockA3 = mockStatic(A.class)) {
-                                      mockA3.when(() -> A.getNumber()).thenReturn(-3);
-                                      assertEquals(A.getNumber(), -3);
+                          if (true) {
+                              mockA1.when(() -> A.getNumber()).thenReturn(-3);
+                              assertEquals(A.getNumber(), -3);
 
-                                      try (MockedStatic<A> mockA4 = mockStatic(A.class)) {
-                                          mockA4.when(() -> A.getNumber()).thenReturn(-4);
-                                          assertEquals(A.getNumber(), -4);
-                                      }
-                                  }
-                              }
-
-                              assertEquals(A.getNumber(), -2);
+                              mockA1.when(() -> A.getNumber()).thenReturn(-4);
+                              assertEquals(A.getNumber(), -4);
                           }
+
+                          assertEquals(A.getNumber(), -2);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void shouldShareSingleMockedStaticForConsecutiveStubbingsOfSameClass() {
+        // https://github.com/openrewrite/rewrite-testing-frameworks/issues/1004
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.example.A;
+
+              import static org.mockito.Mockito.when;
+
+              class Test {
+                  void test() {
+                      when(A.getNumber()).thenReturn(1);
+                      when(A.getNumber()).thenReturn(2);
+                  }
+              }
+              """,
+            """
+              import org.example.A;
+              import org.mockito.MockedStatic;
+
+              import static org.mockito.Mockito.mockStatic;
+              import static org.mockito.Mockito.when;
+
+              class Test {
+                  void test() {
+                      try (MockedStatic<A> mockA1 = mockStatic(A.class)) {
+                          mockA1.when(() -> A.getNumber()).thenReturn(1);
+                          mockA1.when(() -> A.getNumber()).thenReturn(2);
                       }
                   }
               }


### PR DESCRIPTION
- Fixes #1004.

## Summary
- `MockitoWhenOnStaticToMockStatic` previously created nested `try (MockedStatic<X>)` blocks for sibling `Mockito.when()` calls on the same static class. Mockito 5 rejects this at runtime with `static mocking is already registered in the current thread`.
- Subsequent same-class stubbings (siblings at the same level, or nested inside `if`/loop/etc. inner blocks) now share the enclosing `MockedStatic`.

## What changed
- Thread a `pendingResources` map (FQN → variable name) through the recursive `maybeWrapStatementsInTryWithResourcesMockedStatic` so the second `when(X.foo())` in the same block reuses the just-created `mockX1` instead of opening a nested try.
- Maintain a visitor-scoped `generatedMocks` (variable name → FQN) map as a fallback in `getMatchingFilteredResources` for nested blocks. Needed because `JavaTemplate`-generated `try(MockedStatic<X> ...)` resources end up with `MockedStatic<{undefined}>` as their declared type, breaking pure type-based lookup.
- Fixed `reuseMockedStatic` to use the cursor's actual block for `JavaTemplate.apply` coordinates (the recursive caller was passing a synthetic block not in the cursor tree, causing the wrong statement to be returned) and to preserve the original statement's prefix (blank lines).

## Test plan
- [x] New `shouldShareSingleMockedStaticForConsecutiveStubbingsOfSameClass` covers the exact case from #1004.
- [x] Updated `shouldHandleMultipleStaticMocksAndNestedStatements` — its previous expected output codified the broken nested-try behavior; now expects a single `mockA1` shared across siblings and inside the `if`-block.
- [x] All 37 existing tests in `MockitoWhenOnStaticToMockStaticTest` pass.