### PR TITLE
Use assertInstanceOf for expectCause(isA/instanceOf/is(X.class))

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -74,6 +74,11 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         private static final MethodMatcher EXPECTED_MESSAGE_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expectMessage(org.hamcrest.Matcher)");
         private static final MethodMatcher EXPECTED_EXCEPTION_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expect(org.hamcrest.Matcher)");
         private static final MethodMatcher EXPECTED_EXCEPTION_CAUSE_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expectCause(org.hamcrest.Matcher)");
+        // *Matchers wildcard: isA/instanceOf/is are all reachable from both CoreMatchers and the consolidated Matchers.
+        private static final MethodMatcher IS_A_MATCHER = new MethodMatcher("org.hamcrest.*Matchers isA(java.lang.Class)");
+        private static final MethodMatcher INSTANCE_OF_MATCHER = new MethodMatcher("org.hamcrest.*Matchers instanceOf(java.lang.Class)");
+        private static final MethodMatcher IS_MATCHER_CORE_MATCHERS = new MethodMatcher("org.hamcrest.*Matchers is(..)");
+        private static final MethodMatcher IS_MATCHER_CORE_IS = new MethodMatcher("org.hamcrest.core.Is is(..)");
 
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
@@ -196,14 +201,20 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     null);
             b = b.withStatements(ListUtils.map(b.getStatements(), statement -> {
                 if (statement instanceof J.MethodInvocation) {
-                    if (EXPECTED_EXCEPTION_ALL_MATCHER.matches((J.MethodInvocation) statement)) {
+                    J.MethodInvocation invocation = (J.MethodInvocation) statement;
+                    if (EXPECTED_EXCEPTION_ALL_MATCHER.matches(invocation)) {
                         removeStatement.set(true);
-                        return getExpectExceptionTemplate((J.MethodInvocation) statement, ctx)
+                        Optional<Statement> instanceOfAssertion = maybeAssertInstanceOfForCause(
+                                invocation, ctx, new Cursor(updateCursor, statement), exceptionIdentifier);
+                        if (instanceOfAssertion.isPresent()) {
+                            return instanceOfAssertion.get();
+                        }
+                        return getExpectExceptionTemplate(invocation, ctx)
                                 .<J.MethodInvocation>map(t -> t.apply(
                                         new Cursor(updateCursor, statement),
                                         statement.getCoordinates().replace(),
                                         exceptionIdentifier,
-                                        ((J.MethodInvocation) statement).getArguments().get(0)))
+                                        invocation.getArguments().get(0)))
                                 .orElse(null);
                     }
                 }
@@ -307,6 +318,54 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "hamcrest-3"))
                     .staticImports("org.hamcrest.MatcherAssert.assertThat", "org.hamcrest.CoreMatchers.containsString")
                     .build());
+        }
+
+        // expectCause(isA/instanceOf/is(X.class)) becomes the type-safe assertInstanceOf(X.class, exception.getCause()).
+        private Optional<Statement> maybeAssertInstanceOfForCause(
+                J.MethodInvocation invocation, ExecutionContext ctx, Cursor cursor, J.Identifier exceptionIdentifier) {
+            if (!EXPECTED_EXCEPTION_CAUSE_MATCHER.matches(invocation)) {
+                return Optional.empty();
+            }
+            Expression matcherArg = invocation.getArguments().get(0);
+            if (!(matcherArg instanceof J.MethodInvocation)) {
+                return Optional.empty();
+            }
+            Expression classArg = extractClassLiteralFromInstanceOfMatcher((J.MethodInvocation) matcherArg);
+            if (classArg == null) {
+                return Optional.empty();
+            }
+            maybeRemoveImport("org.hamcrest.Matchers.isA");
+            maybeRemoveImport("org.hamcrest.CoreMatchers.isA");
+            maybeRemoveImport("org.hamcrest.Matchers.instanceOf");
+            maybeRemoveImport("org.hamcrest.CoreMatchers.instanceOf");
+            maybeRemoveImport("org.hamcrest.Matchers.is");
+            maybeRemoveImport("org.hamcrest.CoreMatchers.is");
+            maybeRemoveImport("org.hamcrest.core.Is.is");
+            maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
+            return Optional.of(JavaTemplate.builder("assertInstanceOf(#{any()}, #{any(java.lang.Throwable)}.getCause())")
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
+                    .staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf")
+                    .build()
+                    .apply(cursor, invocation.getCoordinates().replace(), classArg, exceptionIdentifier));
+        }
+
+        // Only is(X.class) is treated as an instanceof check, to avoid false positives on is("string") or is(someVariable).
+        private Expression extractClassLiteralFromInstanceOfMatcher(J.MethodInvocation matcherCall) {
+            if (matcherCall.getArguments().isEmpty()) {
+                return null;
+            }
+            Expression arg = matcherCall.getArguments().get(0);
+            if (IS_A_MATCHER.matches(matcherCall) || INSTANCE_OF_MATCHER.matches(matcherCall)) {
+                return arg;
+            }
+            if (isHamcrestIs(matcherCall) && arg instanceof J.FieldAccess && "class".equals(((J.FieldAccess) arg).getName().getSimpleName())) {
+                return arg;
+            }
+            return null;
+        }
+
+        private boolean isHamcrestIs(J.MethodInvocation method) {
+            return IS_MATCHER_CORE_MATCHERS.matches(method) || IS_MATCHER_CORE_IS.matches(method);
         }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -375,6 +375,181 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void refactorExpectCauseWithIsAMatcherToAssertInstanceOf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import org.junit.Rule;
+              import org.junit.rules.ExpectedException;
+
+              import static org.hamcrest.Matchers.isA;
+
+              public class ExampleTests {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  public void expectCause() {
+                      this.thrown.expectCause(isA(IllegalStateException.class));
+                      throw new RuntimeException(new IllegalStateException());
+                  }
+              }
+              """,
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class ExampleTests {
+
+                  public void expectCause() {
+                      Throwable exception = assertThrows(Exception.class, () -> {
+                          throw new RuntimeException(new IllegalStateException());
+                      });
+                      assertInstanceOf(IllegalStateException.class, exception.getCause());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void refactorExpectCauseWithInstanceOfMatcherToAssertInstanceOf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import org.junit.Rule;
+              import org.junit.rules.ExpectedException;
+
+              import static org.hamcrest.Matchers.instanceOf;
+
+              public class ExampleTests {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  public void expectCause() {
+                      this.thrown.expectCause(instanceOf(IllegalStateException.class));
+                      throw new RuntimeException(new IllegalStateException());
+                  }
+              }
+              """,
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class ExampleTests {
+
+                  public void expectCause() {
+                      Throwable exception = assertThrows(Exception.class, () -> {
+                          throw new RuntimeException(new IllegalStateException());
+                      });
+                      assertInstanceOf(IllegalStateException.class, exception.getCause());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void refactorExpectCauseWithIsClassMatcherToAssertInstanceOf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import org.junit.Rule;
+              import org.junit.rules.ExpectedException;
+
+              import static org.hamcrest.CoreMatchers.is;
+
+              public class ExampleTests {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  public void expectCause() {
+                      this.thrown.expectCause(is(IllegalStateException.class));
+                      throw new RuntimeException(new IllegalStateException());
+                  }
+              }
+              """,
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class ExampleTests {
+
+                  public void expectCause() {
+                      Throwable exception = assertThrows(Exception.class, () -> {
+                          throw new RuntimeException(new IllegalStateException());
+                      });
+                      assertInstanceOf(IllegalStateException.class, exception.getCause());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void expectCauseWithIsMatcherDecoratorIsNotTreatedAsInstanceOfCheck() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import org.junit.Rule;
+              import org.junit.rules.ExpectedException;
+
+              import static org.hamcrest.CoreMatchers.is;
+              import static org.hamcrest.Matchers.nullValue;
+
+              public class ExampleTests {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  public void expectCause() {
+                      this.thrown.expectCause(is(nullValue()));
+                      throw new RuntimeException();
+                  }
+              }
+              """,
+            """
+              package org.openrewrite.java.testing.junit5;
+
+              import static org.hamcrest.CoreMatchers.is;
+              import static org.hamcrest.MatcherAssert.assertThat;
+              import static org.hamcrest.Matchers.nullValue;
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class ExampleTests {
+
+                  public void expectCause() {
+                      Throwable exception = assertThrows(Exception.class, () -> {
+                          throw new RuntimeException();
+                      });
+                      assertThat(exception.getCause(), is(nullValue()));
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/72")
     @Test
     void refactorExpectException() {


### PR DESCRIPTION
## What's changed?                                                                                                                                                                 
                                                                                                                                                                                     
  `ExpectedExceptionToAssertThrows` now special-cases `expectCause(isA(X.class))`, `expectCause(instanceOf(X.class))`, and `expectCause(is(X.class))`, emitting the type-safe        
  `assertInstanceOf(X.class, exception.getCause())` instead of the type-unsafe `assertThat(exception.getCause(), isA(X.class))`.                                                     
                                                                                                                                                                                     
  This mirrors the existing `HamcrestInstanceOfToJUnit5` recipe's treatment of `instanceOf`/`isA` matchers, applied to this recipe's `expectCause(...)` handling specifically.       
                                                                                                                                                                                     
  **Key changes:**                                                                                                                                                                   
  - Added `IS_A_MATCHER`, `INSTANCE_OF_MATCHER`, `IS_MATCHER_CORE_MATCHERS`, `IS_MATCHER_CORE_IS` method matchers (using the `org.hamcrest.*Matchers` wildcard, since                
  `isA`/`instanceOf`/`is` are reachable from both `CoreMatchers` and the consolidated `Matchers`)                                                                                    
  - Added `maybeAssertInstanceOfForCause()` to build the `assertInstanceOf(...)` replacement when the matcher argument is a class literal                                            
  - Added `extractClassLiteralFromInstanceOfMatcher()` — `is(X.class)` is only treated as an instanceof check when its argument is a class literal, to avoid false positives on      
  `is("string")` or `is(someOtherMatcher)`                                                                                                                                           
                                                                                                                                                                                     
  ## What's your motivation?                                                                                                                                                         
                                                                                                                                                                                     
  `assertThat(exception.getCause(), isA(X.class))` doesn't give compile-time type safety and reads less directly than `assertInstanceOf(X.class, exception.getCause())`, which is    
  also what JUnit 5 recommends for this exact pattern.                                                                                                                               
                                                                                                                                                                                     
  ## Anything in particular you'd like reviewers to focus on?                                                                                                                        
                                                                                                                                                                                     
  The `is(X.class)` special-casing — `is()` is overloaded between an equality matcher and a `Matcher<T>` decorator, so I only treat it as an instanceof check when the argument is   
  literally a class literal (`J.FieldAccess` ending in `.class`), not a variable or nested matcher.                                                                                  
                                                                                                                                                                                     
  ### Checklist                                                                                                                                                                      
  - [x] I've added unit tests to cover both positive and negative cases                                                                                                              
  - [x] I've read and applied the recipe conventions and best practices                                                                                                              
  - [x] I've used the IntelliJ IDEA auto-formatter on affected files        