### PR TITLE
Convert `assertThrows` with an `Executable` variable

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
@@ -22,7 +22,6 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
@@ -167,10 +166,9 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
                 if (cu == null) {
                     return false;
                 }
-                AtomicBoolean safe = new AtomicBoolean(true);
-                new JavaIsoVisitor<Integer>() {
+                return new JavaIsoVisitor<AtomicBoolean>() {
                     @Override
-                    public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                    public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean safe) {
                         if (safe.get() && Objects.equals(identifier.getFieldType(), variable)) {
                             Object parent = getCursor().getParentTreeCursor().getValue();
                             boolean ok = false;
@@ -188,10 +186,9 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
                                 safe.set(false);
                             }
                         }
-                        return super.visitIdentifier(identifier, integer);
+                        return super.visitIdentifier(identifier, safe);
                     }
-                }.visit(cu, 0);
-                return safe.get();
+                }.reduce(cu, new AtomicBoolean(true)).get();
             }
         });
     }
@@ -204,8 +201,9 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
     @RequiredArgsConstructor
     private static class RetypeExecutableVariable extends JavaIsoVisitor<ExecutionContext> {
 
+        private static final JavaType.ShallowClass THROWING_CALLABLE_TYPE = JavaType.ShallowClass.build(THROWING_CALLABLE);
+
         private final JavaType.Variable variable;
-        private final JavaType.ShallowClass throwingCallable = JavaType.ShallowClass.build(THROWING_CALLABLE);
 
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
@@ -221,7 +219,7 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
             TypeTree typeExpression = mv.getTypeExpression();
             J.Identifier newTypeExpression = new J.Identifier(Tree.randomId(),
                     typeExpression == null ? Space.EMPTY : typeExpression.getPrefix(),
-                    Markers.EMPTY, emptyList(), "ThrowingCallable", throwingCallable, null);
+                    Markers.EMPTY, emptyList(), "ThrowingCallable", THROWING_CALLABLE_TYPE, null);
             return mv.withTypeExpression(newTypeExpression);
         }
 
@@ -230,7 +228,7 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
             J.Identifier id = super.visitIdentifier(identifier, ctx);
             JavaType.Variable fieldType = id.getFieldType();
             if (Objects.equals(fieldType, variable)) {
-                return id.withType(throwingCallable).withFieldType(fieldType.withType(throwingCallable));
+                return id.withType(THROWING_CALLABLE_TYPE).withFieldType(fieldType.withType(THROWING_CALLABLE_TYPE));
             }
             return id;
         }

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionType.java
@@ -16,10 +16,13 @@
 package org.openrewrite.java.testing.assertj;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
@@ -27,14 +30,25 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeTree;
+import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.marker.Markers;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Collections.emptyList;
 
 public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
 
     private static final String JUNIT_ASSERTIONS = "org.junit.jupiter.api.Assertions";
     private static final String ASSERTJ_ASSERTIONS = "org.assertj.core.api.Assertions";
+    private static final String JUNIT_EXECUTABLE = "org.junit.jupiter.api.function.Executable";
+    private static final String THROWING_CALLABLE = "org.assertj.core.api.ThrowableAssert$ThrowingCallable";
     private static final MethodMatcher ASSERT_THROWS_MATCHER = new MethodMatcher(JUNIT_ASSERTIONS + " assertThrows(..)");
 
     @Getter
@@ -60,13 +74,33 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
                     return mi;
                 }
 
+                List<Expression> args = mi.getArguments();
+
+                // When the executable is a variable typed as JUnit's `Executable`, AssertJ's `isThrownBy`
+                // expects a `ThrowingCallable` instead, so the variable declaration has to be retyped to keep
+                // it compiling. That's only safe when every usage of the variable is an `assertThrows`
+                // executable argument; otherwise leave the call untouched as the types would conflict.
+                Expression executable = args.get(1);
+                JavaType.Variable executableVariable = null;
+                if (executable instanceof J.Identifier) {
+                    JavaType.Variable fieldType = ((J.Identifier) executable).getFieldType();
+                    if (fieldType != null && TypeUtils.isOfClassType(fieldType.getType(), JUNIT_EXECUTABLE)) {
+                        if (!allUsagesAreAssertThrowsExecutable(fieldType)) {
+                            return mi;
+                        }
+                        executableVariable = fieldType;
+                    }
+                }
+
                 boolean returnActual = hasReturnType.get();
 
                 maybeRemoveImport(JUNIT_ASSERTIONS);
                 maybeRemoveImport(JUNIT_ASSERTIONS + ".assertThrows");
                 maybeAddImport(ASSERTJ_ASSERTIONS, "assertThatExceptionOfType");
 
-                List<Expression> args = mi.getArguments();
+                if (executableVariable != null) {
+                    doAfterVisit(new RetypeExecutableVariable(executableVariable));
+                }
 
                 if (args.size() == 2) {
                     String code = "assertThatExceptionOfType(#{any(java.lang.Class)}).isThrownBy(#{any(org.assertj.core.api.ThrowableAssert.ThrowingCallable)})";
@@ -120,6 +154,85 @@ public class JUnitAssertThrowsToAssertExceptionType extends Recipe {
                 // Unknown parent type so not supported
                 return Optional.empty();
             }
+
+            /**
+             * Determine whether every reference to the given variable can safely be retyped from JUnit's
+             * {@code Executable} to AssertJ's {@code ThrowingCallable}. That is the case when each reference is
+             * either the variable's own declaration/assignment target or the executable argument of an
+             * {@code assertThrows} call (all of which are converted by this recipe). Any other usage would still
+             * require an {@code Executable} and conflict with the retyped variable.
+             */
+            private boolean allUsagesAreAssertThrowsExecutable(JavaType.Variable variable) {
+                J.CompilationUnit cu = getCursor().firstEnclosing(J.CompilationUnit.class);
+                if (cu == null) {
+                    return false;
+                }
+                AtomicBoolean safe = new AtomicBoolean(true);
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.Identifier visitIdentifier(J.Identifier identifier, Integer integer) {
+                        if (safe.get() && Objects.equals(identifier.getFieldType(), variable)) {
+                            Object parent = getCursor().getParentTreeCursor().getValue();
+                            boolean ok = false;
+                            if (parent instanceof J.VariableDeclarations.NamedVariable) {
+                                ok = ((J.VariableDeclarations.NamedVariable) parent).getName() == identifier;
+                            } else if (parent instanceof J.Assignment) {
+                                ok = ((J.Assignment) parent).getVariable() == identifier;
+                            } else if (parent instanceof J.MethodInvocation) {
+                                J.MethodInvocation enclosing = (J.MethodInvocation) parent;
+                                ok = ASSERT_THROWS_MATCHER.matches(enclosing) &&
+                                        enclosing.getArguments().size() >= 2 &&
+                                        enclosing.getArguments().get(1) == identifier;
+                            }
+                            if (!ok) {
+                                safe.set(false);
+                            }
+                        }
+                        return super.visitIdentifier(identifier, integer);
+                    }
+                }.visit(cu, 0);
+                return safe.get();
+            }
         });
+    }
+
+    /**
+     * Retypes the declaration of an {@code org.junit.jupiter.api.function.Executable} variable to
+     * {@code org.assertj.core.api.ThrowableAssert.ThrowingCallable}, so that a variable previously passed to
+     * {@code assertThrows} keeps compiling when passed to AssertJ's {@code isThrownBy}.
+     */
+    @RequiredArgsConstructor
+    private static class RetypeExecutableVariable extends JavaIsoVisitor<ExecutionContext> {
+
+        private final JavaType.Variable variable;
+        private final JavaType.ShallowClass throwingCallable = JavaType.ShallowClass.build(THROWING_CALLABLE);
+
+        @Override
+        public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+            J.VariableDeclarations mv = super.visitVariableDeclarations(multiVariable, ctx);
+            if (!TypeUtils.isOfClassType(mv.getTypeAsFullyQualified(), JUNIT_EXECUTABLE) ||
+                    mv.getVariables().stream().noneMatch(v -> Objects.equals(v.getVariableType(), variable))) {
+                return mv;
+            }
+
+            maybeRemoveImport(JUNIT_EXECUTABLE);
+            maybeAddImport(THROWING_CALLABLE);
+
+            TypeTree typeExpression = mv.getTypeExpression();
+            J.Identifier newTypeExpression = new J.Identifier(Tree.randomId(),
+                    typeExpression == null ? Space.EMPTY : typeExpression.getPrefix(),
+                    Markers.EMPTY, emptyList(), "ThrowingCallable", throwingCallable, null);
+            return mv.withTypeExpression(newTypeExpression);
+        }
+
+        @Override
+        public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+            J.Identifier id = super.visitIdentifier(identifier, ctx);
+            JavaType.Variable fieldType = id.getFieldType();
+            if (Objects.equals(fieldType, variable)) {
+                return id.withType(throwingCallable).withFieldType(fieldType.withType(throwingCallable));
+            }
+            return id;
+        }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertThrowsToAssertExceptionTypeTest.java
@@ -73,6 +73,151 @@ class JUnitAssertThrowsToAssertExceptionTypeTest implements RewriteTest {
     }
 
     @Test
+    void variableExecutable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.function.Executable;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      Executable executable = () -> foo();
+                      assertThrows(NullPointerException.class, executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+              import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      ThrowingCallable executable = () -> foo();
+                      assertThatExceptionOfType(NullPointerException.class).isThrownBy(executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableExecutableWithMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.function.Executable;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      Executable executable = () -> foo();
+                      assertThrows(NullPointerException.class, executable, "message");
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+              import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      ThrowingCallable executable = () -> foo();
+                      assertThatExceptionOfType(NullPointerException.class).as("message").isThrownBy(executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void fieldExecutable() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.function.Executable;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  private final Executable executable = () -> foo();
+
+                  public void throwsExceptionWithSpecificType() {
+                      assertThrows(NullPointerException.class, executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+              import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+              public class SimpleExpectedExceptionTest {
+                  private final ThrowingCallable executable = () -> foo();
+
+                  public void throwsExceptionWithSpecificType() {
+                      assertThatExceptionOfType(NullPointerException.class).isThrownBy(executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRetypeExecutableSharedWithOtherJUnitAssertion() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.function.Executable;
+
+              import static org.junit.jupiter.api.Assertions.assertAll;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class SimpleExpectedExceptionTest {
+                  public void throwsExceptionWithSpecificType() {
+                      Executable executable = () -> foo();
+                      assertThrows(NullPointerException.class, executable);
+                      assertAll(executable);
+                  }
+                  void foo() {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void memberReference() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
- Fixes #511

### Problem
`JUnitAssertThrowsToAssertExceptionType` was already rewriting `assertThrows(..., executable)` into `assertThatExceptionOfType(...).isThrownBy(executable)` even when `executable` is a variable, but the result did not compile: the variable stayed typed as JUnit's `org.junit.jupiter.api.function.Executable`, while AssertJ's `isThrownBy` requires `ThrowableAssert.ThrowingCallable`. These are distinct functional interfaces — a lambda/method reference coerces to either, a typed variable does not.

### Change
When the executable argument is a variable typed exactly as `Executable`, the recipe now also retypes its declaration (and references) to `ThrowingCallable`, adding/removing imports accordingly.

This is guarded: the conversion only proceeds when *every* usage of that variable is an `assertThrows` executable argument (or the variable's own declaration/assignment). If the same variable is also passed somewhere that requires an `Executable` (e.g. `assertAll`), the types can't both be satisfied, so the call is left untouched rather than emitting non-compiling code.

### Tests
- `variableExecutable` — local variable (the issue's core case)
- `variableExecutableWithMessage` — 3-arg form with `.as(...)`
- `fieldExecutable` — field declaration
- `doNotRetypeExecutableSharedWithOtherJUnitAssertion` — guard: variable shared with `assertAll` is left unchanged