### PR TITLE
Fix UsesType precondition pattern in KotlinTestMethodsShouldReturnUnit

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
@@ -35,6 +35,9 @@ import static java.util.Collections.emptyList;
 public class KotlinTestMethodsShouldReturnUnit extends Recipe {
 
     private static final String TEST_ANNOTATION_PATTERN = "org..* *Test*";
+    // `UsesType` matches against fully qualified type names, so it needs a single-token glob rather
+    // than the two-token (`<owner> <name>`) form `AnnotationMatcher` uses above.
+    private static final String TEST_ANNOTATION_TYPE_PATTERN = "org.junit..*Test*";
     private static final JavaType.Class KOTLIN_UNIT = (JavaType.Class) JavaType.buildType("kotlin.Unit");
 
     @Getter
@@ -47,7 +50,7 @@ public class KotlinTestMethodsShouldReturnUnit extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesType<>(TEST_ANNOTATION_PATTERN, true), new KotlinIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesType<>(TEST_ANNOTATION_TYPE_PATTERN, true), new KotlinIsoVisitor<ExecutionContext>() {
             @Override
             public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                 J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);


### PR DESCRIPTION
The seven `KotlinTestMethodsShouldReturnUnitTest` tests started failing with "Recipe was expected to make a change but made no changes."

- The recipe gated its visitor behind `new UsesType<>("org..* *Test*", true)`. `UsesType` matches against fully qualified type names, but `"org..* *Test*"` is the two-token `<owner> <name>` form that `AnnotationMatcher`/`MethodMatcher` understand — no type name contains a space, so it could only ever match via the `TypeNameMatcher` bug where a `..*` token followed by a suffix matched every name. That bug was fixed upstream in openrewrite/rewrite#8012, which correctly tightened the matcher and exposed this latent issue.

Uses a valid single-token glob `org.junit..*Test*` for the `UsesType` precondition, covering `@Test`, `@ParameterizedTest`, `@RepeatedTest`, and `@TestTemplate`. The `AnnotationMatcher` pattern (which correctly supports the two-token form) is left unchanged.

Validated locally with JDK 21 against the current rewrite snapshot: `KotlinTestMethodsShouldReturnUnitTest` passes (8/8), and the full `./gradlew test` is green (1599 tests, 0 failures).