### PR TITLE
Match MockWebServer.shutdown() against pre-rename type

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit5.yml
+++ b/src/main/resources/META-INF/rewrite/junit5.yml
@@ -314,7 +314,7 @@ recipeList:
       acceptTransitive: true
       scope: test
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: "mockwebserver3.MockWebServer shutdown()"
+      methodPattern: "okhttp3.mockwebserver.MockWebServer shutdown()"
       newMethodName: close
   - org.openrewrite.java.testing.junit5.UpdateMockWebServerMockResponse
 ---

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
@@ -126,4 +126,72 @@ class UpgradeOkHttpMockWebServerTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldRenameShutdownToCloseAlongWithPackageChange() {
+        rewriteRun(
+          spec -> spec
+            .recipeFromResource(
+              "/META-INF/rewrite/junit5.yml",
+              "org.openrewrite.java.testing.junit5.UpgradeOkHttpMockWebServer")
+            .parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(),
+                "mockwebserver-4.10",
+                "okhttp-4.10",
+                "okio-jvm-3.12"
+              )),
+          mavenProject("project",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>demo</artifactId>
+                  <version>0.0.1-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.squareup.okhttp3</groupId>
+                      <artifactId>mockwebserver</artifactId>
+                      <version>4.10.0</version>
+                      <scope>test</scope>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom ->
+                assertThat(pom)
+                  .doesNotContain("<artifactId>mockwebserver</artifactId>")
+                  .contains("<artifactId>mockwebserver3</artifactId>")
+                  .actual()
+              )
+            ),
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import okhttp3.mockwebserver.MockWebServer;
+
+                  class ApiTest {
+                      MockWebServer server = new MockWebServer();
+                      void stop() {
+                          server.shutdown();
+                      }
+                  }
+                  """,
+                """
+                  import mockwebserver3.MockWebServer;
+
+                  class ApiTest {
+                      MockWebServer server = new MockWebServer();
+                      void stop() {
+                          server.close();
+                      }
+                  }
+                  """
+              )
+            )
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpgradeOkHttpMockWebServerTest.java
@@ -138,7 +138,8 @@ class UpgradeOkHttpMockWebServerTest implements RewriteTest {
               .classpathFromResources(new InMemoryExecutionContext(),
                 "mockwebserver-4.10",
                 "okhttp-4.10",
-                "okio-jvm-3.12"
+                "okio-jvm-3.12",
+                "junit-4"
               )),
           mavenProject("project",
             //language=xml


### PR DESCRIPTION
## What

Changes the `ChangeMethodName` step in `UpgradeOkHttpMockWebServer` to match `okhttp3.mockwebserver.MockWebServer shutdown()` instead of `mockwebserver3.MockWebServer shutdown()`.

## Why

The step was placed before `UpdateMockWebServerMockResponse`, which internally runs `ChangePackage("okhttp3.mockwebserver", "mockwebserver3", false)`. With the pattern targeting the post-rename type (`mockwebserver3.MockWebServer`), the method-call's declaring type at the time `ChangeMethodName` runs is still `okhttp3.mockwebserver.MockWebServer` — so the pattern doesn't match on the first cycle. OpenRewrite's iterative execution eventually completes the rename on a subsequent cycle, but it's an unnecessary cycle and the recipe reads in a confusing order (the pattern references a type that doesn't exist yet at that point).

Targeting the pre-rename type lets the rename happen in a single cycle: `shutdown()` → `close()` is applied while the old types are still in scope, then `UpdateMockWebServerMockResponse`'s `ChangePackage` does the bulk move to `mockwebserver3.*` at the end. The recipeList now reads top-to-bottom as a natural pipeline of source rewrites against the old types, followed by the package rename as a final cleanup step.

## Test

Added `shouldRenameShutdownToCloseAlongWithPackageChange` to `UpgradeOkHttpMockWebServerTest`. The fixture has a project with a direct `mockwebserver:4.10.0` test-scope dep and a test source that imports `okhttp3.mockwebserver.MockWebServer` and calls `server.shutdown()`. After the recipe runs the source should import `mockwebserver3.MockWebServer` and call `server.close()`.

Marking draft until CI confirms.