### PR TITLE
Use range selector so JUnit5to6Migration gates on Java 17 or higher

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit6.yml
+++ b/src/main/resources/META-INF/rewrite/junit6.yml
@@ -43,7 +43,7 @@ preconditions:
       fullyQualifiedTypeName: org.testng..*
       includeImplicit: true
   - org.openrewrite.java.search.HasMinimumJavaVersion:
-      version: 17
+      version: "[17,)"
 recipeList:
   - org.openrewrite.java.testing.junit5.UpgradeToJUnit514
   - org.openrewrite.java.dependencies.RemoveDependency:


### PR DESCRIPTION
## Summary
- `HasMinimumJavaVersion` passes its `version` option to `Semver.validate(version, null)`. A bare `"17"` falls through to `ExactVersion`, so the precondition returns false on repos declaring a higher Java version (e.g. Java 21) and the whole `JUnit5to6Migration` recipe is silently skipped.
- Switching to `"[17,)"` (open-upper set range) makes the precondition trigger for Java 17 or higher, which matches what the recipe's name implies.

- See also the tests added in openrewrite/rewrite#8228 documenting how each version selector form behaves.

## Test plan
- [x] `./gradlew test --tests "*JUnit5to6MigrationTest*"`
