### PR TITLE
Recognize meta-annotated test methods in TestsShouldNotBePublic

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublic.java
@@ -25,6 +25,7 @@ import org.openrewrite.Option;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.ChangeMethodAccessLevelVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
@@ -34,11 +35,13 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
 
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
@@ -166,18 +169,25 @@ public class TestsShouldNotBePublic extends ScanningRecipe<TestsShouldNotBePubli
             return m;
         }
 
+        private static final List<AnnotationMatcher> JUNIT5_METHOD_ANNOTATIONS = Arrays.asList(
+                "org.junit.jupiter.api.Test",
+                "org.junit.jupiter.api.RepeatedTest",
+                "org.junit.jupiter.params.ParameterizedTest",
+                "org.junit.jupiter.api.TestFactory",
+                "org.junit.jupiter.api.TestTemplate",
+                "org.junit.jupiter.api.AfterEach",
+                "org.junit.jupiter.api.BeforeEach",
+                "org.junit.jupiter.api.AfterAll",
+                "org.junit.jupiter.api.BeforeAll").stream()
+                .map(fqn -> new AnnotationMatcher("@" + fqn, true))
+                .collect(toList());
+
         private boolean hasJUnit5MethodAnnotation(J.MethodDeclaration method) {
             for (J.Annotation a : method.getLeadingAnnotations()) {
-                if (TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.Test") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.RepeatedTest") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.params.ParameterizedTest") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.TestFactory") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.TestTemplate") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.AfterEach") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.BeforeEach") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.AfterAll") ||
-                        TypeUtils.isOfClassType(a.getType(), "org.junit.jupiter.api.BeforeAll")) {
-                    return true;
+                for (AnnotationMatcher matcher : JUNIT5_METHOD_ANNOTATIONS) {
+                    if (matcher.matches(a)) {
+                        return true;
+                    }
                 }
             }
             return false;

--- a/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/TestsShouldNotBePublicTest.java
@@ -495,6 +495,44 @@ class TestsShouldNotBePublicTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/308")
+    @Test
+    void removePublicClassModifierForMetaAnnotatedTestMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.lang.annotation.Retention;
+              import java.lang.annotation.RetentionPolicy;
+              import org.junit.jupiter.api.Test;
+
+              @Retention(RetentionPolicy.RUNTIME)
+              @Test
+              public @interface CustomTest {
+              }
+              """
+          ),
+          java(
+            """
+              public class ATest {
+
+                  @CustomTest
+                  void testMethod() {
+                  }
+              }
+              """,
+            """
+              class ATest {
+
+                  @CustomTest
+                  void testMethod() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/309")
     @Test
     void baseclassForTestsNeedsToStayPublic() {


### PR DESCRIPTION
- Resolves #308.

`TestsShouldNotBePublic` previously only matched methods with a direct JUnit 5 annotation (`@Test`, `@BeforeEach`, etc.). Methods annotated with a *custom* annotation that is itself meta-annotated with one of these (e.g. itf's [`@MavenTest`](https://github.com/khmarbaise/maven-it-extension/blob/itf-extension-0.12.0/itf-jupiter-extension/src/main/java/com/soebes/itf/jupiter/extension/MavenTest.java#L44), which is annotated with `@TestTemplate`/`@Test`) were not recognized, so the enclosing class kept its redundant `public` modifier.

## Change
- `hasJUnit5MethodAnnotation` now recurses through meta-annotations via `JavaType.FullyQualified#getAnnotations()`, with a `seen` set to guard against annotation cycles.
- Added a test covering a method annotated with a custom `@Test`-meta-annotated annotation.