### PR TITLE
Fix AssertThrowsOnLastStatement crash on unattributed argument types

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatement.java
@@ -159,6 +159,15 @@ public class AssertThrowsOnLastStatement extends Recipe {
                             return e;
                         }
 
+                        // Unattributed (`None`/`Unknown`), `void` or `null` typed expressions can't be rendered as a
+                        // typed variable declaration; leave them inline rather than generating an invalid template
+                        // (`= expr` assignments or `void`/`<unknown>` declarations that fail to parse)
+                        JavaType type = e.getType();
+                        if (type instanceof JavaType.Unknown ||
+                                type == JavaType.Primitive.None || type == JavaType.Primitive.Void || type == JavaType.Primitive.Null) {
+                            return e;
+                        }
+
                         String variableName = getVariableName(e, generatedVariableSuffixes);
 
                         // Kotlin infers the type; add `val name = expr` as a statement on the method body, since replacing
@@ -177,11 +186,11 @@ public class AssertThrowsOnLastStatement extends Recipe {
 
                         Object variableTypeShort = "Object";
                         JavaType variableTypeFqn = null;
-                        if (e.getType() instanceof JavaType.Primitive) {
-                            variableTypeShort = e.getType().toString();
-                            variableTypeFqn = e.getType();
-                        } else if (e.getType() instanceof JavaType.Parameterized) {
-                            JavaType.Parameterized paramType = (JavaType.Parameterized) e.getType();
+                        if (type instanceof JavaType.Primitive) {
+                            variableTypeShort = type.toString();
+                            variableTypeFqn = type;
+                        } else if (type instanceof JavaType.Parameterized) {
+                            JavaType.Parameterized paramType = (JavaType.Parameterized) type;
                             // TODO look into possibly employing `TypeUtils.toString()` here, possibly with some changes upstream allowing for non-fully-qualified names
                             variableTypeShort = buildParameterizedTypeName(paramType);
                             variableTypeFqn = paramType;
@@ -191,8 +200,8 @@ public class AssertThrowsOnLastStatement extends Recipe {
                                     maybeAddImport(((JavaType.FullyQualified) typeParam).getFullyQualifiedName(), false);
                                 }
                             }
-                        } else if (e.getType() instanceof JavaType.FullyQualified) {
-                            JavaType.FullyQualified aClass = (JavaType.FullyQualified) e.getType();
+                        } else if (type instanceof JavaType.FullyQualified) {
+                            JavaType.FullyQualified aClass = (JavaType.FullyQualified) type;
                             variableTypeShort = aClass.getClassName();
                             variableTypeFqn = aClass;
                             maybeAddImport(aClass.getFullyQualifiedName(), false);

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertThrowsOnLastStatementTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.kotlin.Assertions.kotlin;
@@ -1189,6 +1190,51 @@ class AssertThrowsOnLastStatementTest implements RewriteTest {
 
                   void doA() {}
                   void doB(String arg) {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void lastStatementArgumentWithUnattributedTypeIsLeftInline() {
+        // A freshly-migrated `assertThrows` lambda (e.g. from `@Test(expected = ...)`) can carry arguments whose type
+        // is not attributed yet; those must be left inline rather than crashing while rendering a variable declaration
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).build()),
+          //language=java
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              class MyTest {
+                  @Test
+                  void test() {
+                      assertThrows(RuntimeException.class, () -> {
+                          setup();
+                          consume(unknownA + unknownB);
+                      });
+                  }
+                  void setup() {}
+                  void consume(Object o) {}
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              class MyTest {
+                  @Test
+                  void test() {
+                      setup();
+                      assertThrows(RuntimeException.class, () ->
+                          consume(unknownA + unknownB));
+                  }
+                  void setup() {}
+                  void consume(Object o) {}
               }
               """
           )


### PR DESCRIPTION
`AssertThrowsOnLastStatement` extracts complex last-statement arguments into a typed variable declaration, but derived the type token from `e.getType().toString()`, which is unusable for unattributed types: `None` → `""` (rendering ` name = expr;`, a `J.Assignment`, causing `J$Assignment cannot be cast to J$VariableDeclarations`), and `Void`/`Unknown` → `"void"`/`"<unknown>"` (templates that generate no statements). These degenerate types show up when the `assertThrows` lambda was just synthesized earlier in the same run, e.g. by the `@Test(expected = ...)` → `assertThrows` migration. The fix skips extraction for `Unknown`/`None`/`Void`/`Null`-typed arguments, leaving them inline, and adds a regression test.