### PR TITLE
Add CategoryToTag regression test for nested category classes

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/CategoryToTagTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CategoryToTagTest.java
@@ -248,6 +248,36 @@ class CategoryToTagTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/447")
+    @Test
+    void nestedCategoryClass() {
+        rewriteRun(
+          java(
+            """
+              public class Appenders {
+                  public interface Cassandra {}
+              }
+              """
+          ),
+          java(
+            """
+              import org.junit.experimental.categories.Category;
+
+              @Category(Appenders.Cassandra.class)
+              public class B {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Tag;
+
+              @Tag("Cassandra")
+              public class B {
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/305")
     @Test
     void fullyQualifiedClass() {


### PR DESCRIPTION
Adds a regression test for `CategoryToTag` covering a `@Category` referencing a nested class, e.g. `@Category(Appenders.Cassandra.class)`.

- This is the exact scenario reported in #447, where the recipe threw `ClassCastException: J$FieldAccess cannot be cast to J$Identifier`. The root cause was assuming `category.getTarget()` was always a simple `J.Identifier`, which is not the case for `Outer.Inner.class` references.

- The underlying bug was already fixed in a6925633 (`CategoryToTag: Support qualified class names`, which added the `convertToTagName` helper to handle `J.FieldAccess` targets). However, the existing tests only cover package-qualified names (`foo.FastTests.class`); none covered the nested-class scenario from #447. This test locks in that behavior so the issue can be closed.

- Fixes #447