### PR TITLE
Keep `mockStatic` import in `CleanupMockitoImports` when type info is incomplete

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CleanupMockitoImports.java
@@ -67,6 +67,8 @@ public class CleanupMockitoImports extends Recipe {
                 "ignoreStubs",
                 "inOrder",
                 "mock",
+                "mockConstruction",
+                "mockStatic",
                 "mockingDetails",
                 "never",
                 "only",

--- a/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CleanupMockitoImportsTest.java
@@ -173,6 +173,27 @@ class CleanupMockitoImportsTest implements RewriteTest {
     }
 
     @Test
+    void doNotRemoveMockStaticImportPossiblyAssociatedWithAnUntypedMockitoMethod() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.all().methodInvocations(false)),
+          java(
+            """
+              import static org.mockito.Mockito.mockStatic;
+
+              class MyObjectTest {
+                void test() {
+                  mockStatic(MyObject.class);
+                }
+              }
+              class MyObject {
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotRemoveStartImportsPossiblyAssociatedWithAnUntypedMockitoMethod() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed

`CleanupMockitoImports` keeps a curated list of Mockito method names (`MOCKITO_METHOD_NAMES`). When a call's type information isn't well-formed (e.g. an older Mockito on the classpath, or surrounding types that don't fully resolve), the recipe relies on this list to recognize the call and **avoid** removing the still-needed static import.

`mockStatic` (and its sibling `mockConstruction`) were missing from that list — only `mock` was present. As a result, `import static org.mockito.Mockito.mockStatic;` was wrongly removed whenever the `mockStatic(...)` call's type couldn't be resolved, even though it was still in use.

This PR adds `mockStatic` and `mockConstruction` to the list, and adds a reproducing test.

## Context

Reported via a Moderne result on `moderneinc/rewrite-ai-search` where `mockStatic` was being stripped from `SpellCheckCommentsInFrenchTest.java` despite being used.