### PR TITLE
Box primitive casts in `Whitebox.getInternalState`/`invokeMethod` reflection

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxGetInternalStateToJavaReflection.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxGetInternalStateToJavaReflection.java
@@ -67,7 +67,7 @@ public class PowerMockWhiteboxGetInternalStateToJavaReflection extends Recipe {
             String prefix = fieldLookupPrefix(varName);
             if (sink.varName != null) {
                 if (isNonObjectCast(sink.castType)) {
-                    return prefix + sink.castType + " " + sink.varName + " = (" + sink.castType + ") " + varName + ".get(#{any(java.lang.Object)});";
+                    return prefix + sink.castType + " " + sink.varName + " = (" + boxedCastType(sink.castType) + ") " + varName + ".get(#{any(java.lang.Object)});";
                 }
                 return prefix + "Object " + sink.varName + " = " + varName + ".get(#{any(java.lang.Object)});";
             }

--- a/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxInvokeMethodToJavaReflection.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxInvokeMethodToJavaReflection.java
@@ -90,7 +90,7 @@ public class PowerMockWhiteboxInvokeMethodToJavaReflection extends Recipe {
             // invoke line
             if (sink.varName != null) {
                 if (isNonObjectCast(sink.castType)) {
-                    sb.append(sink.castType).append(" ").append(sink.varName).append(" = (").append(sink.castType).append(") ");
+                    sb.append(sink.castType).append(" ").append(sink.varName).append(" = (").append(boxedCastType(sink.castType)).append(") ");
                 } else {
                     sb.append("Object ").append(sink.varName).append(" = ");
                 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/WhiteboxToReflectionVisitor.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/WhiteboxToReflectionVisitor.java
@@ -31,7 +31,9 @@ import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
@@ -49,6 +51,19 @@ abstract class WhiteboxToReflectionVisitor extends JavaIsoVisitor<ExecutionConte
     static final String WHITEBOX_FQN = "org.powermock.reflect.Whitebox";
 
     private static final String WHITEBOX_REPLACED = "whiteboxReplaced";
+
+    private static final Map<String, String> BOXED_TYPES = new HashMap<>();
+
+    static {
+        BOXED_TYPES.put("int", "Integer");
+        BOXED_TYPES.put("long", "Long");
+        BOXED_TYPES.put("double", "Double");
+        BOXED_TYPES.put("float", "Float");
+        BOXED_TYPES.put("boolean", "Boolean");
+        BOXED_TYPES.put("byte", "Byte");
+        BOXED_TYPES.put("short", "Short");
+        BOXED_TYPES.put("char", "Character");
+    }
 
     private final String reflectiveImport;
     private final List<MethodMatcher> matchers;
@@ -262,6 +277,15 @@ abstract class WhiteboxToReflectionVisitor extends JavaIsoVisitor<ExecutionConte
             return ((JavaType.Primitive) type).getKeyword();
         }
         return null;
+    }
+
+    /**
+     * {@code Field.get}/{@code Method.invoke} return {@code Object} (boxing primitives), so a primitive
+     * declared type must be cast to its wrapper (a direct {@code (int) object} cast does not compile);
+     * the surrounding assignment then auto-unboxes.
+     */
+    String boxedCastType(String castType) {
+        return BOXED_TYPES.getOrDefault(castType, castType);
     }
 
     private J.MethodDeclaration addThrowsExceptionIfAbsent(J.MethodDeclaration md) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxGetInternalStateToJavaReflectionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxGetInternalStateToJavaReflectionTest.java
@@ -75,4 +75,42 @@ class PowerMockWhiteboxGetInternalStateToJavaReflectionTest implements RewriteTe
           )
         );
     }
+
+    @Test
+    void primitiveResultUsesBoxedCast() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyService {
+                  private int count = 3;
+              }
+              """
+          ),
+          java(
+            """
+              import org.powermock.reflect.Whitebox;
+
+              class MyServiceTest {
+                  void test() {
+                      MyService service = new MyService();
+                      int count = Whitebox.getInternalState(service, "count");
+                  }
+              }
+              """,
+            """
+              import java.lang.reflect.Field;
+
+              class MyServiceTest {
+                  void test() throws Exception {
+                      MyService service = new MyService();
+                      Field countField = service.getClass().getDeclaredField("count");
+                      countField.setAccessible(true);
+                      int count = (Integer) countField.get(service);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxInvokeMethodToJavaReflectionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/PowerMockWhiteboxInvokeMethodToJavaReflectionTest.java
@@ -280,4 +280,44 @@ class PowerMockWhiteboxInvokeMethodToJavaReflectionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void primitiveResultUsesBoxedCast() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class MyService {
+                  private int compute() {
+                      return 42;
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              import org.powermock.reflect.Whitebox;
+
+              class MyServiceTest {
+                  void test() {
+                      MyService service = new MyService();
+                      int r = Whitebox.invokeMethod(service, "compute");
+                  }
+              }
+              """,
+            """
+              import java.lang.reflect.Method;
+
+              class MyServiceTest {
+                  void test() throws Exception {
+                      MyService service = new MyService();
+                      Method computeMethod = service.getClass().getDeclaredMethod("compute");
+                      computeMethod.setAccessible(true);
+                      int r = (Integer) computeMethod.invoke(service);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What
`PowerMockWhiteboxGetInternalStateToJavaReflection` and `PowerMockWhiteboxInvokeMethodToJavaReflection` produced non-compiling output when the migrated result was assigned to a primitive-typed local:

```java
int count = (int) countField.get(service);   // does not compile
```

`Field.get`/`Method.invoke` return `Object`, and Java forbids a direct `(int) Object` cast.

## Fix
Cast to the wrapper; the assignment auto-unboxes:

```java
int count = (Integer) countField.get(service);
```

A small `boxedCastType` helper on the shared `WhiteboxToReflectionVisitor` maps primitive keywords to their wrappers; reference-typed casts are unchanged.

## Tests
Added a `primitiveResultUsesBoxedCast` case to each recipe's test. Existing reference-typed cases are unaffected.