### PR TITLE
Re-include CloseUnclosedStaticMocks in Mockito1to4Migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -92,7 +92,7 @@ recipeList:
       artifactId: byte-buddy*
       newVersion: 1.12.19
   - org.openrewrite.java.testing.mockito.ReplaceInitMockToOpenMock
-#  - org.openrewrite.java.testing.mockito.CloseUnclosedStaticMocks
+  - org.openrewrite.java.testing.mockito.CloseUnclosedStaticMocks
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.testing.mockito.Mockito1to3Migration


### PR DESCRIPTION
## What's changed?

Re-enables `CloseUnclosedStaticMocks` inside the `Mockito1to4Migration` composite recipe.

## What's your motivation?

- `CloseUnclosedStaticMocks` was added to `Mockito1to4Migration` in #739 so users wouldn't need to seek it out separately, then commented out two days later in d1e6bbba after @timtebeek observed it injecting teardown in the wrong scope for `@Nested` classes — e.g. `JMockitMockUpToMockitoTest.mockUpAtSetUpWithTearDownTest()` (see [the discussion on #739](https://github.com/openrewrite/rewrite-testing-frameworks/pull/739#issuecomment-2916048488)).

- #742 (merged two days after the comment-out) handled nested classes and qualified mocked-class names, fixing the underlying issue. The YAML line was never re-enabled — appears to have been an oversight rather than a remaining concern.

## Verification

Locally green:

- `JMockitMockUpToMockitoTest` (the canary @timtebeek originally pointed at)
- `CloseUnclosedStaticMocksTest`
- `Mockito1to3MigrationTest`, `Mockito1to4MigrationTest`, `Mockito1to5MigrationTest`
- Full `org.openrewrite.java.testing.mockito.*` and `org.openrewrite.java.testing.jmockit.*` packages
- `recipeCsvValidate` (both completeness and content)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases (covered by existing `CloseUnclosedStaticMocksTest` and the composite migration tests)
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files