### PR TITLE
Update MockWebServer MockResponse test for nested-type render change

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateMockWebServerMockResponseTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateMockWebServerMockResponseTest.java
@@ -117,14 +117,13 @@ class UpdateMockWebServerMockResponseTest implements RewriteTest {
               """,
             """
               import mockwebserver3.MockResponse;
-              import mockwebserver3.MockResponse.Builder;
               import okhttp3.Headers;
               import mockwebserver3.MockWebServer;
 
               class A {
                   private Headers.Builder headersBuilder = new Headers.Builder();
                   private MockWebServer mockWebServer = new MockWebServer();
-                  private Builder mockResponse = new MockResponse.Builder()
+                  private MockResponse.Builder mockResponse = new MockResponse.Builder()
                       .status("a")
                       .headers(headersBuilder.build())
                       .setHeader("headerA", "someValue");


### PR DESCRIPTION
The `UpdateMockWebServerMockResponseTest.shouldMigrateMockResponseToBuilder()` test started failing against the latest `rewrite` snapshot (`8.85.0-SNAPSHOT`).

### Root cause

- [openrewrite/rewrite#7993](https://github.com/openrewrite/rewrite/pull/7993) changed `ChangeMethodInvocationReturnType` to rewrite a variable’s declared type only when the variable’s initializer **is** the matched invocation, not when the match is merely nested inside the initializer.

In this test, `mockResponse`’s initializer is a chain whose outermost call is `setHeader(...)`, which is not in the recipe’s replacement map — so the matched `setStatus(...)` is nested, not the initializer. The declared-type change is therefore now performed by the later `ChangeType` step (rather than `ChangeMethodInvocationReturnType`), and `ChangeType` renders the nested type in qualified `MockResponse.Builder` form (reusing the existing `mockwebserver3.MockResponse` import) instead of importing `mockwebserver3.MockResponse.Builder` and using the simple name `Builder`.

### Change

Update the expected output of `shouldMigrateMockResponseToBuilder`:

```diff
 import mockwebserver3.MockResponse;
-import mockwebserver3.MockResponse.Builder;
 ...
-    private Builder mockResponse = new MockResponse.Builder()
+    private MockResponse.Builder mockResponse = new MockResponse.Builder()
```

This matches the new (more correct, consistent) output — `mockResponse2` in the same test already renders as `MockResponse.Builder`.

### Verification

- Pinned core `org.openrewrite` modules to `8.84.7` (pre-#7993): test passes.
- Against `8.85.0-SNAPSHOT` (has #7993): test fails before this change, passes after.