### PR TITLE
Don't add MockitoExtension during migration when unsafe (#875)

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
@@ -169,7 +169,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
     private static boolean shouldSkip(J.ClassDeclaration classDecl) {
         // Interfaces, enums, annotations and abstract bases are not concrete Mockito test classes
         if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class ||
-                classDecl.getModifiers().stream().anyMatch(m -> m.getType() == J.Modifier.Type.Abstract)) {
+                classDecl.hasModifier(J.Modifier.Type.Abstract)) {
             return true;
         }
         // Only add to classes that declare Mockito annotations. The search spans the class subtree on purpose: a

--- a/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
@@ -27,12 +27,16 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.search.IsLikelyTest;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Comparator.comparing;
 import static org.openrewrite.Preconditions.*;
@@ -41,6 +45,13 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
 
     private static final String EXTEND_WITH = "org.junit.jupiter.api.extension.ExtendWith";
     private static final String RUN_WITH = "org.junit.runner.RunWith";
+    // Explicit list rather than a wildcard like `org.mockito.*`, which would also match non-injection annotations
+    // such as `@DoNotMock`, `@CheckReturnValue` or `@Incubating` and cause false positives.
+    private static final List<String> MOCKITO_FIELD_ANNOTATIONS = Arrays.asList(
+            "org.mockito.Captor",
+            "org.mockito.Mock",
+            "org.mockito.Spy",
+            "org.mockito.InjectMocks");
 
     @Getter
     final String displayName = "Adds Mockito extensions to Mockito tests";
@@ -91,7 +102,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, EXTEND_WITH)) {
+                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), EXTEND_WITH)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
@@ -111,7 +122,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, RUN_WITH)) {
+                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), RUN_WITH)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.MockitoJUnitRunner");
@@ -131,7 +142,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new KotlinIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, EXTEND_WITH)) {
+                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), EXTEND_WITH)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
@@ -152,26 +163,26 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
      * not already register an extension or runner (e.g. {@code SpringExtension}). This avoids redundant or harmful
      * additions; see <a href="https://github.com/openrewrite/rewrite-testing-frameworks/issues/875">#875</a>.
      */
-    private static boolean shouldSkip(J.ClassDeclaration classDecl, String existingExtensionType) {
+    private static boolean shouldSkip(J.ClassDeclaration classDecl, List<J.Annotation> classAnnotations, String existingExtensionType) {
         // Interfaces, enums, annotations and abstract bases are not concrete Mockito test classes
         if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class ||
                 classDecl.getModifiers().stream().anyMatch(m -> m.getType() == J.Modifier.Type.Abstract)) {
             return true;
         }
-        // Don't add when the class already registers an extension or runner directly (e.g. SpringExtension)
-        for (J.Annotation annotation : classDecl.getLeadingAnnotations()) {
+        // Don't add when the class already registers an extension or runner (e.g. SpringExtension)
+        for (J.Annotation annotation : classAnnotations) {
             if (TypeUtils.isOfClassType(annotation.getType(), existingExtensionType)) {
                 return true;
             }
         }
-        // Only add to classes that themselves declare Mockito annotations
+        // Only add to classes that declare Mockito annotations. The search spans the class subtree on purpose: a
+        // `@Mock` in a `@Nested` inner class should annotate the enclosing class, since JUnit 5 propagates the
+        // extension to nested classes (and the visitor only annotates the outermost class).
         return !declaresMockitoAnnotation(classDecl);
     }
 
     private static boolean declaresMockitoAnnotation(J.ClassDeclaration classDecl) {
-        return !FindAnnotations.find(classDecl, "@org.mockito.Mock").isEmpty() ||
-                !FindAnnotations.find(classDecl, "@org.mockito.Spy").isEmpty() ||
-                !FindAnnotations.find(classDecl, "@org.mockito.Captor").isEmpty() ||
-                !FindAnnotations.find(classDecl, "@org.mockito.InjectMocks").isEmpty();
+        return MOCKITO_FIELD_ANNOTATIONS.stream()
+                .anyMatch(fqn -> !FindAnnotations.find(classDecl, "@" + fqn).isEmpty());
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.search.IsLikelyTest;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
@@ -37,6 +38,10 @@ import static java.util.Comparator.comparing;
 import static org.openrewrite.Preconditions.*;
 
 public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
+
+    private static final String EXTEND_WITH = "org.junit.jupiter.api.extension.ExtendWith";
+    private static final String RUN_WITH = "org.junit.runner.RunWith";
+
     @Getter
     final String displayName = "Adds Mockito extensions to Mockito tests";
 
@@ -47,8 +52,6 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        TreeVisitor<?, ExecutionContext> hasExtendedWithAnnotation = new FindAnnotations("org.junit.jupiter.api.extension.ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)", false).getVisitor();
-        TreeVisitor<?, ExecutionContext> hasRunWithAnnotation = new FindAnnotations("org.junit.runner.RunWith", false).getVisitor();
         @SuppressWarnings("unchecked")
         TreeVisitor<?, ExecutionContext>[] hasAnyMockitoAnnotation = new TreeVisitor[]{
                 // see https://www.baeldung.com/mockito-annotations for examples
@@ -61,12 +64,10 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return check(and(new IsLikelyTest().getVisitor(),
                         or(hasAnyMockitoAnnotation),
                         or(
-                                // JUnit 5: has JUnit 5 types and no @ExtendWith(MockitoExtension.class)
-                                and(new FindTypes("org.junit.jupiter..*", false).getVisitor(),
-                                        not(hasExtendedWithAnnotation)),
-                                // JUnit 4: has @org.junit.Test, no @RunWith
-                                and(new FindAnnotations("org.junit.Test", false).getVisitor(),
-                                        not(hasRunWithAnnotation))
+                                // JUnit 5: has JUnit 5 types
+                                new FindTypes("org.junit.jupiter..*", false).getVisitor(),
+                                // JUnit 4: has @org.junit.Test
+                                new FindAnnotations("org.junit.Test", false).getVisitor()
                         )),
                 new TreeVisitor<Tree, ExecutionContext>() {
                     @Override
@@ -90,6 +91,9 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                if (shouldSkip(classDecl, EXTEND_WITH)) {
+                    return classDecl;
+                }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
                 maybeAddImport("org.junit.jupiter.api.extension.ExtendWith");
 
@@ -107,6 +111,9 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                if (shouldSkip(classDecl, RUN_WITH)) {
+                    return classDecl;
+                }
                 maybeAddImport("org.mockito.junit.MockitoJUnitRunner");
                 maybeAddImport("org.junit.runner.RunWith");
 
@@ -124,6 +131,9 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new KotlinIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+                if (shouldSkip(classDecl, EXTEND_WITH)) {
+                    return classDecl;
+                }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
                 maybeAddImport("org.junit.jupiter.api.extension.ExtendWith");
 
@@ -135,5 +145,33 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
                         .apply(getCursor(), classDecl.getCoordinates().addAnnotation(comparing(J.Annotation::getSimpleName)));
             }
         };
+    }
+
+    /**
+     * Only add the extension/runner to a concrete test class that itself declares Mockito annotations and does
+     * not already register an extension or runner (e.g. {@code SpringExtension}). This avoids redundant or harmful
+     * additions; see <a href="https://github.com/openrewrite/rewrite-testing-frameworks/issues/875">#875</a>.
+     */
+    private static boolean shouldSkip(J.ClassDeclaration classDecl, String existingExtensionType) {
+        // Interfaces, enums, annotations and abstract bases are not concrete Mockito test classes
+        if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class ||
+                classDecl.getModifiers().stream().anyMatch(m -> m.getType() == J.Modifier.Type.Abstract)) {
+            return true;
+        }
+        // Don't add when the class already registers an extension or runner directly (e.g. SpringExtension)
+        for (J.Annotation annotation : classDecl.getLeadingAnnotations()) {
+            if (TypeUtils.isOfClassType(annotation.getType(), existingExtensionType)) {
+                return true;
+            }
+        }
+        // Only add to classes that themselves declare Mockito annotations
+        return !declaresMockitoAnnotation(classDecl);
+    }
+
+    private static boolean declaresMockitoAnnotation(J.ClassDeclaration classDecl) {
+        return !FindAnnotations.find(classDecl, "@org.mockito.Mock").isEmpty() ||
+                !FindAnnotations.find(classDecl, "@org.mockito.Spy").isEmpty() ||
+                !FindAnnotations.find(classDecl, "@org.mockito.Captor").isEmpty() ||
+                !FindAnnotations.find(classDecl, "@org.mockito.InjectMocks").isEmpty();
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
@@ -27,9 +27,7 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.FindTypes;
 import org.openrewrite.java.search.IsLikelyTest;
-import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.KotlinIsoVisitor;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
@@ -43,8 +41,6 @@ import static org.openrewrite.Preconditions.*;
 
 public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
 
-    private static final String EXTEND_WITH = "org.junit.jupiter.api.extension.ExtendWith";
-    private static final String RUN_WITH = "org.junit.runner.RunWith";
     // Explicit list rather than a wildcard like `org.mockito.*`, which would also match non-injection annotations
     // such as `@DoNotMock`, `@CheckReturnValue` or `@Incubating` and cause false positives.
     private static final List<String> MOCKITO_FIELD_ANNOTATIONS = Arrays.asList(
@@ -63,6 +59,11 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
+        // Match any `@ExtendWith`/`@RunWith` (no `.class` argument): if a test already registers an extension or runner
+        // (e.g. `SpringExtension`), adding `MockitoExtension` is at best redundant and at worst breaks the test
+        // lifecycle. See https://github.com/openrewrite/rewrite-testing-frameworks/issues/875
+        TreeVisitor<?, ExecutionContext> hasExtendWithAnnotation = new FindAnnotations("org.junit.jupiter.api.extension.ExtendWith", false).getVisitor();
+        TreeVisitor<?, ExecutionContext> hasRunWithAnnotation = new FindAnnotations("org.junit.runner.RunWith", false).getVisitor();
         @SuppressWarnings("unchecked")
         TreeVisitor<?, ExecutionContext>[] hasAnyMockitoAnnotation = new TreeVisitor[]{
                 // see https://www.baeldung.com/mockito-annotations for examples
@@ -75,10 +76,12 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return check(and(new IsLikelyTest().getVisitor(),
                         or(hasAnyMockitoAnnotation),
                         or(
-                                // JUnit 5: has JUnit 5 types
-                                new FindTypes("org.junit.jupiter..*", false).getVisitor(),
-                                // JUnit 4: has @org.junit.Test
-                                new FindAnnotations("org.junit.Test", false).getVisitor()
+                                // JUnit 5: has JUnit 5 types and no `@ExtendWith` yet
+                                and(new FindTypes("org.junit.jupiter..*", false).getVisitor(),
+                                        not(hasExtendWithAnnotation)),
+                                // JUnit 4: has @org.junit.Test and no `@RunWith` yet
+                                and(new FindAnnotations("org.junit.Test", false).getVisitor(),
+                                        not(hasRunWithAnnotation))
                         )),
                 new TreeVisitor<Tree, ExecutionContext>() {
                     @Override
@@ -102,7 +105,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), EXTEND_WITH)) {
+                if (shouldSkip(classDecl)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
@@ -122,7 +125,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), RUN_WITH)) {
+                if (shouldSkip(classDecl)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.MockitoJUnitRunner");
@@ -142,7 +145,7 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         return new KotlinIsoVisitor<ExecutionContext>() {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                if (shouldSkip(classDecl, service(AnnotationService.class).getAllAnnotations(getCursor()), EXTEND_WITH)) {
+                if (shouldSkip(classDecl)) {
                     return classDecl;
                 }
                 maybeAddImport("org.mockito.junit.jupiter.MockitoExtension");
@@ -159,21 +162,15 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
     }
 
     /**
-     * Only add the extension/runner to a concrete test class that itself declares Mockito annotations and does
-     * not already register an extension or runner (e.g. {@code SpringExtension}). This avoids redundant or harmful
-     * additions; see <a href="https://github.com/openrewrite/rewrite-testing-frameworks/issues/875">#875</a>.
+     * Only add the extension/runner to a concrete test class that declares Mockito annotations. Whether an extension
+     * or runner is already present is handled by the precondition; see
+     * <a href="https://github.com/openrewrite/rewrite-testing-frameworks/issues/875">#875</a>.
      */
-    private static boolean shouldSkip(J.ClassDeclaration classDecl, List<J.Annotation> classAnnotations, String existingExtensionType) {
+    private static boolean shouldSkip(J.ClassDeclaration classDecl) {
         // Interfaces, enums, annotations and abstract bases are not concrete Mockito test classes
         if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class ||
                 classDecl.getModifiers().stream().anyMatch(m -> m.getType() == J.Modifier.Type.Abstract)) {
             return true;
-        }
-        // Don't add when the class already registers an extension or runner (e.g. SpringExtension)
-        for (J.Annotation annotation : classAnnotations) {
-            if (TypeUtils.isOfClassType(annotation.getType(), existingExtensionType)) {
-                return true;
-            }
         }
         // Only add to classes that declare Mockito annotations. The search spans the class subtree on purpose: a
         // `@Mock` in a `@Nested` inner class should annotate the enclosing class, since JUnit 5 propagates the

--- a/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsed.java
@@ -33,21 +33,10 @@ import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static java.util.Comparator.comparing;
 import static org.openrewrite.Preconditions.*;
 
 public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
-
-    // Explicit list rather than a wildcard like `org.mockito.*`, which would also match non-injection annotations
-    // such as `@DoNotMock`, `@CheckReturnValue` or `@Incubating` and cause false positives.
-    private static final List<String> MOCKITO_FIELD_ANNOTATIONS = Arrays.asList(
-            "org.mockito.Captor",
-            "org.mockito.Mock",
-            "org.mockito.Spy",
-            "org.mockito.InjectMocks");
 
     @Getter
     final String displayName = "Adds Mockito extensions to Mockito tests";
@@ -58,30 +47,18 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-
-        // Match any `@ExtendWith`/`@RunWith` (no `.class` argument): if a test already registers an extension or runner
-        // (e.g. `SpringExtension`), adding `MockitoExtension` is at best redundant and at worst breaks the test
-        // lifecycle. See https://github.com/openrewrite/rewrite-testing-frameworks/issues/875
-        TreeVisitor<?, ExecutionContext> hasExtendWithAnnotation = new FindAnnotations("org.junit.jupiter.api.extension.ExtendWith", false).getVisitor();
-        TreeVisitor<?, ExecutionContext> hasRunWithAnnotation = new FindAnnotations("org.junit.runner.RunWith", false).getVisitor();
-        @SuppressWarnings("unchecked")
-        TreeVisitor<?, ExecutionContext>[] hasAnyMockitoAnnotation = new TreeVisitor[]{
-                // see https://www.baeldung.com/mockito-annotations for examples
-                new FindAnnotations("org.mockito.Captor", false).getVisitor(),
-                new FindAnnotations("org.mockito.Mock", false).getVisitor(),
-                new FindAnnotations("org.mockito.Spy", false).getVisitor(),
-                new FindAnnotations("org.mockito.InjectMocks", false).getVisitor(),
-        };
-
         return check(and(new IsLikelyTest().getVisitor(),
-                        or(hasAnyMockitoAnnotation),
+                        new FindAnnotations("org.mockito.*", false).getVisitor(),
+                        // Match any `@ExtendWith`/`@RunWith` (no `.class` argument): if a test already registers an extension or runner
+                        // (e.g. `SpringExtension`), adding `MockitoExtension` is at best redundant and at worst breaks the test
+                        // lifecycle. See https://github.com/openrewrite/rewrite-testing-frameworks/issues/875
                         or(
                                 // JUnit 5: has JUnit 5 types and no `@ExtendWith` yet
                                 and(new FindTypes("org.junit.jupiter..*", false).getVisitor(),
-                                        not(hasExtendWithAnnotation)),
+                                        not(new FindAnnotations("org.junit.jupiter.api.extension.ExtendWith", false).getVisitor())),
                                 // JUnit 4: has @org.junit.Test and no `@RunWith` yet
                                 and(new FindAnnotations("org.junit.Test", false).getVisitor(),
-                                        not(hasRunWithAnnotation))
+                                        not(new FindAnnotations("org.junit.runner.RunWith", false).getVisitor()))
                         )),
                 new TreeVisitor<Tree, ExecutionContext>() {
                     @Override
@@ -175,11 +152,6 @@ public class AddMockitoExtensionIfAnnotationsUsed extends Recipe {
         // Only add to classes that declare Mockito annotations. The search spans the class subtree on purpose: a
         // `@Mock` in a `@Nested` inner class should annotate the enclosing class, since JUnit 5 propagates the
         // extension to nested classes (and the visitor only annotates the outermost class).
-        return !declaresMockitoAnnotation(classDecl);
-    }
-
-    private static boolean declaresMockitoAnnotation(J.ClassDeclaration classDecl) {
-        return MOCKITO_FIELD_ANNOTATIONS.stream()
-                .anyMatch(fqn -> !FindAnnotations.find(classDecl, "@" + fqn).isEmpty());
+        return FindAnnotations.find(classDecl, "@org.mockito.*").isEmpty();
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWith.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWith.java
@@ -24,6 +24,9 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.Expression;
@@ -37,6 +40,7 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
 
     private static final String POWER_MOCK_RUNNER_DELEGATE = "org.powermock.modules.junit4.PowerMockRunnerDelegate";
     private static final String POWER_MOCK_RUNNER = "org.powermock.modules.junit4.PowerMockRunner";
+    private static final String MOCKITO_JUNIT_RUNNER = "org.mockito.junit.MockitoJUnitRunner";
     private static final AnnotationMatcher DELEGATE_MATCHER =
             new AnnotationMatcher("@" + POWER_MOCK_RUNNER_DELEGATE);
     private static final AnnotationMatcher RUN_WITH_POWER_MOCK_RUNNER_MATCHER =
@@ -47,8 +51,9 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
 
     @Getter
     final String description = "Replaces `@RunWith(PowerMockRunner.class)`. If `@PowerMockRunnerDelegate(X.class)` " +
-            "is present, promotes the delegate runner to `@RunWith(X.class)`. Otherwise, removes the " +
-            "`@RunWith(PowerMockRunner.class)` annotation entirely.";
+            "is present, promotes the delegate runner to `@RunWith(X.class)`. Otherwise, replaces it with " +
+            "`@RunWith(MockitoJUnitRunner.class)` when the class uses Mockito annotations like `@Mock`, or removes " +
+            "the `@RunWith(PowerMockRunner.class)` annotation entirely.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -84,7 +89,26 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
                             }));
                         }
 
-                        // No delegate — just remove @RunWith(PowerMockRunner.class)
+                        // No delegate, but Mockito annotations are used — switch to the Mockito JUnit 4 runner
+                        // so the mocks remain initialized
+                        if (declaresMockitoAnnotation(cd)) {
+                            maybeAddImport(MOCKITO_JUNIT_RUNNER);
+                            return (J.ClassDeclaration) new JavaIsoVisitor<ExecutionContext>() {
+                                @Override
+                                public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                                    if (RUN_WITH_POWER_MOCK_RUNNER_MATCHER.matches(annotation)) {
+                                        return JavaTemplate.builder("@RunWith(MockitoJUnitRunner.class)")
+                                                .imports("org.junit.runner.RunWith", MOCKITO_JUNIT_RUNNER)
+                                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-4", "mockito-core"))
+                                                .build()
+                                                .apply(getCursor(), annotation.getCoordinates().replace());
+                                    }
+                                    return annotation;
+                                }
+                            }.visitNonNull(cd, ctx, getCursor().getParentOrThrow());
+                        }
+
+                        // No delegate and no Mockito annotations — just remove @RunWith(PowerMockRunner.class)
                         maybeRemoveImport("org.junit.runner.RunWith");
                         return cd.withLeadingAnnotations(ListUtils.map(cd.getLeadingAnnotations(), annotation -> {
                             if (RUN_WITH_POWER_MOCK_RUNNER_MATCHER.matches(annotation)) {
@@ -92,6 +116,13 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
                             }
                             return annotation;
                         }));
+                    }
+
+                    private boolean declaresMockitoAnnotation(J.ClassDeclaration cd) {
+                        return !FindAnnotations.find(cd, "@org.mockito.Mock").isEmpty() ||
+                                !FindAnnotations.find(cd, "@org.mockito.Spy").isEmpty() ||
+                                !FindAnnotations.find(cd, "@org.mockito.Captor").isEmpty() ||
+                                !FindAnnotations.find(cd, "@org.mockito.InjectMocks").isEmpty();
                     }
 
                     private @Nullable Expression findDelegateRunnerArg(J.ClassDeclaration cd) {

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWith.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWith.java
@@ -91,7 +91,7 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
 
                         // No delegate, but Mockito annotations are used — switch to the Mockito JUnit 4 runner
                         // so the mocks remain initialized
-                        if (declaresMockitoAnnotation(cd)) {
+                        if (!FindAnnotations.find(cd, "@org.mockito.*").isEmpty()) {
                             maybeAddImport(MOCKITO_JUNIT_RUNNER);
                             return (J.ClassDeclaration) new JavaIsoVisitor<ExecutionContext>() {
                                 @Override
@@ -116,13 +116,6 @@ public class PowerMockRunnerDelegateToRunWith extends Recipe {
                             }
                             return annotation;
                         }));
-                    }
-
-                    private boolean declaresMockitoAnnotation(J.ClassDeclaration cd) {
-                        return !FindAnnotations.find(cd, "@org.mockito.Mock").isEmpty() ||
-                                !FindAnnotations.find(cd, "@org.mockito.Spy").isEmpty() ||
-                                !FindAnnotations.find(cd, "@org.mockito.Captor").isEmpty() ||
-                                !FindAnnotations.find(cd, "@org.mockito.InjectMocks").isEmpty();
                     }
 
                     private @Nullable Expression findDelegateRunnerArg(J.ClassDeclaration cd) {

--- a/src/main/resources/META-INF/rewrite/jmockit.yml
+++ b/src/main/resources/META-INF/rewrite/jmockit.yml
@@ -43,11 +43,22 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: mockit.integration.junit4.JMockit
       newFullyQualifiedTypeName: org.mockito.junit.MockitoJUnitRunner
+  # Unlike the generic Mockito migration (see https://github.com/openrewrite/rewrite-testing-frameworks/issues/875),
+  # JMockit tests using `@Mocked` without `@ExtendWith(JMockitExtension.class)` (the javaagent style) have no extension
+  # to carry over, so the converted `@Mock` fields would never be initialized. Add the extension here; the hardened
+  # recipe leaves classes that already register an extension/runner untouched.
+  - org.openrewrite.java.testing.mockito.AddMockitoExtensionIfAnnotationsUsed
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.mockito
       artifactId: mockito-core
       version: 5.x
       onlyIfUsing: org.mockito.*
+      acceptTransitive: true
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.mockito
+      artifactId: mockito-junit-jupiter
+      version: 5.x
+      onlyIfUsing: org.mockito.junit.jupiter.MockitoExtension
       acceptTransitive: true
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.jmockit

--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -184,8 +184,13 @@ recipeList:
   - org.openrewrite.java.testing.mockito.ReplacePowerMockito
   - org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension
   - org.openrewrite.java.testing.mockito.AddMockitoSettingsWithWarnStrictnessForLegacyMockito
-  - org.openrewrite.java.testing.mockito.AddMockitoExtensionIfAnnotationsUsed
-  - org.openrewrite.java.testing.mockito.AddMockitoJupiterDependency
+  # Intentionally NOT applied as part of the migration; see https://github.com/openrewrite/rewrite-testing-frameworks/issues/875
+  # `@ExtendWith(MockitoExtension.class)` cannot be added safely: the extension may already be provided by a super class,
+  # an interface, a meta-annotation, an explicit `MockitoAnnotations.openMocks(this)` call, or `SpringExtension` (which
+  # already initializes `@Mock` fields), so adding it is at best redundant and at worst breaks the test lifecycle.
+  # Do not re-enable these without first making the recipes aware of those cases.
+  # - org.openrewrite.java.testing.mockito.AddMockitoExtensionIfAnnotationsUsed
+  # - org.openrewrite.java.testing.mockito.AddMockitoJupiterDependency
   - org.openrewrite.java.testing.mockito.ReplaceMockitoTestExecutionListenerForJupiter
   - org.openrewrite.java.testing.mockito.ReplaceMockitoTestExecutionListenerForJUnit4
   - org.openrewrite.java.testing.mockito.ReplaceMockitoTestExecutionListenerForTestNG

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -1800,8 +1800,11 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
 
+              @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   private MyInterface myMock;

--- a/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/jmockit/JMockitExpectationsToMockitoTest.java
@@ -1800,11 +1800,8 @@ class JMockitExpectationsToMockitoTest implements RewriteTest {
               """,
             """
               import org.junit.jupiter.api.Test;
-              import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
 
-              @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   private MyInterface myMock;

--- a/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsedTest.java
@@ -251,6 +251,100 @@ class AddMockitoExtensionIfAnnotationsUsedTest implements RewriteTest {
     }
 
     @Test
+    void doNotAddWhenSpringExtensionPresent() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api", "mockito-junit-jupiter", "mockito-core", "spring-test-6.1")
+            .dependsOn("public class Service {}")),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+              @ExtendWith(SpringExtension.class)
+              class MyTest {
+                  @Mock
+                  Service service;
+                  @Test
+                  void test() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotAddToAbstractClass() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              abstract class BaseTest {
+                  @Mock
+                  Service service;
+                  @Test
+                  void test() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotAddToInterfaceOrClassWithoutOwnMockitoAnnotations() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              interface MyService {}
+
+              class HelperWithoutMocks {
+                  @Test
+                  void test() {}
+              }
+
+              class MyTest {
+                  @Mock
+                  MyService service;
+                  @Test
+                  void test() {}
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              interface MyService {}
+
+              class HelperWithoutMocks {
+                  @Test
+                  void test() {}
+              }
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  MyService service;
+                  @Test
+                  void test() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotAddIfPresentInKotlinWithJUnit5() {
         rewriteRun(
           spec -> spec.parser(KotlinParser.builder()

--- a/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoExtensionIfAnnotationsUsedTest.java
@@ -345,6 +345,50 @@ class AddMockitoExtensionIfAnnotationsUsedTest implements RewriteTest {
     }
 
     @Test
+    void addToEnclosingClassForNestedMock() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Nested;
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              class OuterTest {
+                  @Nested
+                  class InnerTest {
+                      @Mock
+                      Service service;
+
+                      @Test
+                      void test() {}
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Nested;
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              class OuterTest {
+                  @Nested
+                  class InnerTest {
+                      @Mock
+                      Service service;
+
+                      @Test
+                      void test() {}
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotAddIfPresentInKotlinWithJUnit5() {
         rewriteRun(
           spec -> spec.parser(KotlinParser.builder()

--- a/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoJupiterDependencyTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/AddMockitoJupiterDependencyTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.testing.mockito;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class AddMockitoJupiterDependencyTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .beforeRecipe(withToolingApi())
+          .recipe(new AddMockitoJupiterDependency())
+          .parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api", "mockito-core", "mockito-junit-jupiter"));
+    }
+
+    @DocumentExample
+    @Test
+    void addsMockitoJupiterDependencyWhenMockUsedInJUnit5() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.mockito.Mock;
+
+              class MyTest {
+                  @Mock
+                  Object myMock;
+
+                  @Test
+                  void someTest() {
+                  }
+              }
+              """
+          ),
+          //language=groovy
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                  testImplementation("org.mockito:mockito-core:3.12.4")
+              }
+              test {
+                  useJUnitPlatform()
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
+                  testImplementation("org.mockito:mockito-core:3.12.4")
+                  testImplementation "org.mockito:mockito-junit-jupiter:3.12.4"
+              }
+              test {
+                  useJUnitPlatform()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotAddWhenMockitoExtensionAlreadyPresent() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              class MyTest {
+                  @Mock
+                  Object myMock;
+
+                  @Test
+                  void someTest() {
+                  }
+              }
+              """
+          ),
+          //language=xml
+          pomXml(
+            """
+              <project>
+                <groupId>org.example</groupId>
+                <artifactId>some-project</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-api</artifactId>
+                        <version>5.11.4</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>3.12.4</version>
+                    </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/JunitMockitoUpgradeIntegrationTest.java
@@ -89,19 +89,25 @@ class JunitMockitoUpgradeIntegrationTest implements RewriteTest {
             """
               package org.openrewrite.java.testing.junit5;
 
+              import org.junit.jupiter.api.AfterEach;
+              import org.junit.jupiter.api.BeforeEach;
               import org.junit.jupiter.api.Test;
-              import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
+              import org.mockito.MockitoAnnotations;
 
               import java.util.List;
 
               import static org.mockito.Mockito.verify;
 
-              @ExtendWith(MockitoExtension.class)
               public class MockitoTests {
+                  private AutoCloseable mocks;
                   @Mock
                   List<String> mockedList;
+
+                  @BeforeEach
+                  public void initMocks() {
+                      mocks = MockitoAnnotations.openMocks(this);
+                  }
 
                   @Test
                   public void usingAnnotationBasedMock() {
@@ -111,6 +117,11 @@ class JunitMockitoUpgradeIntegrationTest implements RewriteTest {
 
                       verify(mockedList).add("one");
                       verify(mockedList).clear();
+                  }
+
+                  @AfterEach
+                  void tearDown() throws Exception {
+                      mocks.close();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/Mockito1to3MigrationTest.java
@@ -173,16 +173,13 @@ class Mockito1to3MigrationTest implements RewriteTest {
             """
               import org.junit.jupiter.api.BeforeEach;
               import org.junit.jupiter.api.Test;
-              import org.junit.jupiter.api.extension.ExtendWith;
               import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
 
               import static org.mockito.ArgumentMatchers.anyList;
               import static org.mockito.ArgumentMatchers.any;
               import static org.mockito.ArgumentMatchers.anyString;
               import static org.mockito.Mockito.when;
 
-              @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object objectMock;
@@ -288,7 +285,9 @@ class Mockito1to3MigrationTest implements RewriteTest {
     }
 
     @Test
-    void addMockitoJupiterDependencyIfMockitoExtensionIsAdded() {
+    void doesNotAddMockitoExtensionOrJupiterDependency() {
+        // The migration upgrades the Mockito dependency but must not add `@ExtendWith(MockitoExtension.class)`
+        // nor the `mockito-junit-jupiter` dependency; see https://github.com/openrewrite/rewrite-testing-frameworks/issues/875
         rewriteRun(
           //language=groovy
           buildGradle(
@@ -317,7 +316,6 @@ class Mockito1to3MigrationTest implements RewriteTest {
               dependencies {
                   testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.4")
                   testImplementation("org.mockito:mockito-core:3.12.4")
-                  testImplementation "org.mockito:mockito-junit-jupiter:3.12.4"
               }
               test {
                   useJUnitPlatform()
@@ -361,12 +359,6 @@ class Mockito1to3MigrationTest implements RewriteTest {
                         <artifactId>mockito-core</artifactId>
                         <version>3.12.4</version>
                     </dependency>
-                  <dependency>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-junit-jupiter</artifactId>
-                    <version>3.12.4</version>
-                    <scope>test</scope>
-                  </dependency>
                 </dependencies>
               </project>
               """
@@ -377,22 +369,6 @@ class Mockito1to3MigrationTest implements RewriteTest {
               import org.junit.jupiter.api.Test;
               import org.mockito.Mock;
 
-              class MyTest {
-                  @Mock
-                  Object myMock;
-
-                  @Test
-                  void someTest() {
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.Test;
-              import org.junit.jupiter.api.extension.ExtendWith;
-              import org.mockito.Mock;
-              import org.mockito.junit.jupiter.MockitoExtension;
-
-              @ExtendWith(MockitoExtension.class)
               class MyTest {
                   @Mock
                   Object myMock;

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWithTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockRunnerDelegateToRunWithTest.java
@@ -102,6 +102,53 @@ class PowerMockRunnerDelegateToRunWithTest implements RewriteTest {
     }
 
     @Test
+    void replacesRunWithPowerMockRunnerWithMockitoJUnitRunnerWhenMockAnnotationsPresent() {
+        //language=java
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+            .logCompilationWarningsAndErrors(true)
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "junit-4",
+              "mockito-core",
+              "powermock-module-junit4")),
+          java(
+            """
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import org.mockito.Mock;
+              import org.powermock.modules.junit4.PowerMockRunner;
+
+              @RunWith(PowerMockRunner.class)
+              public class MyTest {
+                  @Mock
+                  Object myMock;
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import org.mockito.Mock;
+              import org.mockito.junit.MockitoJUnitRunner;
+
+              @RunWith(MockitoJUnitRunner.class)
+              public class MyTest {
+                  @Mock
+                  Object myMock;
+
+                  @Test
+                  public void testSomething() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removesRunWithPowerMockRunnerWithoutDelegate() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
- Fixes #875

## Problem
`AddMockitoExtensionIfAnnotationsUsed` (run as part of `Mockito1to3Migration`) added `@ExtendWith(MockitoExtension.class)` to any test using `@Mock`/`@Spy`/`@Captor`/`@InjectMocks`, even when Mockito support was already provided another way. This was at best redundant and at worst broke the test lifecycle — e.g. when `SpringExtension` is present (it already initializes `@Mock` fields), when a parent class/interface/meta-annotation provides the extension, or when `MockitoAnnotations.openMocks(this)` is used explicitly.

## Changes
**Removed from the migration (do no harm)**
- `AddMockitoExtensionIfAnnotationsUsed` and its companion `AddMockitoJupiterDependency` are no longer applied as part of `Mockito1to3Migration`. They are kept as **commented-out** entries with an explanatory comment so the intent is captured and they aren't re-added without first teaching the recipes about these cases.

**Hardened the standalone recipe** (`AddMockitoExtensionIfAnnotationsUsed`)
- Skips when any `@ExtendWith`/`@RunWith` is already present (covers `SpringExtension`).
- Skips non-concrete classes (interfaces, enums, annotations, `abstract` bases).
- Only annotates classes that themselves declare a Mockito annotation.

**Preserved the PowerMock migration path**
- `PowerMockRunnerDelegateToRunWith` now replaces `@RunWith(PowerMockRunner.class)` with `@RunWith(MockitoJUnitRunner.class)` when the class uses Mockito annotations (instead of relying on the now-removed generic auto-add), and still removes it entirely otherwise.

**Tests**
- Added cases for the hardened recipe (SpringExtension present, abstract class, interface + helper without mocks).
- Added standalone `AddMockitoJupiterDependencyTest` to keep that recipe covered.
- Updated migration/integration tests to the new, correct behavior (explicit `initMocks` is now preserved/migrated to `openMocks` + `AutoCloseable` instead of being replaced by the extension).

## Notes / not covered
The hardened recipe still does not detect the **inheritance**, **meta-annotation** (e.g. `@MockitoSettings`), or **explicit-`initMocks`** cases — these now only matter to someone invoking the standalone recipe directly, since it no longer runs in the migration.

Full test suite passes locally.