### PR TITLE
Support 4-arg Whitebox.setInternalState(target, field, value, Class)

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxToJavaReflection.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxToJavaReflection.java
@@ -40,6 +40,8 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
     private static final String WHITEBOX_FQN = "org.powermock.reflect.Whitebox";
     private static final MethodMatcher SET_INTERNAL_STATE =
             new MethodMatcher("org.powermock.reflect.Whitebox setInternalState(java.lang.Object, java.lang.String, java.lang.Object)");
+    private static final MethodMatcher SET_INTERNAL_STATE_WHERE =
+            new MethodMatcher("org.powermock.reflect.Whitebox setInternalState(java.lang.Object, java.lang.String, java.lang.Object, java.lang.Class)");
     private static final MethodMatcher GET_INTERNAL_STATE =
             new MethodMatcher("org.powermock.reflect.Whitebox getInternalState(java.lang.Object, java.lang.String)");
     private static final MethodMatcher INVOKE_METHOD =
@@ -125,7 +127,7 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
                                     templateArgs
                             );
                     getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, WHITEBOX_REPLACED, true);
-                    if (SET_INTERNAL_STATE.matches(mi) || GET_INTERNAL_STATE.matches(mi)) {
+                    if (SET_INTERNAL_STATE.matches(mi) || SET_INTERNAL_STATE_WHERE.matches(mi) || GET_INTERNAL_STATE.matches(mi)) {
                         getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, NEEDS_FIELD_IMPORT, true);
                     }
                     if (INVOKE_METHOD.matches(mi)) {
@@ -144,7 +146,10 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
             List<Expression> args = mi.getArguments();
 
             if (SET_INTERNAL_STATE.matches(mi) && args.size() == 3) {
-                return buildSetInternalStateTemplate(args, scope);
+                return buildSetInternalStateTemplate(args, scope, false);
+            }
+            if (SET_INTERNAL_STATE_WHERE.matches(mi) && args.size() == 4) {
+                return buildSetInternalStateTemplate(args, scope, true);
             }
             if (GET_INTERNAL_STATE.matches(mi) && args.size() == 2) {
                 return buildGetInternalStateTemplate(args, statement, scope);
@@ -162,6 +167,10 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
                 // target, fieldName, target, value
                 return new Object[]{args.get(0), args.get(1), args.get(0), args.get(2)};
             }
+            if (SET_INTERNAL_STATE_WHERE.matches(mi) && args.size() == 4) {
+                // whereClass, fieldName, target, value
+                return new Object[]{args.get(3), args.get(1), args.get(0), args.get(2)};
+            }
             if (GET_INTERNAL_STATE.matches(mi) && args.size() == 2) {
                 // target, fieldName, target
                 return new Object[]{args.get(0), args.get(1), args.get(0)};
@@ -172,13 +181,16 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
             return new Object[0];
         }
 
-        private @Nullable String buildSetInternalStateTemplate(List<Expression> args, Cursor scope) {
+        private @Nullable String buildSetInternalStateTemplate(List<Expression> args, Cursor scope, boolean where) {
             String fieldName = extractStringLiteral(args.get(1));
             if (fieldName == null) {
                 return null;
             }
             String varName = generateVariableName(fieldName + "Field", scope, INCREMENT_NUMBER);
-            return "Field " + varName + " = #{any(java.lang.Object)}.getClass().getDeclaredField(#{any(java.lang.String)});\n" +
+            String lookup = where ?
+                    "Field " + varName + " = #{any(java.lang.Class)}.getDeclaredField(#{any(java.lang.String)});\n" :
+                    "Field " + varName + " = #{any(java.lang.Object)}.getClass().getDeclaredField(#{any(java.lang.String)});\n";
+            return lookup +
                     varName + ".setAccessible(true);\n" +
                     varName + ".set(#{any(java.lang.Object)}, #{any(java.lang.Object)});";
         }
@@ -325,7 +337,8 @@ public class PowerMockWhiteboxToJavaReflection extends Recipe {
         private J.@Nullable MethodInvocation extractWhiteboxInvocation(Statement statement) {
             if (statement instanceof J.MethodInvocation) {
                 J.MethodInvocation mi = (J.MethodInvocation) statement;
-                if (SET_INTERNAL_STATE.matches(mi) || GET_INTERNAL_STATE.matches(mi) || INVOKE_METHOD.matches(mi)) {
+                if (SET_INTERNAL_STATE.matches(mi) || SET_INTERNAL_STATE_WHERE.matches(mi) ||
+                        GET_INTERNAL_STATE.matches(mi) || INVOKE_METHOD.matches(mi)) {
                     return mi;
                 }
             }

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxToJavaReflectionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxToJavaReflectionTest.java
@@ -77,6 +77,96 @@ class PowerMockWhiteboxToJavaReflectionTest implements RewriteTest {
     }
 
     @Test
+    void setInternalStateWithWhereClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Parent {
+                  private String name;
+              }
+              """
+          ),
+          java(
+            """
+              class Child extends Parent {
+              }
+              """
+          ),
+          java(
+            """
+              import org.powermock.reflect.Whitebox;
+
+              class MyServiceTest {
+                  void test() {
+                      Child child = new Child();
+                      Whitebox.setInternalState(child, "name", "newValue", Parent.class);
+                  }
+              }
+              """,
+            """
+              import java.lang.reflect.Field;
+
+              class MyServiceTest {
+                  void test() throws Exception {
+                      Child child = new Child();
+                      Field nameField = Parent.class.getDeclaredField("name");
+                      nameField.setAccessible(true);
+                      nameField.set(child, "newValue");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void setInternalStateWithWhereClassVariable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Parent {
+                  private String name;
+              }
+              """
+          ),
+          java(
+            """
+              class Child extends Parent {
+              }
+              """
+          ),
+          java(
+            """
+              import org.powermock.reflect.Whitebox;
+
+              class MyServiceTest {
+                  void test() {
+                      Child child = new Child();
+                      Class<?> where = Parent.class;
+                      Whitebox.setInternalState(child, "name", "newValue", where);
+                  }
+              }
+              """,
+            """
+              import java.lang.reflect.Field;
+
+              class MyServiceTest {
+                  void test() throws Exception {
+                      Child child = new Child();
+                      Class<?> where = Parent.class;
+                      Field nameField = where.getDeclaredField("name");
+                      nameField.setAccessible(true);
+                      nameField.set(child, "newValue");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void getInternalStateWithAssignment() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What

Extends `PowerMockWhiteboxToJavaReflection` to also handle the 4-arg overload
`Whitebox.setInternalState(target, "field", value, Class)`. The 3-arg form was already
migrated; this overload was left untouched.

## Why

The 4th argument is the **declaring class** to look the field up on, and it matters because
`getDeclaredField` does **not** walk the class hierarchy. For an inherited field,
`child.getClass().getDeclaredField("name")` throws `NoSuchFieldException` — only
`Parent.class.getDeclaredField("name")` resolves it. This overload is exactly what test code
uses to reach a field declared on a superclass.

The only semantic difference from the 3-arg path is the **receiver of `getDeclaredField`**:

| Overload | Generated lookup receiver |
|---|---|
| 3-arg `setInternalState(child, "name", v)` | `child.getClass()` (runtime class only) |
| 4-arg `setInternalState(child, "name", v, Parent.class)` | `Parent.class` (declaring superclass) |

Everything else — `setAccessible(true)`, `field.set(target, value)`, the `throws Exception`,
the `java.lang.reflect.Field` import — is identical to the shipped 3-arg path. No cast, no boxing.

## Before → After

```java
// before
Whitebox.setInternalState(child, "name", "newValue", Parent.class);

// after
Field nameField = Parent.class.getDeclaredField("name");
nameField.setAccessible(true);
nameField.set(child, "newValue");
```

## Notes

- New `MethodMatcher` for `setInternalState(Object, String, Object, Class)`; the `String` 2nd
  param disambiguates it from the `setInternalState(Object, Class, Object, Class)` sibling overload.
- The 4th `Class` argument flows straight into a `#{any(java.lang.Class)}` placeholder, so a
  non-literal `Class<?>` variable as the 4th arg works too (generates `where.getDeclaredField(...)`).
- No catalog/YAML change — the recipe is already wired in and `displayName`/`description` are unchanged.

## Tests

Two new tests in `PowerMockWhiteboxToJavaReflectionTest`:
- `setInternalStateWithWhereClass` — inherited field via a literal `Parent.class`.
- `setInternalStateWithWhereClassVariable` — a `Class<?>` variable as the 4th arg.

`./gradlew check` passes (license, recipe CSV completeness/content validation, full test suite).