### PR TITLE
Converge AssertJ isSameAs/isNotSameAs(0|1) within a single run

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJByteRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJByteRules.java
@@ -73,7 +73,7 @@ public class AssertJByteRules {
   static final class AbstractByteAssertIsZero {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
-      return byteAssert.isEqualTo((byte) 0);
+      return Refaster.anyOf(byteAssert.isEqualTo((byte) 0), byteAssert.isSameAs((byte) 0));
     }
 
     @AfterTemplate
@@ -89,7 +89,7 @@ public class AssertJByteRules {
   static final class AbstractByteAssertIsNotZero {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
-      return byteAssert.isNotEqualTo((byte) 0);
+      return Refaster.anyOf(byteAssert.isNotEqualTo((byte) 0), byteAssert.isNotSameAs((byte) 0));
     }
 
     @AfterTemplate
@@ -105,7 +105,7 @@ public class AssertJByteRules {
   static final class AbstractByteAssertIsOne {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
-      return byteAssert.isEqualTo((byte) 1);
+      return Refaster.anyOf(byteAssert.isEqualTo((byte) 1), byteAssert.isSameAs((byte) 1));
     }
 
     @AfterTemplate

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJDoubleRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJDoubleRules.java
@@ -110,7 +110,10 @@ public class AssertJDoubleRules {
       return Refaster.anyOf(
           doubleAssert.isEqualTo(0),
           doubleAssert.isEqualTo(0.0),
-          doubleAssert.isEqualTo(0d)
+          doubleAssert.isEqualTo(0d),
+          doubleAssert.isSameAs(0),
+          doubleAssert.isSameAs(0.0),
+          doubleAssert.isSameAs(0d)
       );
     }
 
@@ -130,7 +133,10 @@ public class AssertJDoubleRules {
       return Refaster.anyOf(
           doubleAssert.isNotEqualTo(0),
           doubleAssert.isNotEqualTo(0.0),
-          doubleAssert.isNotEqualTo(0d)
+          doubleAssert.isNotEqualTo(0d),
+          doubleAssert.isNotSameAs(0),
+          doubleAssert.isNotSameAs(0.0),
+          doubleAssert.isNotSameAs(0d)
       );
     }
 
@@ -150,7 +156,10 @@ public class AssertJDoubleRules {
       return Refaster.anyOf(
           doubleAssert.isEqualTo(1),
           doubleAssert.isEqualTo(1.0),
-          doubleAssert.isEqualTo(1d)
+          doubleAssert.isEqualTo(1d),
+          doubleAssert.isSameAs(1),
+          doubleAssert.isSameAs(1.0),
+          doubleAssert.isSameAs(1d)
       );
     }
 

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJFloatRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJFloatRules.java
@@ -107,7 +107,9 @@ public class AssertJFloatRules {
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return Refaster.anyOf(
           floatAssert.isEqualTo(0),
-          floatAssert.isEqualTo(0f)
+          floatAssert.isEqualTo(0f),
+          floatAssert.isSameAs(0),
+          floatAssert.isSameAs(0f)
       );
     }
 
@@ -126,7 +128,9 @@ public class AssertJFloatRules {
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return Refaster.anyOf(
           floatAssert.isNotEqualTo(0),
-          floatAssert.isNotEqualTo(0f)
+          floatAssert.isNotEqualTo(0f),
+          floatAssert.isNotSameAs(0),
+          floatAssert.isNotSameAs(0f)
       );
     }
 
@@ -145,7 +149,9 @@ public class AssertJFloatRules {
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return Refaster.anyOf(
           floatAssert.isEqualTo(1),
-          floatAssert.isEqualTo(1f)
+          floatAssert.isEqualTo(1f),
+          floatAssert.isSameAs(1),
+          floatAssert.isSameAs(1f)
       );
     }
 

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJIntegerRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJIntegerRules.java
@@ -72,7 +72,7 @@ public class AssertJIntegerRules {
   static final class AbstractIntegerAssertIsZero {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isEqualTo(0);
+      return Refaster.anyOf(intAssert.isEqualTo(0), intAssert.isSameAs(0));
     }
 
     @AfterTemplate
@@ -88,7 +88,7 @@ public class AssertJIntegerRules {
   static final class AbstractIntegerAssertIsNotZero {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isNotEqualTo(0);
+      return Refaster.anyOf(intAssert.isNotEqualTo(0), intAssert.isNotSameAs(0));
     }
 
     @AfterTemplate
@@ -104,7 +104,7 @@ public class AssertJIntegerRules {
   static final class AbstractIntegerAssertIsOne {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isEqualTo(1);
+      return Refaster.anyOf(intAssert.isEqualTo(1), intAssert.isSameAs(1));
     }
 
     @AfterTemplate

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJLongRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJLongRules.java
@@ -72,7 +72,7 @@ public class AssertJLongRules {
   static final class AbstractLongAssertIsZero {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
-      return longAssert.isEqualTo(0);
+      return Refaster.anyOf(longAssert.isEqualTo(0), longAssert.isSameAs(0));
     }
 
     @AfterTemplate
@@ -88,7 +88,7 @@ public class AssertJLongRules {
   static final class AbstractLongAssertIsNotZero {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
-      return longAssert.isNotEqualTo(0);
+      return Refaster.anyOf(longAssert.isNotEqualTo(0), longAssert.isNotSameAs(0));
     }
 
     @AfterTemplate
@@ -104,7 +104,7 @@ public class AssertJLongRules {
   static final class AbstractLongAssertIsOne {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
-      return longAssert.isEqualTo(1);
+      return Refaster.anyOf(longAssert.isEqualTo(1), longAssert.isSameAs(1));
     }
 
     @AfterTemplate

--- a/src/main/java/org/openrewrite/java/testing/assertj/AssertJShortRules.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/AssertJShortRules.java
@@ -73,7 +73,7 @@ public class AssertJShortRules {
   static final class AbstractShortAssertIsZero {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
-      return shortAssert.isEqualTo((short) 0);
+      return Refaster.anyOf(shortAssert.isEqualTo((short) 0), shortAssert.isSameAs((short) 0));
     }
 
     @AfterTemplate
@@ -89,7 +89,7 @@ public class AssertJShortRules {
   static final class AbstractShortAssertIsNotZero {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
-      return shortAssert.isNotEqualTo((short) 0);
+      return Refaster.anyOf(shortAssert.isNotEqualTo((short) 0), shortAssert.isNotSameAs((short) 0));
     }
 
     @AfterTemplate
@@ -105,7 +105,7 @@ public class AssertJShortRules {
   static final class AbstractShortAssertIsOne {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
-      return shortAssert.isEqualTo((short) 1);
+      return Refaster.anyOf(shortAssert.isEqualTo((short) 1), shortAssert.isSameAs((short) 1));
     }
 
     @AfterTemplate

--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -76,9 +76,14 @@ recipeList:
   - tech.picnic.errorprone.refasterrules.AssertJObjectRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJOptionalRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJPathRulesRecipes
+  # Our type-specific rules must run before AssertJPrimitiveRulesRecipes, which normalizes
+  # `isSameAs`/`isNotSameAs` to `isEqualTo`/`isNotEqualTo`. Running our rules first lets, for instance,
+  # `isNotSameAs(0)` collapse straight to `isNotZero()` within a single cycle, rather than only reaching
+  # `isNotEqualTo(0)` and needing another run to converge.
+  # See https://github.com/openrewrite/rewrite-testing-frameworks/issues/1032
+  - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJPrimitiveRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJRulesRecipes
-  - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJStringRulesRecipes
   - tech.picnic.errorprone.refasterrules.AssertJThrowingCallableRulesRecipes
 

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
@@ -101,6 +101,48 @@ class AssertJBestPracticesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1032")
+    @Test
+    void isSameAsZeroConvergesToIsZeroInSingleRun() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class MyTest {
+                  void testMethod(int a, int b, int c, long d, double e, float f, byte g, short h) {
+                      assertThat(a).isNotSameAs(0);
+                      assertThat(b).isSameAs(0);
+                      assertThat(c).isSameAs(1);
+                      assertThat(d).isNotSameAs(0L);
+                      assertThat(e).isSameAs(0.0);
+                      assertThat(f).isSameAs(0f);
+                      assertThat(g).isSameAs((byte) 0);
+                      assertThat(h).isSameAs((short) 0);
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class MyTest {
+                  void testMethod(int a, int b, int c, long d, double e, float f, byte g, short h) {
+                      assertThat(a).isNotZero();
+                      assertThat(b).isZero();
+                      assertThat(c).isOne();
+                      assertThat(d).isNotZero();
+                      assertThat(e).isZero();
+                      assertThat(f).isZero();
+                      assertThat(g).isZero();
+                      assertThat(h).isZero();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Nested
     class CollapseAfterConversion {
         @Test

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJByteRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJByteRulesTest.java
@@ -41,6 +41,7 @@ class AssertJByteRulesTest implements RewriteTest {
                       class A {
                           public void test(byte b) {
                               Assertions.assertThat(b).isEqualTo((byte)0);
+                              Assertions.assertThat(b).isSameAs((byte)0);
                           }
                       }
                       """,
@@ -49,6 +50,7 @@ class AssertJByteRulesTest implements RewriteTest {
 
                       class A {
                           public void test(byte b) {
+                              Assertions.assertThat(b).isZero();
                               Assertions.assertThat(b).isZero();
                           }
                       }
@@ -68,6 +70,7 @@ class AssertJByteRulesTest implements RewriteTest {
                       class A {
                           public void test(byte b) {
                               Assertions.assertThat(b).isNotEqualTo((byte)0);
+                              Assertions.assertThat(b).isNotSameAs((byte)0);
                           }
                       }
                       """,
@@ -76,6 +79,7 @@ class AssertJByteRulesTest implements RewriteTest {
 
                       class A {
                           public void test(byte b) {
+                              Assertions.assertThat(b).isNotZero();
                               Assertions.assertThat(b).isNotZero();
                           }
                       }
@@ -159,6 +163,7 @@ class AssertJByteRulesTest implements RewriteTest {
               class A {
                   public void test(byte b) {
                       Assertions.assertThat(b).isEqualTo((byte)1);
+                      Assertions.assertThat(b).isSameAs((byte)1);
                   }
               }
               """,
@@ -167,6 +172,7 @@ class AssertJByteRulesTest implements RewriteTest {
 
               class A {
                   public void test(byte b) {
+                      Assertions.assertThat(b).isOne();
                       Assertions.assertThat(b).isOne();
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJDoubleRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJDoubleRulesTest.java
@@ -43,6 +43,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
                               Assertions.assertThat(d).isEqualTo(0);
                               Assertions.assertThat(d).isEqualTo(0.0);
                               Assertions.assertThat(d).isEqualTo(0d);
+                              Assertions.assertThat(d).isSameAs(0);
+                              Assertions.assertThat(d).isSameAs(0.0);
+                              Assertions.assertThat(d).isSameAs(0d);
                           }
                       }
                       """,
@@ -51,6 +54,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isZero();
+                              Assertions.assertThat(d).isZero();
+                              Assertions.assertThat(d).isZero();
                               Assertions.assertThat(d).isZero();
                               Assertions.assertThat(d).isZero();
                               Assertions.assertThat(d).isZero();
@@ -74,6 +80,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
                               Assertions.assertThat(d).isNotEqualTo(0);
                               Assertions.assertThat(d).isNotEqualTo(0.0);
                               Assertions.assertThat(d).isNotEqualTo(0d);
+                              Assertions.assertThat(d).isNotSameAs(0);
+                              Assertions.assertThat(d).isNotSameAs(0.0);
+                              Assertions.assertThat(d).isNotSameAs(0d);
                           }
                       }
                       """,
@@ -82,6 +91,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
                       class A {
                           public void test(double d) {
+                              Assertions.assertThat(d).isNotZero();
+                              Assertions.assertThat(d).isNotZero();
+                              Assertions.assertThat(d).isNotZero();
                               Assertions.assertThat(d).isNotZero();
                               Assertions.assertThat(d).isNotZero();
                               Assertions.assertThat(d).isNotZero();
@@ -216,6 +228,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
                       Assertions.assertThat(d).isEqualTo(1);
                       Assertions.assertThat(d).isEqualTo(1.0);
                       Assertions.assertThat(d).isEqualTo(1d);
+                      Assertions.assertThat(d).isSameAs(1);
+                      Assertions.assertThat(d).isSameAs(1.0);
+                      Assertions.assertThat(d).isSameAs(1d);
                   }
               }
               """,
@@ -224,6 +239,9 @@ class AssertJDoubleRulesTest implements RewriteTest {
 
               class A {
                   public void test(double d) {
+                      Assertions.assertThat(d).isOne();
+                      Assertions.assertThat(d).isOne();
+                      Assertions.assertThat(d).isOne();
                       Assertions.assertThat(d).isOne();
                       Assertions.assertThat(d).isOne();
                       Assertions.assertThat(d).isOne();

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJFloatRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJFloatRulesTest.java
@@ -45,6 +45,8 @@ class AssertJFloatRulesTest implements RewriteTest {
                               Assertions.assertThat(f).isEqualTo(0.0f);
                               Assertions.assertThat(f).isEqualTo(0F);
                               Assertions.assertThat(f).isEqualTo(0.0F);
+                              Assertions.assertThat(f).isSameAs(0);
+                              Assertions.assertThat(f).isSameAs(0f);
                           }
                       }
                       """,
@@ -53,6 +55,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isZero();
+                              Assertions.assertThat(f).isZero();
                               Assertions.assertThat(f).isZero();
                               Assertions.assertThat(f).isZero();
                               Assertions.assertThat(f).isZero();
@@ -78,6 +82,8 @@ class AssertJFloatRulesTest implements RewriteTest {
                               Assertions.assertThat(f).isNotEqualTo(0);
                               Assertions.assertThat(f).isNotEqualTo(0f);
                               Assertions.assertThat(f).isNotEqualTo(0.0f);
+                              Assertions.assertThat(f).isNotSameAs(0);
+                              Assertions.assertThat(f).isNotSameAs(0f);
                           }
                       }
                       """,
@@ -86,6 +92,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
                       class A {
                           public void test(float f) {
+                              Assertions.assertThat(f).isNotZero();
+                              Assertions.assertThat(f).isNotZero();
                               Assertions.assertThat(f).isNotZero();
                               Assertions.assertThat(f).isNotZero();
                               Assertions.assertThat(f).isNotZero();
@@ -212,6 +220,8 @@ class AssertJFloatRulesTest implements RewriteTest {
                       Assertions.assertThat(f).isEqualTo(1);
                       Assertions.assertThat(f).isEqualTo(1f);
                       Assertions.assertThat(f).isEqualTo(1.0f);
+                      Assertions.assertThat(f).isSameAs(1);
+                      Assertions.assertThat(f).isSameAs(1f);
                   }
               }
               """,
@@ -220,6 +230,8 @@ class AssertJFloatRulesTest implements RewriteTest {
 
               class A {
                   public void test(float f) {
+                      Assertions.assertThat(f).isOne();
+                      Assertions.assertThat(f).isOne();
                       Assertions.assertThat(f).isOne();
                       Assertions.assertThat(f).isOne();
                       Assertions.assertThat(f).isOne();

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJIntegerRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJIntegerRulesTest.java
@@ -41,6 +41,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
                       class A {
                           public void test(int i) {
                               Assertions.assertThat(i).isEqualTo(0);
+                              Assertions.assertThat(i).isSameAs(0);
                           }
                       }
                       """,
@@ -49,6 +50,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
 
                       class A {
                           public void test(int i) {
+                              Assertions.assertThat(i).isZero();
                               Assertions.assertThat(i).isZero();
                           }
                       }
@@ -68,6 +70,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
                       class A {
                           public void test(int i) {
                               Assertions.assertThat(i).isNotEqualTo(0);
+                              Assertions.assertThat(i).isNotSameAs(0);
                           }
                       }
                       """,
@@ -76,6 +79,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
 
                       class A {
                           public void test(int i) {
+                              Assertions.assertThat(i).isNotZero();
                               Assertions.assertThat(i).isNotZero();
                           }
                       }
@@ -159,6 +163,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
               class A {
                   public void test(int i) {
                       Assertions.assertThat(i).isEqualTo(1);
+                      Assertions.assertThat(i).isSameAs(1);
                   }
               }
               """,
@@ -167,6 +172,7 @@ class AssertJIntegerRulesTest implements RewriteTest {
 
               class A {
                   public void test(int i) {
+                      Assertions.assertThat(i).isOne();
                       Assertions.assertThat(i).isOne();
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJLongRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJLongRulesTest.java
@@ -41,6 +41,7 @@ class AssertJLongRulesTest implements RewriteTest {
                       class A {
                           public void test(long l) {
                               Assertions.assertThat(l).isEqualTo(0L);
+                              Assertions.assertThat(l).isSameAs(0L);
                           }
                       }
                       """,
@@ -49,6 +50,7 @@ class AssertJLongRulesTest implements RewriteTest {
 
                       class A {
                           public void test(long l) {
+                              Assertions.assertThat(l).isZero();
                               Assertions.assertThat(l).isZero();
                           }
                       }
@@ -68,6 +70,7 @@ class AssertJLongRulesTest implements RewriteTest {
                       class A {
                           public void test(long l) {
                               Assertions.assertThat(l).isNotEqualTo(0L);
+                              Assertions.assertThat(l).isNotSameAs(0L);
                           }
                       }
                       """,
@@ -76,6 +79,7 @@ class AssertJLongRulesTest implements RewriteTest {
 
                       class A {
                           public void test(long l) {
+                              Assertions.assertThat(l).isNotZero();
                               Assertions.assertThat(l).isNotZero();
                           }
                       }
@@ -159,6 +163,7 @@ class AssertJLongRulesTest implements RewriteTest {
               class A {
                   public void test(long l) {
                       Assertions.assertThat(l).isEqualTo(1L);
+                      Assertions.assertThat(l).isSameAs(1L);
                   }
               }
               """,
@@ -167,6 +172,7 @@ class AssertJLongRulesTest implements RewriteTest {
 
               class A {
                   public void test(long l) {
+                      Assertions.assertThat(l).isOne();
                       Assertions.assertThat(l).isOne();
                   }
               }

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJShortRulesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJShortRulesTest.java
@@ -41,6 +41,7 @@ class AssertJShortRulesTest implements RewriteTest {
                       class A {
                           public void test(short s) {
                               Assertions.assertThat(s).isEqualTo((short)0);
+                              Assertions.assertThat(s).isSameAs((short)0);
                           }
                       }
                       """,
@@ -49,6 +50,7 @@ class AssertJShortRulesTest implements RewriteTest {
 
                       class A {
                           public void test(short s) {
+                              Assertions.assertThat(s).isZero();
                               Assertions.assertThat(s).isZero();
                           }
                       }
@@ -68,6 +70,7 @@ class AssertJShortRulesTest implements RewriteTest {
                       class A {
                           public void test(short s) {
                               Assertions.assertThat(s).isNotEqualTo((short)0);
+                              Assertions.assertThat(s).isNotSameAs((short)0);
                           }
                       }
                       """,
@@ -76,6 +79,7 @@ class AssertJShortRulesTest implements RewriteTest {
 
                       class A {
                           public void test(short s) {
+                              Assertions.assertThat(s).isNotZero();
                               Assertions.assertThat(s).isNotZero();
                           }
                       }
@@ -159,6 +163,7 @@ class AssertJShortRulesTest implements RewriteTest {
               class A {
                   public void test(short s) {
                       Assertions.assertThat(s).isEqualTo((short)1);
+                      Assertions.assertThat(s).isSameAs((short)1);
                   }
               }
               """,
@@ -167,6 +172,7 @@ class AssertJShortRulesTest implements RewriteTest {
 
               class A {
                   public void test(short s) {
+                      Assertions.assertThat(s).isOne();
                       Assertions.assertThat(s).isOne();
                   }
               }


### PR DESCRIPTION
## What's changed?

- Resolves the non-convergence reported in #1032: a single `rewriteRun` of the `Assertj` aggregate left `assertThat(intValue).isNotSameAs(0)` as `isNotEqualTo(0)`, and only a *second* run collapsed it to `isNotZero()`.

### Root cause

Within the aggregate, Picnic's `AssertJPrimitiveRulesRecipes` normalizes `isSameAs`/`isNotSameAs` on primitives to `isEqualTo`/`isNotEqualTo`. Our type-specific rules then collapse `isEqualTo(0)` → `isZero()`, etc. But the node produced by the primitive rule isn't given a typed (`AbstractIntegerAssert`) receiver by between-cycle re-attribution, so our Refaster rules don't match it until the source is fully re-parsed on a later run.

### Fix

- Our overriding number rules (`Integer`, `Long`, `Short`, `Byte`, `Double`, `Float`) now also match the `isSameAs`/`isNotSameAs` forms directly, collapsing straight to `isZero()`/`isNotZero()`/`isOne()` on the freshly-parsed, fully-typed source.
- Reordered `AssertJShortRulesRecipes` ahead of `AssertJPrimitiveRulesRecipes` so *all* our number rules run before the primitive normalization (the other six already did), letting them win within a single cycle.

`BigInteger` is unaffected — Picnic's primitive rules don't touch it, so there is no intermediate `isSameAs` → `isEqualTo` step to converge.

### Testing

- Added a single-run convergence test across all affected primitive types to `AssertJBestPracticesTest`.
- Extended the per-type rule tests (`Integer`/`Long`/`Short`/`Byte`/`Double`/`Float`) with the `isSameAs`/`isNotSameAs` forms.
- Full test suite passes.

- Fixes #1032