### PR TITLE
Fix Hamcrest not() unwrap infinite loop and support CoreMatchers

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
@@ -70,7 +70,7 @@ public class HamcrestInstanceOfToJUnit5 extends Recipe {
                     }
 
                     J.MethodInvocation matcherInvocation = (J.MethodInvocation) hamcrestMatcher;
-                    while ("not".equals(matcherInvocation.getSimpleName())) {
+                    while (RemoveNotMatcherVisitor.NOT_MATCHER.matches(matcherInvocation)) {
                         maybeRemoveImport("org.hamcrest.Matchers.not");
                         maybeRemoveImport("org.hamcrest.CoreMatchers.not");
                         matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx);

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
@@ -38,8 +38,8 @@ public class HamcrestInstanceOfToJUnit5 extends Recipe {
     @Getter
     final String description = "Migrate from Hamcrest `instanceOf` and `isA` matcher to JUnit5 `assertInstanceOf` assertion.";
 
-    private static final MethodMatcher INSTANCE_OF_MATCHER = new MethodMatcher("org.hamcrest.Matchers instanceOf(..)");
-    private static final MethodMatcher IS_A_MATCHER = new MethodMatcher("org.hamcrest.Matchers isA(..)");
+    private static final MethodMatcher INSTANCE_OF_MATCHER = new MethodMatcher("org.hamcrest.*Matchers instanceOf(..)");
+    private static final MethodMatcher IS_A_MATCHER = new MethodMatcher("org.hamcrest.*Matchers isA(..)");
     private static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.hamcrest.MatcherAssert assertThat(.., org.hamcrest.Matcher)");
 
     @Override

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -137,7 +137,7 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                     J.MethodInvocation matcherInvocation = (J.MethodInvocation) hamcrestMatcher;
                     maybeRemoveImport("org.hamcrest.MatcherAssert.assertThat");
 
-                    while ("not".equals(matcherInvocation.getSimpleName())) {
+                    while (RemoveNotMatcherVisitor.NOT_MATCHER.matches(matcherInvocation)) {
                         maybeRemoveImport("org.hamcrest.Matchers.not");
                         maybeRemoveImport("org.hamcrest.CoreMatchers.not");
                         matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx);

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveNotMatcherVisitor.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/RemoveNotMatcherVisitor.java
@@ -26,7 +26,7 @@ import java.security.InvalidParameterException;
 import java.util.Objects;
 
 class RemoveNotMatcherVisitor extends JavaIsoVisitor<ExecutionContext> {
-    static final MethodMatcher NOT_MATCHER = new MethodMatcher("org.hamcrest.Matchers not(..)");
+    static final MethodMatcher NOT_MATCHER = new MethodMatcher("org.hamcrest.*Matchers not(..)");
 
     public static boolean getLogicalContext(J.MethodInvocation mi, ExecutionContext ctx) throws InvalidParameterException {
         Object msg = ctx.getMessage(mi.toString());

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5Test.java
@@ -86,7 +86,7 @@ class HamcrestInstanceOfToJUnit5Test implements RewriteTest {
 
     @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    void notFromCoreMatchersDoesNotHang() {
+    void notFromCoreMatchers() {
         //language=java
         rewriteRun(
           java(
@@ -95,7 +95,7 @@ class HamcrestInstanceOfToJUnit5Test implements RewriteTest {
               import java.util.List;
 
               import static org.hamcrest.MatcherAssert.assertThat;
-              import static org.hamcrest.Matchers.instanceOf;
+              import static org.hamcrest.CoreMatchers.instanceOf;
               import static org.hamcrest.CoreMatchers.not;
 
               class ATest {
@@ -103,6 +103,61 @@ class HamcrestInstanceOfToJUnit5Test implements RewriteTest {
                   @Test
                   void testInstance() {
                       assertThat(list, not(instanceOf(Integer.class)));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.List;
+
+              import static org.junit.jupiter.api.Assertions.assertFalse;
+
+              class ATest {
+                  private static final List<Integer> list = List.of();
+                  @Test
+                  void testInstance() {
+                      assertFalse(Integer.class.isAssignableFrom(list.getClass()));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void instanceOfAndIsAFromCoreMatchers() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.List;
+
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.CoreMatchers.instanceOf;
+              import static org.hamcrest.CoreMatchers.isA;
+
+              class ATest {
+                  private static final List<Integer> list = List.of();
+                  @Test
+                  void testInstance() {
+                      assertThat(list, instanceOf(Iterable.class));
+                      assertThat(list, isA(Iterable.class));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.List;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  private static final List<Integer> list = List.of();
+                  @Test
+                  void testInstance() {
+                      assertInstanceOf(Iterable.class, list);
+                      assertInstanceOf(Iterable.class, list);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5Test.java
@@ -16,11 +16,14 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.TypeValidation.all;
@@ -74,6 +77,32 @@ class HamcrestInstanceOfToJUnit5Test implements RewriteTest {
                       assertInstanceOf(Iterable.class, list);
                       assertFalse(Integer.class.isAssignableFrom(list.getClass()));
                       assertInstanceOf(Iterable.class, list);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void notFromCoreMatchersDoesNotHang() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import java.util.List;
+
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.instanceOf;
+              import static org.hamcrest.CoreMatchers.not;
+
+              class ATest {
+                  private static final List<Integer> list = List.of();
+                  @Test
+                  void testInstance() {
+                      assertThat(list, not(instanceOf(Integer.class)));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -16,11 +16,14 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.TypeValidation.all;
@@ -151,6 +154,32 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
                       String str1 = "Hello world!";
                       String str2 = "Hello world!";
                       assertNotEquals(str1, str2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void notFromCoreMatchersDoesNotHang() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().immutableExecutionContext(false)),
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.CoreMatchers.equalTo;
+              import static org.hamcrest.CoreMatchers.not;
+
+              class ATest {
+                  @Test
+                  void testEquals() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, not(equalTo(str2)));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -163,7 +163,7 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
 
     @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    void notFromCoreMatchersDoesNotHang() {
+    void notFromCoreMatchers() {
         //language=java
         rewriteRun(
           spec -> spec.typeValidationOptions(all().immutableExecutionContext(false)),
@@ -180,6 +180,20 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
                       String str1 = "Hello world!";
                       String str2 = "Hello world!";
                       assertThat(str1, not(equalTo(str2)));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+              class ATest {
+                  @Test
+                  void testEquals() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertNotEquals(str1, str2);
                   }
               }
               """


### PR DESCRIPTION
## What's changed

Two commits:

1. **Fix an infinite loop** in `HamcrestMatcherToJUnit5` / `HamcrestInstanceOfToJUnit5` on a `not(...)` matcher that isn't `org.hamcrest.Matchers.not`.
2. **Migrate `CoreMatchers` variants** of `not`/`instanceOf`/`isA` instead of skipping them.

## The hang

The unwrap loop continues on a name check but only makes progress on a type check, so they disagree:

```java
while ("not".equals(matcherInvocation.getSimpleName())) {          // any not
    matcherInvocation = new RemoveNotMatcherVisitor().visit(...);  // only strips org.hamcrest.Matchers.not
}
```

A `CoreMatchers.not` (or a `not` with unresolved type) never gets stripped, the name stays `"not"`, and the loop spins forever. Repro:

```java
import static org.hamcrest.CoreMatchers.not;
import static org.hamcrest.CoreMatchers.equalTo;
assertThat(a, not(equalTo(b))); // hangs
```

**Fix:** loop on the matcher that decides strippability, so continuation and progress can't disagree:

```java
while (RemoveNotMatcherVisitor.NOT_MATCHER.matches(matcherInvocation)) {
```

No change to existing migrations.

## CoreMatchers support

Broadens the three matchers from `org.hamcrest.Matchers` to `org.hamcrest.*Matchers` (matches exactly `Matchers` and `CoreMatchers`, identical methods), so `CoreMatchers.not`/`instanceOf`/`isA` migrate too.

## Tests

`notFromCoreMatchers` (both recipes, asserting the real migration, `@Timeout`-guarded so a regressed hang fails fast) and `instanceOfAndIsAFromCoreMatchers`. Full suite passes.
