### PR TITLE
Support Kotlin in three JUnit testing recipes (fix crashes/no-ops)

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNull.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNull.java
@@ -16,17 +16,18 @@
 package org.openrewrite.java.testing.cleanup;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.JavaParser;
-import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 
 public class AssertTrueNullToAssertNull extends Recipe {
     private static final MethodMatcher ASSERT_TRUE = new MethodMatcher(
@@ -40,50 +41,44 @@ public class AssertTrueNullToAssertNull extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new UsesMethod<>(ASSERT_TRUE), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(new UsesMethod<>(ASSERT_TRUE), new JavaIsoVisitor<ExecutionContext>() {
             @Override
-            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                J.MethodInvocation mi = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-                if (ASSERT_TRUE.matches(mi) && isEqualBinaryWithNull(mi)) {
-                    J.Binary binary = (J.Binary) mi.getArguments().get(0);
-                    Expression nonNullExpression = getNonNullExpression(binary);
-
-                    StringBuilder sb = new StringBuilder();
-                    if (mi.getSelect() == null) {
-                        maybeRemoveImport("org.junit.jupiter.api.Assertions");
-                        maybeAddImport("org.junit.jupiter.api.Assertions", "assertNull");
-                    } else {
-                        sb.append("Assertions.");
-                    }
-                    sb.append("assertNull(#{any(java.lang.Object)}");
-
-                    Object[] args;
-                    if (mi.getArguments().size() == 2) {
-                        sb.append(", #{any()}");
-                        args = new J[]{nonNullExpression, mi.getArguments().get(1)};
-                    } else {
-                        args = new J[]{nonNullExpression};
-                    }
-                    sb.append(")");
-                    JavaTemplate t;
-                    if (mi.getSelect() == null) {
-                        t = JavaTemplate.builder(sb.toString())
-                                .contextSensitive()
-                                .staticImports("org.junit.jupiter.api.Assertions.assertNull")
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "junit-jupiter-api-5"))
-                                .build();
-                    } else {
-                        t = JavaTemplate.builder(sb.toString())
-                                .contextSensitive()
-                                .imports("org.junit.jupiter.api.Assertions")
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "junit-jupiter-api-5"))
-                                .build();
-                    }
-                    return t.apply(updateCursor(mi), mi.getCoordinates().replace(), args);
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                if (!ASSERT_TRUE.matches(mi) || !isEqualBinaryWithNull(mi)) {
+                    return mi;
                 }
-                return mi;
+
+                J.Binary binary = (J.Binary) mi.getArguments().get(0);
+                Expression nonNullExpression = getNonNullExpression(binary);
+
+                if (mi.getSelect() == null) {
+                    maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
+                    maybeAddImport("org.junit.jupiter.api.Assertions", "assertNull");
+                }
+
+                JavaType.Method newType = assertNullMethodType(mi.getMethodType(), mi.getArguments().size());
+                return mi.withName(mi.getName().withSimpleName("assertNull").withType(newType))
+                        .withMethodType(newType)
+                        .withArguments(ListUtils.mapFirst(mi.getArguments(),
+                                arg -> nonNullExpression.withPrefix(binary.getPrefix())));
+            }
+
+            private JavaType.@Nullable Method assertNullMethodType(JavaType.@Nullable Method assertTrue, int parameterCount) {
+                if (assertTrue == null) {
+                    return null;
+                }
+                JavaType messageType = parameterCount == 2 ?
+                        assertTrue.getParameterTypes().get(assertTrue.getParameterTypes().size() - 1) : null;
+                for (JavaType.Method method : assertTrue.getDeclaringType().getMethods()) {
+                    if ("assertNull".equals(method.getName()) &&
+                            method.getParameterTypes().size() == parameterCount &&
+                            (messageType == null || messageType.equals(method.getParameterTypes().get(parameterCount - 1)))) {
+                        return method;
+                    }
+                }
+                // fallback when type attribution was stubbed
+                return assertTrue.withName("assertNull");
             }
 
             private Expression getNonNullExpression(J.Binary binary) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSource.java
@@ -34,6 +34,9 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.TypeUtils;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.KotlinTemplate;
+import org.openrewrite.kotlin.tree.K;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +64,7 @@ public class CsvSourceToValueSource extends Recipe {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
                         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+                        boolean kotlin = getCursor().firstEnclosing(K.CompilationUnit.class) != null;
 
                         // Check if method has exactly one parameter
                         if (m.getParameters().size() != 1 || m.getParameters().get(0) instanceof J.Empty) {
@@ -111,11 +115,9 @@ public class CsvSourceToValueSource extends Recipe {
                                     Expression templateArg = annotation.getArguments().get(0) instanceof J.Assignment ?
                                             ((J.Assignment) annotation.getArguments().get(0)).getAssignment() :
                                             annotation.getArguments().get(0);
-                                    J.MethodDeclaration updated = JavaTemplate.builder("@ValueSource(strings = {})")
-                                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-params-5"))
-                                            .imports("org.junit.jupiter.params.provider.ValueSource")
-                                            .build()
-                                            .apply(getCursor(), annotation.getCoordinates().replace());
+                                    J.MethodDeclaration updated = applyValueSourceTemplate(
+                                            kotlin ? "@ValueSource(strings = [])" : "@ValueSource(strings = {})",
+                                            annotation, kotlin, ctx);
                                     return updated.withLeadingAnnotations(ListUtils.map(updated.getLeadingAnnotations(), ann ->
                                             VALUE_SOURCE_MATCHER.matches(ann) ?
                                                     ann.withArguments(ListUtils.map(ann.getArguments(),
@@ -133,7 +135,7 @@ public class CsvSourceToValueSource extends Recipe {
                                 }
 
                                 // Build a new ValueSource annotation
-                                String valueSourceAnnotationTemplate = buildValueSourceAnnotation(paramType, values, fromTextBlock);
+                                String valueSourceAnnotationTemplate = buildValueSourceAnnotation(paramType, values, fromTextBlock, kotlin);
                                 if (valueSourceAnnotationTemplate == null) {
                                     return m;
                                 }
@@ -141,11 +143,7 @@ public class CsvSourceToValueSource extends Recipe {
                                 // Replace the annotation
                                 maybeRemoveImport("org.junit.jupiter.params.provider.CsvSource");
                                 maybeAddImport("org.junit.jupiter.params.provider.ValueSource");
-                                J.MethodDeclaration replaced = JavaTemplate.builder(valueSourceAnnotationTemplate)
-                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-params-5"))
-                                        .imports("org.junit.jupiter.params.provider.ValueSource")
-                                        .build()
-                                        .apply(getCursor(), annotation.getCoordinates().replace());
+                                J.MethodDeclaration replaced = applyValueSourceTemplate(valueSourceAnnotationTemplate, annotation, kotlin, ctx);
                                 if (fromTextBlock && values.size() > 1) {
                                     return autoFormat(replaced, ctx);
                                 }
@@ -156,7 +154,22 @@ public class CsvSourceToValueSource extends Recipe {
                         return m;
                     }
 
-                    private @Nullable String buildValueSourceAnnotation(String paramType, List<String> values, boolean multiLine) {
+                    private J.MethodDeclaration applyValueSourceTemplate(String template, J.Annotation annotation, boolean kotlin, ExecutionContext ctx) {
+                        if (kotlin) {
+                            return KotlinTemplate.builder(template)
+                                    .imports("org.junit.jupiter.params.provider.ValueSource")
+                                    .parser(KotlinParser.builder().classpathFromResources(ctx, "junit-jupiter-params-5"))
+                                    .build()
+                                    .apply(getCursor(), annotation.getCoordinates().replace());
+                        }
+                        return JavaTemplate.builder(template)
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-params-5"))
+                                .imports("org.junit.jupiter.params.provider.ValueSource")
+                                .build()
+                                .apply(getCursor(), annotation.getCoordinates().replace());
+                    }
+
+                    private @Nullable String buildValueSourceAnnotation(String paramType, List<String> values, boolean multiLine, boolean kotlin) {
                         String attributeName;
                         String formattedValues;
 
@@ -218,10 +231,12 @@ public class CsvSourceToValueSource extends Recipe {
                         if (values.size() == 1) {
                             return "@ValueSource(" + attributeName + " = " + formattedValues + ")";
                         }
+                        String open = kotlin ? "[" : "{";
+                        String close = kotlin ? "]" : "}";
                         if (multiLine) {
-                            return "@ValueSource(" + attributeName + " = {\n" + formattedValues + "\n})";
+                            return "@ValueSource(" + attributeName + " = " + open + "\n" + formattedValues + "\n" + close + ")";
                         }
-                        return "@ValueSource(" + attributeName + " = {" + formattedValues + "})";
+                        return "@ValueSource(" + attributeName + " = " + open + formattedValues + close + ")";
                     }
 
                     private List<String> parseTextBlockLines(String textBlock) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.*;
 import org.openrewrite.java.search.FindImports;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.staticanalysis.LambdaBlockToExpression;
 
@@ -108,6 +109,14 @@ public class UpdateTestAnnotation extends Recipe {
             ChangeTestAnnotation cta = new ChangeTestAnnotation();
             J.MethodDeclaration m = (J.MethodDeclaration) cta.visitNonNull(method, ctx, getCursor().getParentOrThrow());
             if (m != method) {
+                // The `expected`/`timeout` rewrites below build the replacement body and annotation with
+                // `JavaTemplate`, which does not render against a Kotlin LST. Rather than dropping the arguments
+                // or crashing, leave the JUnit 4 `@Test(expected = ..., timeout = ...)` intact on Kotlin.
+                if ((cta.expectedException != null || cta.timeout != null) &&
+                        getCursor().firstEnclosing(K.CompilationUnit.class) != null) {
+                    return super.visitMethodDeclaration(method, ctx);
+                }
+
                 JavaParser.Builder<?, ?> javaParser = JavaParser.fromJavaVersion()
                         .classpathFromResources(ctx, "junit-jupiter-api-5", "apiguardian-api-1.1");
                 if (cta.expectedException != null) {

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNullTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueNullToAssertNullTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class AssertTrueNullToAssertNullTest implements RewriteTest {
 
@@ -30,6 +32,7 @@ class AssertTrueNullToAssertNullTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5"))
+          .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5"))
           .recipe(new AssertTrueNullToAssertNull());
     }
 
@@ -108,6 +111,37 @@ class AssertTrueNullToAssertNullTest implements RewriteTest {
                       String b = null;
                       Assertions.assertNull(b);
                       Assertions.assertNull(b, "message");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void simplifyToAssertNullKotlin() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.Assertions.assertTrue
+
+              class FooTest {
+                  fun test(foundCreditLine: Any?) {
+                      assertTrue(foundCreditLine == null)
+                      assertTrue(foundCreditLine == null, "message")
+                      assertTrue(null == foundCreditLine)
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions.assertNull
+
+              class FooTest {
+                  fun test(foundCreditLine: Any?) {
+                      assertNull(foundCreditLine)
+                      assertNull(foundCreditLine, "message")
+                      assertNull(foundCreditLine)
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CsvSourceToValueSourceTest.java
@@ -19,10 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class CsvSourceToValueSourceTest implements RewriteTest {
     @Override
@@ -30,7 +32,60 @@ class CsvSourceToValueSourceTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "junit-jupiter-params-5"))
+          .parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "junit-jupiter-params-5"))
           .recipe(new CsvSourceToValueSource());
+    }
+
+    @Test
+    void replaceCsvSourceWithValueSourceForStringsKotlin() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.CsvSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(value = ["BERMUDA", "TUNM", "LOL"])
+                  fun testWithStrings(country: String) {
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.ValueSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @ValueSource(strings = ["BERMUDA", "TUNM", "LOL"])
+                  fun testWithStrings(country: String) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void leaveKotlinNonStringCsvSourceUnchanged() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.params.ParameterizedTest
+              import org.junit.jupiter.params.provider.CsvSource
+
+              class TestClass {
+                  @ParameterizedTest
+                  @CsvSource(value = ["1", "2", "3"])
+                  fun testWithInts(number: Int) {
+                  }
+              }
+              """
+          )
+        );
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -20,10 +20,12 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 class UpdateTestAnnotationTest implements RewriteTest {
 
@@ -32,7 +34,28 @@ class UpdateTestAnnotationTest implements RewriteTest {
         spec
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "junit-4"))
+          .parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-4"))
           .recipe(new UpdateTestAnnotation());
+    }
+
+    @Test
+    void expectedExceptionLeftUnchangedOnKotlin() {
+        rewriteRun(
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.Test
+
+              class MyTest {
+                  @Test(expected = IllegalArgumentException::class)
+                  fun test() {
+                      throw IllegalArgumentException()
+                  }
+              }
+              """
+          )
+        );
     }
 
     @DocumentExample


### PR DESCRIPTION
- Fixes three testing recipes that crashed or silently no-op'd on Kotlin sources (surfaced by a mass-run against Kotlin repos; see moderneinc/customer-requests#2861).

- `AssertTrueNullToAssertNull`: replaced the `contextSensitive` `JavaTemplate` (which generated 0 statements on Kotlin) with direct LST manipulation — rename to `assertNull`, rewrite the first argument, and fix the method type — so it works on both Java and Kotlin.
- `CsvSourceToValueSource`: the `@ValueSource` `JavaTemplate` could not be spliced into a Kotlin compilation unit ("Could not parse as Java"), so single-`String` `@CsvSource` now uses `KotlinTemplate` with Kotlin `[...]` array syntax; non-`String` Kotlin `@CsvSource` is left unchanged (no crash) because the `Annotated`/`Literal` traits don't resolve Kotlin array attributes.
- `UpdateTestAnnotation`: the body-wrapping `JavaTemplate` produced an empty Kotlin body and threw `IndexOutOfBounds`, so `@Test(expected/timeout)` is now left intact on Kotlin rather than crashing or dropping the arguments.

Each recipe gains a Kotlin test covering the fixed behavior.