### PR TITLE
TestNgToAssertj: emit a static import for assertThat

### DIFF
--- a/src/main/resources/META-INF/rewrite/testng.yml
+++ b/src/main/resources/META-INF/rewrite/testng.yml
@@ -48,3 +48,8 @@ recipeList:
   - org.openrewrite.java.testing.testng.TestNgAssertNotSameToAssertThat
   - org.openrewrite.java.testing.testng.TestNgAssertThrowsToAssertThat
   - org.openrewrite.java.testing.testng.TestNgAssertListToAssertThat
+  # Normalize the AssertJ entry points we introduce to a static import, regardless of how the original TestNG
+  # assertion was qualified, so qualified `Assert.assertX(...)` calls don't become qualified
+  # `Assertions.assertThat(...)`; see https://github.com/openrewrite/rewrite-testing-frameworks/issues/1029
+  - org.openrewrite.java.UseStaticImport:
+      methodPattern: "org.assertj.core.api.Assertions *(..)"

--- a/src/test/java/org/openrewrite/java/testing/testng/TestNgToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/testng/TestNgToAssertJTest.java
@@ -141,6 +141,43 @@ class TestNgToAssertJTest implements RewriteTest {
         );
     }
 
+    /**
+     * Qualified `Assert.assertX(...)` calls should become static-imported `assertThat(...)`, rather than
+     * mirroring the source qualification as `Assertions.assertThat(...)`; see
+     * <a href="https://github.com/openrewrite/rewrite-testing-frameworks/issues/1029">issue 1029</a>.
+     */
+    @Test
+    void qualifiedAssertBecomesStaticImport() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.testing.testng.TestNgToAssertj"),
+          //language=java
+          java(
+            """
+              import org.testng.Assert;
+
+              class Test {
+                  void test(Object value, Object actual, Object expected, boolean flag) {
+                      Assert.assertNotNull(value);
+                      Assert.assertEquals(actual, expected);
+                      Assert.assertTrue(flag, "should be true");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void test(Object value, Object actual, Object expected, boolean flag) {
+                      assertThat(value).isNotNull();
+                      assertThat(actual).isEqualTo(expected);
+                      assertThat(flag).withFailMessage("should be true").isTrue();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void assertEqualsAndNotEquals() {
         rewriteRun(


### PR DESCRIPTION
- Resolves #1029

`TestNgToAssertj` previously mirrored the source's qualification style: qualified `Assert.assertX(...)` calls became qualified `Assertions.assertThat(...)`, while statically-imported calls stayed static-imported. A class that mixed both styles ended up with a mixed import form (`import static ...assertThat` **and** `import ...Assertions`).

This composes `org.openrewrite.java.UseStaticImport` for `org.assertj.core.api.Assertions *(..)` as a cleanup step, normalizing every AssertJ entry point the recipe introduces (`assertThat`, `assertThatThrownBy`, `assertThatExceptionOfType`, `fail`, …) to a static import — AssertJ's documented convention — regardless of the original TestNG qualification.

The broad `Assertj` recipe already ran `StaticImports` after `TestNgToAssertj`, so this only changes behavior when `TestNgToAssertj` runs standalone, which is what the issue reports.

Added a test exercising the standalone recipe on qualified `Assert.` calls.