### PR TITLE
Fix Hamcrest not() unwrap crash when wrapping a bare value

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestInstanceOfToJUnit5.java
@@ -73,7 +73,7 @@ public class HamcrestInstanceOfToJUnit5 extends Recipe {
                     while (RemoveNotMatcherVisitor.NOT_MATCHER.matches(matcherInvocation)) {
                         maybeRemoveImport("org.hamcrest.Matchers.not");
                         maybeRemoveImport("org.hamcrest.CoreMatchers.not");
-                        matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx);
+                        matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx, getCursor());
                     }
 
                     if (INSTANCE_OF_MATCHER.matches(matcherInvocation) || IS_A_MATCHER.matches(matcherInvocation)) {

--- a/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
+++ b/src/main/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5.java
@@ -140,7 +140,7 @@ public class HamcrestMatcherToJUnit5 extends Recipe {
                     while (RemoveNotMatcherVisitor.NOT_MATCHER.matches(matcherInvocation)) {
                         maybeRemoveImport("org.hamcrest.Matchers.not");
                         maybeRemoveImport("org.hamcrest.CoreMatchers.not");
-                        matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx);
+                        matcherInvocation = (J.MethodInvocation) new RemoveNotMatcherVisitor().visit(matcherInvocation, ctx, getCursor());
                     }
 
                     //we do not handle nested matchers

--- a/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
+++ b/src/test/java/org/openrewrite/java/testing/hamcrest/HamcrestMatcherToJUnit5Test.java
@@ -162,6 +162,44 @@ class HamcrestMatcherToJUnit5Test implements RewriteTest {
     }
 
     @Test
+    void notWithBareValue() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(all().immutableExecutionContext(false)),
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.not;
+
+              class ATest {
+                  @Test
+                  void testEquals() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertThat(str1, not(str2));
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+              class ATest {
+                  @Test
+                  void testEquals() {
+                      String str1 = "Hello world!";
+                      String str2 = "Hello world!";
+                      assertNotEquals(str1, str2);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     @Timeout(value = 30, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     void notFromCoreMatchers() {
         //language=java


### PR DESCRIPTION
## What's changed

`HamcrestMatcherToJUnit5` and `HamcrestInstanceOfToJUnit5` invoke `RemoveNotMatcherVisitor` via `visit(matcherInvocation, ctx)`, which roots the sub-visitor at `Cursor.ROOT`. The `matcherInvocation` passed in is a detached subtree, so its cursor path has no enclosing `JavaSourceFile`.

When a `not(...)` matcher wraps a bare value rather than another Hamcrest matcher, `RemoveNotMatcherVisitor` wraps the value in `equalTo(...)` and calls `maybeAddImport`. That triggers an `ImportService` lookup which walks the cursor for a `JavaSourceFile` ancestor and throws `IllegalArgumentException: No JavaSourceFile parent found`.

The fix passes the current cursor as the parent (`visit(matcherInvocation, ctx, getCursor())`) so the sub-visitor inherits a path that includes the `JavaSourceFile` ancestor. Applied to both call sites.

## Example

Before this fix, the recipe crashed on:

```java
assertThat(str1, not(str2)); // str2 is a bare value, not a Hamcrest matcher
```

Now it correctly migrates to:

```java
assertNotEquals(str1, str2);
```

## Testing

Added `notWithBareValue` to `HamcrestMatcherToJUnit5Test`, which reproduces the crash without the fix and passes with it. All existing Hamcrest recipe tests continue to pass.