### PR TITLE
KotlinTestMethodsShouldReturnUnit: exclude @TestFactory methods

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnit.java
@@ -35,6 +35,11 @@ import static java.util.Collections.emptyList;
 public class KotlinTestMethodsShouldReturnUnit extends Recipe {
 
     private static final String TEST_ANNOTATION_PATTERN = "org..* *Test*";
+    // `TEST_ANNOTATION_PATTERN`'s `*Test*` segment matches any simple name containing "Test", which
+    // incidentally also matches `@TestFactory`. Unlike `@Test`/`@ParameterizedTest`/`@RepeatedTest`/
+    // `@TestTemplate`, `@TestFactory` methods are required by JUnit Jupiter to return a value (e.g.
+    // `Collection<DynamicTest>`), so they must be excluded here.
+    private static final String TEST_FACTORY_ANNOTATION_PATTERN = "org.junit.jupiter.api.TestFactory";
     // `UsesType` matches against fully qualified type names, so it needs a single-token glob rather
     // than the two-token (`<owner> <name>`) form `AnnotationMatcher` uses above.
     private static final String TEST_ANNOTATION_TYPE_PATTERN = "org.junit..*Test*";
@@ -61,8 +66,11 @@ public class KotlinTestMethodsShouldReturnUnit extends Recipe {
                     return m;
                 }
 
-                // Only consider test methods
-                if (!service(AnnotationService.class).matches(getCursor(), new AnnotationMatcher(TEST_ANNOTATION_PATTERN, true))) {
+                // Only consider test methods, excluding `@TestFactory` (see comment on
+                // TEST_FACTORY_ANNOTATION_PATTERN above).
+                AnnotationService annotationService = service(AnnotationService.class);
+                if (!annotationService.matches(getCursor(), new AnnotationMatcher(TEST_ANNOTATION_PATTERN, true)) ||
+                        annotationService.matches(getCursor(), new AnnotationMatcher(TEST_FACTORY_ANNOTATION_PATTERN, true))) {
                     return m;
                 }
 

--- a/src/test/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnitTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/KotlinTestMethodsShouldReturnUnitTest.java
@@ -309,6 +309,27 @@ class KotlinTestMethodsShouldReturnUnitTest implements RewriteTest {
     }
 
     @Test
+    void doNotChangeTestFactoryMethods() {
+        // `@TestFactory` methods are required by JUnit Jupiter to return a value such as
+        // `Collection<DynamicTest>`, unlike `@Test`/`@ParameterizedTest`/`@RepeatedTest`/`@TestTemplate`,
+        // so they must not be forced to `Unit`.
+        //language=kotlin
+        rewriteRun(
+          kotlin(
+            """
+              import org.junit.jupiter.api.DynamicTest
+              import org.junit.jupiter.api.TestFactory
+
+              class ATest {
+                  @TestFactory
+                  fun myTestFactory() = listOf(DynamicTest.dynamicTest("test") {})
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeAlreadyUnitTestMethods() {
         //language=kotlin
         rewriteRun(


### PR DESCRIPTION
## What's changed?                                                                                                                                     
`KotlinTestMethodsShouldReturnUnit`'s `TEST_ANNOTATION_PATTERN` (`"org..* *Test*"`) uses a substring wildcard (`*Test*`) that unintentionally also matches `@TestFactory`, even though the recipe's own description only targets `@Test`, `@ParameterizedTest`, `@RepeatedTest`, and `@TestTemplate`. This adds an explicit exclusion for `@TestFactory` plus a regression test.                                                                                  
                                                                                                                                                         
## What's your motivation?                                                                                                                             
Unlike those four annotations, `@TestFactory` methods are required by JUnit Jupiter to return a value (e.g. `Collection<DynamicTest>`), not `Unit`. Applying this recipe to a `@TestFactory` method currently rewrites its declared return type to `Unit` while the body still evaluates to something like `List<DynamicTest>`, producing a Kotlin type-mismatch compile error. We hit this adopting the recipe fleet-wide and found real `@TestFactory` usages it would have broken.                                                                                                                                     
                                                                                                                                                         
## Anything in particular you'd like reviewers to focus on?                                                                                            
Whether an explicit exclusion check is preferable to tightening `TEST_ANNOTATION_PATTERN` itself — the pattern DSL doesn't appear to support alternation, so a separate exclusion seemed simpler.                                                           

## Anyone you would like to review specifically?                                                                                                       
@timtebeek
@greg-dennis 