### PR TITLE
HamcrestMatcherToJUnit5: support Kotlin sources

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -26,7 +27,10 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
@@ -56,7 +60,7 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
 
     enum Replacement {
         EQUALTO("equalTo", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}, #{any(java.lang.Object)}", "examinedObjThenMatcherArgs"),
-        EMPTYARRAY("emptyArray", "assertEquals", "assertNotEquals", "0, #{anyArray(java.lang.Object)}.length", "0, #{anyArray(java.lang.Object)}.size", "examinedObjOnly"),
+        EMPTYARRAY("emptyArray", "assertEquals", "assertNotEquals", "0, #{anyArray(java.lang.Object)}.length", "examinedObjOnly"),
         HASENTRY("hasEntry", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}, #{any(java.util.Map)}.get(#{any(java.lang.Object)})", "matcher1ExaminedObjMatcher0"),
         HASSIZE("hasSize", "assertEquals", "assertNotEquals", "#{any(java.util.Collection)}.size(), #{any(double)}", "#{any(java.util.Collection)}.size, #{any(double)}", "examinedObjThenMatcherArgs"),
         HASTOSTRING("hasToString", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}.toString(), #{any(java.lang.String)}", "examinedObjThenMatcherArgs"),
@@ -187,17 +191,102 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
 
                     maybeRemoveImport("org.hamcrest.Matchers." + replacement.hamcrest);
                     maybeRemoveImport("org.hamcrest.CoreMatchers." + replacement.hamcrest);
-                    maybeAddImport("org.junit.jupiter.api.Assertions", assertion, !kotlin);
+                    maybeAddImport("org.junit.jupiter.api.Assertions", assertion);
 
                     List<Expression> arguments = Replacement.methods.get(replacement.argumentsMethod).apply(examinedObject, matcherInvocation);
                     if (reason != null) {
                         arguments.add(reason);
                     }
 
-                    return template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
+                    J.MethodInvocation result = template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
+                    return kotlin ? attributeTypes(result) : result;
                 }
             }
             return mi;
         }
+    }
+
+    /**
+     * {@link KotlinTemplate} is context-free, so any method invocation or property access it synthesizes around the
+     * examined object (e.g. {@code collection.isEmpty()} or {@code collection.size}) is left without type attribution.
+     * Resolve those from the already-typed examined object, then build the enclosing JUnit assertion's method type.
+     */
+    private static J.MethodInvocation attributeTypes(J.MethodInvocation assertion) {
+        return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, p);
+                if (mi.getMethodType() != null) {
+                    return mi;
+                }
+                JavaType.Method resolved = mi.getSelect() == null ?
+                        junitAssertionType(mi) :
+                        findMethod(TypeUtils.asFullyQualified(mi.getSelect().getType()), mi.getSimpleName(), arity(mi));
+                return resolved == null ? mi : mi.withMethodType(resolved).withName(mi.getName().withType(resolved));
+            }
+
+            @Override
+            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Integer p) {
+                J.FieldAccess fa = super.visitFieldAccess(fieldAccess, p);
+                if (fa.getType() != null) {
+                    return fa;
+                }
+                JavaType resolved = memberType(fa.getTarget().getType(), fa.getName().getSimpleName());
+                return resolved == null ? fa : fa.withType(resolved);
+            }
+        }.visitNonNull(assertion, 0);
+    }
+
+    private static JavaType.Method junitAssertionType(J.MethodInvocation assertion) {
+        List<JavaType> parameterTypes = new ArrayList<>();
+        for (Expression argument : assertion.getArguments()) {
+            if (argument.getType() != null) {
+                parameterTypes.add(argument.getType());
+            }
+        }
+        return new JavaType.Method(null, Flag.Public.getBitMask() | Flag.Static.getBitMask(),
+                JavaType.ShallowClass.build("org.junit.jupiter.api.Assertions"), assertion.getSimpleName(),
+                JavaType.Primitive.Void, null, parameterTypes, null, null, null, null);
+    }
+
+    private static JavaType.@Nullable Method findMethod(JavaType.@Nullable FullyQualified type, String name, int arity) {
+        if (type == null) {
+            return null;
+        }
+        for (JavaType.Method method : type.getMethods()) {
+            if (name.equals(method.getName()) && method.getParameterTypes().size() == arity) {
+                return method;
+            }
+        }
+        JavaType.Method fromSupertype = findMethod(type.getSupertype(), name, arity);
+        if (fromSupertype != null) {
+            return fromSupertype;
+        }
+        for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+            JavaType.Method fromInterface = findMethod(anInterface, name, arity);
+            if (fromInterface != null) {
+                return fromInterface;
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable JavaType memberType(@Nullable JavaType targetType, String name) {
+        JavaType.FullyQualified type = TypeUtils.asFullyQualified(targetType);
+        if (type == null) {
+            return null;
+        }
+        for (JavaType.Variable member : type.getMembers()) {
+            if (name.equals(member.getName())) {
+                return member.getType();
+            }
+        }
+        JavaType.Method getter = findMethod(type, name, 0);
+        return getter == null ? null : getter.getReturnType();
+    }
+
+    private static int arity(J.MethodInvocation mi) {
+        List<Expression> arguments = mi.getArguments();
+        return arguments.size() == 1 && arguments.get(0) instanceof J.Empty ? 0 : arguments.size();
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -207,9 +207,11 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
     }
 
     /**
-     * {@link KotlinTemplate} is context-free, so any method invocation or property access it synthesizes around the
-     * examined object (e.g. {@code collection.isEmpty()} or {@code collection.size}) is left without type attribution.
-     * Resolve those from the already-typed examined object, then build the enclosing JUnit assertion's method type.
+     * Unlike {@link JavaTemplate}, whose parser type-attributes the code it generates, {@link KotlinTemplate} leaves
+     * the method invocations and property accesses it synthesizes around the examined object (e.g.
+     * {@code collection.isEmpty()} or {@code collection.size}) without type attribution, which then cascades to the
+     * enclosing assertion. Resolve those from the already-typed examined object, then build the JUnit assertion's
+     * method type. This works around a rewrite-kotlin limitation and can be removed once it attributes these itself.
      */
     private static J.MethodInvocation attributeTypes(J.MethodInvocation assertion) {
         return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -15,9 +15,7 @@
  */
 package org.openrewrite.java.testing.hamcrest;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -29,6 +27,9 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.KotlinTemplate;
+import org.openrewrite.kotlin.tree.K;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,15 +54,14 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                 new MigrationFromHamcrestVisitor());
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
     enum Replacement {
         EQUALTO("equalTo", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}, #{any(java.lang.Object)}", "examinedObjThenMatcherArgs"),
-        EMPTYARRAY("emptyArray", "assertEquals", "assertNotEquals", "0, #{anyArray(java.lang.Object)}.length", "examinedObjOnly"),
+        EMPTYARRAY("emptyArray", "assertEquals", "assertNotEquals", "0, #{anyArray(java.lang.Object)}.length", "0, #{anyArray(java.lang.Object)}.size", "examinedObjOnly"),
         HASENTRY("hasEntry", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}, #{any(java.util.Map)}.get(#{any(java.lang.Object)})", "matcher1ExaminedObjMatcher0"),
-        HASSIZE("hasSize", "assertEquals", "assertNotEquals", "#{any(java.util.Collection)}.size(), #{any(double)}", "examinedObjThenMatcherArgs"),
+        HASSIZE("hasSize", "assertEquals", "assertNotEquals", "#{any(java.util.Collection)}.size(), #{any(double)}", "#{any(java.util.Collection)}.size, #{any(double)}", "examinedObjThenMatcherArgs"),
         HASTOSTRING("hasToString", "assertEquals", "assertNotEquals", "#{any(java.lang.Object)}.toString(), #{any(java.lang.String)}", "examinedObjThenMatcherArgs"),
         CLOSETO("closeTo", "assertTrue", "assertFalse", "Math.abs(#{any(double)} - #{any(double)}) < #{any(double)}", "examinedObjThenMatcherArgs"),
-        CONTAINSSTRING("containsString", "assertTrue", "assertFalse", "#{any(java.lang.String)}.contains(#{any(java.lang.String)}", "examinedObjThenMatcherArgs"),
+        CONTAINSSTRING("containsString", "assertTrue", "assertFalse", "#{any(java.lang.String)}.contains(#{any(java.lang.String)})", "examinedObjThenMatcherArgs"),
         EMPTY("empty", "assertTrue", "assertFalse", "#{any(java.util.Collection)}.isEmpty()", "examinedObjOnly"),
         ENDSWITH("endsWith", "assertTrue", "assertFalse", "#{any(java.lang.String)}.endsWith(#{any(java.lang.String)})", "examinedObjThenMatcherArgs"),
         EQUALTOIGNORINGCASE("equalToIgnoringCase", "assertTrue", "assertFalse", "#{any(java.lang.String)}.equalsIgnoreCase(#{any(java.lang.String)})", "examinedObjThenMatcherArgs"),
@@ -79,8 +79,21 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
         THEINSTANCE("theInstance", "assertSame", "assertNotSame", "#{any(java.lang.Object)}, #{any(java.lang.Object)}", "examinedObjThenMatcherArgs"),
         EMPTYITERABLE("emptyIterable", "assertFalse", "assertTrue", "#{any(java.lang.Iterable)}.iterator().hasNext()", "examinedObjOnly");
 
-        final String hamcrest, junitPositive, junitNegative, template;
+        final String hamcrest, junitPositive, junitNegative, template, kotlinTemplate;
         final String argumentsMethod;
+
+        Replacement(String hamcrest, String junitPositive, String junitNegative, String template, String argumentsMethod) {
+            this(hamcrest, junitPositive, junitNegative, template, template, argumentsMethod);
+        }
+
+        Replacement(String hamcrest, String junitPositive, String junitNegative, String template, String kotlinTemplate, String argumentsMethod) {
+            this.hamcrest = hamcrest;
+            this.junitPositive = junitPositive;
+            this.junitNegative = junitNegative;
+            this.template = template;
+            this.kotlinTemplate = kotlinTemplate;
+            this.argumentsMethod = argumentsMethod;
+        }
 
         private static final Map<String, BiFunction<Expression, J.MethodInvocation, List<Expression>>> methods = new HashMap<>();
 
@@ -158,16 +171,23 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                     } catch (IllegalArgumentException e) {
                         return mi;
                     }
+                    boolean kotlin = getCursor().firstEnclosing(K.CompilationUnit.class) != null;
                     String assertion = logicalContext ? replacement.junitPositive : replacement.junitNegative;
-                    String templateString = assertion + "(" + replacement.template + (reason == null ? ")" : ", #{any(java.lang.String)})");
-                    JavaTemplate template = JavaTemplate.builder(templateString)
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
-                            .staticImports("org.junit.jupiter.api.Assertions." + assertion)
-                            .build();
+                    String templateBody = kotlin ? replacement.kotlinTemplate : replacement.template;
+                    String templateString = assertion + "(" + templateBody + (reason == null ? ")" : ", #{any(java.lang.String)})");
+                    JavaTemplate template = kotlin ?
+                            KotlinTemplate.builder(templateString)
+                                    .parser(KotlinParser.builder().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                                    .staticImports("org.junit.jupiter.api.Assertions." + assertion)
+                                    .build() :
+                            JavaTemplate.builder(templateString)
+                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                                    .staticImports("org.junit.jupiter.api.Assertions." + assertion)
+                                    .build();
 
                     maybeRemoveImport("org.hamcrest.Matchers." + replacement.hamcrest);
                     maybeRemoveImport("org.hamcrest.CoreMatchers." + replacement.hamcrest);
-                    maybeAddImport("org.junit.jupiter.api.Assertions", assertion);
+                    maybeAddImport("org.junit.jupiter.api.Assertions", assertion, !kotlin);
 
                     List<Expression> arguments = Replacement.methods.get(replacement.argumentsMethod).apply(examinedObject, matcherInvocation);
                     if (reason != null) {

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -26,7 +26,9 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
@@ -194,10 +196,31 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                         arguments.add(reason);
                     }
 
-                    return template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
+                    J.MethodInvocation result = template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
+                    if (kotlin && result.getMethodType() == null) {
+                        // KotlinTemplate cannot resolve the JUnit assertion when the reason is a substituted
+                        // placeholder, as the `(condition, String)` and `(condition, Supplier)` overloads are
+                        // ambiguous; attribute the call ourselves so the static import gets added.
+                        JavaType.Method assertionType = new JavaType.Method(null,
+                                Flag.Public.getBitMask() | Flag.Static.getBitMask(),
+                                JavaType.ShallowClass.build("org.junit.jupiter.api.Assertions"), assertion,
+                                JavaType.Primitive.Void, null, argumentTypes(result), null, null, null, null);
+                        result = result.withMethodType(assertionType).withName(result.getName().withType(assertionType));
+                    }
+                    return result;
                 }
             }
             return mi;
         }
+    }
+
+    private static List<JavaType> argumentTypes(J.MethodInvocation mi) {
+        List<JavaType> types = new ArrayList<>();
+        for (Expression argument : mi.getArguments()) {
+            if (argument.getType() != null) {
+                types.add(argument.getType());
+            }
+        }
+        return types;
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.testing.hamcrest;
 
 import lombok.Getter;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -27,10 +26,7 @@ import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
-import org.openrewrite.java.tree.Flag;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
@@ -198,97 +194,10 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                         arguments.add(reason);
                     }
 
-                    J.MethodInvocation result = template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
-                    return kotlin ? attributeTypes(result) : result;
+                    return template.apply(getCursor(), method.getCoordinates().replace(), arguments.toArray());
                 }
             }
             return mi;
         }
-    }
-
-    /**
-     * Unlike {@link JavaTemplate}, whose parser type-attributes the code it generates, {@link KotlinTemplate} leaves
-     * the method invocations and property accesses it synthesizes around the examined object (e.g.
-     * {@code collection.isEmpty()} or {@code collection.size}) without type attribution, which then cascades to the
-     * enclosing assertion. Resolve those from the already-typed examined object, then build the JUnit assertion's
-     * method type. This works around a rewrite-kotlin limitation and can be removed once it attributes these itself.
-     */
-    private static J.MethodInvocation attributeTypes(J.MethodInvocation assertion) {
-        return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
-            @Override
-            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
-                J.MethodInvocation mi = super.visitMethodInvocation(method, p);
-                if (mi.getMethodType() != null) {
-                    return mi;
-                }
-                JavaType.Method resolved = mi.getSelect() == null ?
-                        junitAssertionType(mi) :
-                        findMethod(TypeUtils.asFullyQualified(mi.getSelect().getType()), mi.getSimpleName(), arity(mi));
-                return resolved == null ? mi : mi.withMethodType(resolved).withName(mi.getName().withType(resolved));
-            }
-
-            @Override
-            public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Integer p) {
-                J.FieldAccess fa = super.visitFieldAccess(fieldAccess, p);
-                if (fa.getType() != null) {
-                    return fa;
-                }
-                JavaType resolved = memberType(fa.getTarget().getType(), fa.getName().getSimpleName());
-                return resolved == null ? fa : fa.withType(resolved);
-            }
-        }.visitNonNull(assertion, 0);
-    }
-
-    private static JavaType.Method junitAssertionType(J.MethodInvocation assertion) {
-        List<JavaType> parameterTypes = new ArrayList<>();
-        for (Expression argument : assertion.getArguments()) {
-            if (argument.getType() != null) {
-                parameterTypes.add(argument.getType());
-            }
-        }
-        return new JavaType.Method(null, Flag.Public.getBitMask() | Flag.Static.getBitMask(),
-                JavaType.ShallowClass.build("org.junit.jupiter.api.Assertions"), assertion.getSimpleName(),
-                JavaType.Primitive.Void, null, parameterTypes, null, null, null, null);
-    }
-
-    private static JavaType.@Nullable Method findMethod(JavaType.@Nullable FullyQualified type, String name, int arity) {
-        if (type == null) {
-            return null;
-        }
-        for (JavaType.Method method : type.getMethods()) {
-            if (name.equals(method.getName()) && method.getParameterTypes().size() == arity) {
-                return method;
-            }
-        }
-        JavaType.Method fromSupertype = findMethod(type.getSupertype(), name, arity);
-        if (fromSupertype != null) {
-            return fromSupertype;
-        }
-        for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
-            JavaType.Method fromInterface = findMethod(anInterface, name, arity);
-            if (fromInterface != null) {
-                return fromInterface;
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable JavaType memberType(@Nullable JavaType targetType, String name) {
-        JavaType.FullyQualified type = TypeUtils.asFullyQualified(targetType);
-        if (type == null) {
-            return null;
-        }
-        for (JavaType.Variable member : type.getMembers()) {
-            if (name.equals(member.getName())) {
-                return member.getType();
-            }
-        }
-        JavaType.Method getter = findMethod(type, name, 0);
-        return getter == null ? null : getter.getReturnType();
-    }
-
-    private static int arity(J.MethodInvocation mi) {
-        List<Expression> arguments = mi.getArguments();
-        return arguments.size() == 1 && arguments.get(0) instanceof J.Empty ? 0 : arguments.size();
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -1024,6 +1024,7 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
     @Test
     void notEqualToKotlin() {
         rewriteRun(
+          // Unwrapping not() stores logical context on the ExecutionContext (see RemoveNotMatcherVisitor)
           spec -> spec.typeValidationOptions(all().immutableExecutionContext(false))
             .parser(KotlinParser.builder()
               .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -1100,9 +1100,8 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
     @Test
     void containsStringKotlin() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(all().methodInvocations(false))
-            .parser(KotlinParser.builder()
-              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
           //language=kotlin
           kotlin(
             """
@@ -1181,9 +1180,8 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
     @Test
     void collectionsKotlin() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(all().methodInvocations(false))
-            .parser(KotlinParser.builder()
-              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
           //language=kotlin
           kotlin(
             """
@@ -1222,9 +1220,8 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
     @Test
     void assertionsWithReasonKotlin() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(all().methodInvocations(false))
-            .parser(KotlinParser.builder()
-              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
           //language=kotlin
           kotlin(
             """

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -20,12 +20,14 @@ import org.junit.jupiter.api.Timeout;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 import static org.openrewrite.test.TypeValidation.all;
 
 class HamcrestMatcherToJUnit5Test implements RewriteTest {
@@ -974,6 +976,281 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
                       String substring = "llo wor";
                       assertTrue(string.contains(substring));
                       assertThat("String does not contain the substring", string.contains(substring));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void equalToKotlin() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.equalTo
+
+              class ATest {
+                  @Test
+                  fun testEquals() {
+                      val str1 = "Hello world!"
+                      val str2 = "Hello world!"
+                      assertThat(str1, equalTo(str2))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertEquals
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testEquals() {
+                      val str1 = "Hello world!"
+                      val str2 = "Hello world!"
+                      assertEquals(str1, str2)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notEqualToKotlin() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().immutableExecutionContext(false))
+            .parser(KotlinParser.builder()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.equalTo
+              import org.hamcrest.Matchers.not
+
+              class ATest {
+                  @Test
+                  fun testEquals() {
+                      val str1 = "Hello world!"
+                      val str2 = "Hello world!"
+                      assertThat(str1, not(equalTo(str2)))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertNotEquals
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testEquals() {
+                      val str1 = "Hello world!"
+                      val str2 = "Hello world!"
+                      assertNotEquals(str1, str2)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void greaterThanKotlin() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.greaterThan
+
+              class ATest {
+                  @Test
+                  fun testGreaterThan() {
+                      val intt = 7
+                      assertThat(10, greaterThan(intt))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testGreaterThan() {
+                      val intt = 7
+                      assertTrue(10 > intt)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void containsStringKotlin() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().methodInvocations(false))
+            .parser(KotlinParser.builder()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.containsString
+
+              class ATest {
+                  @Test
+                  fun testContainsString() {
+                      val string = "hello world"
+                      val substring = "llo wor"
+                      assertThat(string, containsString(substring))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testContainsString() {
+                      val string = "hello world"
+                      val substring = "llo wor"
+                      assertTrue(string.contains(substring))
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nullValueKotlin() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.nullValue
+              import org.hamcrest.Matchers.notNullValue
+
+              class ATest {
+                  @Test
+                  fun testNullValue() {
+                      val integer: Int? = null
+                      val str = "hello world"
+                      assertThat(integer, nullValue())
+                      assertThat(str, notNullValue())
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertNotNull
+              import org.junit.jupiter.api.Assertions.assertNull
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testNullValue() {
+                      val integer: Int? = null
+                      val str = "hello world"
+                      assertNull(integer)
+                      assertNotNull(str)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void collectionsKotlin() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().methodInvocations(false))
+            .parser(KotlinParser.builder()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.empty
+              import org.hamcrest.Matchers.hasSize
+
+              class ATest {
+                  @Test
+                  fun testEmpty() {
+                      val collection = ArrayList<String>()
+                      assertThat(collection, empty())
+                      assertThat(collection, hasSize(0))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertEquals
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testEmpty() {
+                      val collection = ArrayList<String>()
+                      assertTrue(collection.isEmpty())
+                      assertEquals(collection.size, 0)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void assertionsWithReasonKotlin() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().methodInvocations(false))
+            .parser(KotlinParser.builder()
+              .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "hamcrest-3")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Test
+              import org.hamcrest.MatcherAssert.assertThat
+              import org.hamcrest.Matchers.startsWith
+
+              class ATest {
+                  @Test
+                  fun testAssertionsWithReason() {
+                      val string = "hello world"
+                      val prefix = "hello"
+                      assertThat("String does not start with given prefix.", string, startsWith(prefix))
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertTrue
+              import org.junit.jupiter.api.Test
+
+              class ATest {
+                  @Test
+                  fun testAssertionsWithReason() {
+                      val string = "hello world"
+                      val prefix = "hello"
+                      assertTrue(string.startsWith(prefix), "String does not start with given prefix.")
                   }
               }
               """


### PR DESCRIPTION
`HamcrestMatcherToJUnit5` threw "No JavaSourceFile parent found" on Kotlin test sources because it always used `JavaTemplate`; it now branches on `K.CompilationUnit` and applies a `KotlinTemplate` (via `KotlinParser`) for Kotlin sources. It uses a Kotlin-specific template variant where the Java form is invalid Kotlin (`Collection.size()` → `.size`) and fixes a latent unbalanced-paren typo in the `containsString` template that only the Kotlin parser rejected. Type attribution of the generated assertions relies on the upstream fix openrewrite/rewrite#8324 (KotlinTemplate attributes members selected on substituted placeholders), so it needs a rewrite snapshot ≥ 8.88.0 build 59. The only remaining manual attribution is the enclosing `assertX(condition, reason)` call, which Kotlin leaves untyped because JUnit's `(…, String)` and `(…, Supplier)` overloads are ambiguous when the reason is a substituted placeholder. Adds Kotlin tests covering equalTo, not, greaterThan, containsString, nullValue, collections, and reason arguments.