### PR TITLE
Simplify JUnit5to6Migration minimum Java version to '17'

### DIFF
--- a/src/main/resources/META-INF/rewrite/junit6.yml
+++ b/src/main/resources/META-INF/rewrite/junit6.yml
@@ -43,7 +43,7 @@ preconditions:
       fullyQualifiedTypeName: org.testng..*
       includeImplicit: true
   - org.openrewrite.java.search.HasMinimumJavaVersion:
-      version: "[17,)"
+      version: 17
 recipeList:
   - org.openrewrite.java.testing.junit5.UpgradeToJUnit514
   - org.openrewrite.java.dependencies.RemoveDependency:


### PR DESCRIPTION
## Summary
- Reverts the `HasMinimumJavaVersion` argument in `JUnit5to6Migration` from `"[17,)"` back to the plain `17` most contributors would reach for.
- Depends on openrewrite/rewrite#8229, which teaches `HasMinimumJavaVersion` to canonicalize a plain version (bare or dotted) to `[N,)`. Once that lands and is picked up here, both forms behave identically and the shorter one is easier to read.

- Should not be merged before openrewrite/rewrite#8229 is released and consumed.

## Test plan
- [x] `./gradlew test --tests "*JUnit5to6MigrationTest*"` (passes today because the range form still works; behavior parity relies on #8229)
