### PR TITLE
Simplify AssertJ hasSize(0) to isEmpty() for Iterable

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -512,7 +512,7 @@ recipeList:
       assertToReplace: hasSize
       literalArgument: 0
       dedicatedAssertion: isEmpty
-      requiredType: java.util.Collection
+      requiredType: java.lang.Iterable
   - org.openrewrite.java.testing.assertj.SimplifyAssertJAssertion:
       assertToReplace: hasSize
       literalArgument: 0

--- a/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/AssertJBestPracticesTest.java
@@ -467,6 +467,11 @@ class AssertJBestPracticesTest implements RewriteTest {
 //              arguments("long[]", "assertThat(x.length).isGreaterThan(4)", "assertThat(x).hasSizeGreaterThan(4)"),
 //              arguments("char[]", "assertThat(x.length).isGreaterThanOrEqualTo(1)", "assertThat(x).hasSizeGreaterThanOrEqualTo(1)"),
               // Related to Collection
+              arguments("java.lang.Iterable", "assertThat(x).hasSize(0)", "assertThat(x).isEmpty()"),
+              arguments(
+                "java.util.Collection<String>",
+                "assertThat(x).hasSize(0)",
+                "assertThat(x).isEmpty()"),
               arguments(
                 "java.util.Collection<String>",
                 "assertThat(x.isEmpty()).isTrue()",


### PR DESCRIPTION
## What's changed

`assertThat(x).hasSize(0)` is already simplified to `assertThat(x).isEmpty()` for `String`, `File`, `Collection`, and `Map`. But `SimplifyAssertJAssertion` gates on `TypeUtils.isAssignableTo(requiredType, actualType)`, so an actual typed as the broader `java.lang.Iterable` was *not* matched by the `java.util.Collection` entry (Iterable is a supertype of Collection, not assignable to it).

This widens the required type to `java.lang.Iterable`, which subsumes the `Collection` case since every `Collection` is assignable to `Iterable`.

Confirmed by adding the issue's own reproduction case to `AssertJBestPracticesTest.SonarDedicatedAssertions#replacements`, which failed before and passes after.

- Fixes #811