### PR TITLE
Verify junit5.StaticImports respects existing shadowing methods

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/StaticImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/StaticImportsTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.junit5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -35,6 +36,27 @@ class StaticImportsTest implements RewriteTest {
             .scanRuntimeClasspath("org.openrewrite.java.testing")
             .build()
             .activateRecipes("org.openrewrite.java.testing.junit5.StaticImports"));
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/459")
+    @Test
+    void doNotStaticImportWhenShadowedByLocalMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              import org.junit.jupiter.api.Assertions;
+
+              public class Test {
+                  public static void assertEquals(List<String> expected, List<String> actual) {
+                      // explicit Assertions reference is required to disambiguate from the method declared above
+                      Assertions.assertEquals(expected.toString(), actual.toString());
+                  }
+              }
+              """
+          )
+        );
     }
 
     @DocumentExample


### PR DESCRIPTION
- Closes #459

When a class declares a method whose name collides with a JUnit Jupiter assertion (e.g. a helper `assertEquals(List, List)`), a fully-qualified `Assertions.assertEquals(..)` call inside that class must keep the explicit `Assertions.` qualifier. Converting it to a static import would let the local method shadow the imported one, producing a compile error like:

```
java: incompatible types: java.lang.String cannot be converted to java.util.List<...>
```

The underlying `org.openrewrite.java.UseStaticImport` recipe (which `junit5.StaticImports` delegates to) already guards against this case. This PR adds a regression test that pins the behavior so it doesn't regress.

I confirmed the test is meaningful: renaming the local method so it no longer shadows the assertion makes the recipe convert the call as expected.