### PR TITLE
Add a blank line after the `mocks` field generated in Kotlin sources

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/ReplaceInitMockToOpenMock.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/ReplaceInitMockToOpenMock.java
@@ -72,8 +72,10 @@ public class ReplaceInitMockToOpenMock extends Recipe {
                             variableName = generateVariableName("mocks", getCursor(), INCREMENT_NUMBER);
                             if (getCursor().firstEnclosing(K.CompilationUnit.class) != null) {
                                 // Do not autoformat the whole class, as the Kotlin formatter would reformat unrelated code
-                                return KotlinTemplate.apply("private lateinit var " + variableName + ": AutoCloseable",
+                                J.ClassDeclaration after = KotlinTemplate.apply("private lateinit var " + variableName + ": AutoCloseable",
                                         getCursor(), cd.getBody().getCoordinates().firstStatement());
+                                return after.withBody(after.getBody().withStatements(ListUtils.map(after.getBody().getStatements(),
+                                        (i, stmt) -> i == 1 ? withBlankLineBefore(stmt) : stmt)));
                             }
                             J.ClassDeclaration after = JavaTemplate.apply("private AutoCloseable " + variableName + ";",
                                     getCursor(), cd.getBody().getCoordinates().firstStatement());
@@ -122,9 +124,8 @@ public class ReplaceInitMockToOpenMock extends Recipe {
                                             .build()
                                             .apply(getCursor(), cd.getBody().getCoordinates().lastStatement());
                                     // Blank line before the added method; the class is not autoformatted as a whole
-                                    cd = cd.withBody(cd.getBody().withStatements(ListUtils.mapLast(cd.getBody().getStatements(),
-                                            stmt -> stmt.getPrefix().getWhitespace().startsWith("\n\n") ? stmt :
-                                                    stmt.withPrefix(stmt.getPrefix().withWhitespace("\n" + stmt.getPrefix().getWhitespace())))));
+                                    cd = cd.withBody(cd.getBody().withStatements(
+                                            ListUtils.mapLast(cd.getBody().getStatements(), stm -> withBlankLineBefore(stm))));
                                 } else {
                                     cd = JavaTemplate.builder("@AfterEach\nvoid " + tearDownMethodName(cd) + "() throws Exception {\n}")
                                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5"))
@@ -239,6 +240,12 @@ public class ReplaceInitMockToOpenMock extends Recipe {
                             return updatedMethodName;
                         }
                     };
+
+            private Statement withBlankLineBefore(Statement stmt) {
+                Space prefix = stmt.getPrefix();
+                return prefix.getWhitespace().startsWith("\n\n") ? stmt :
+                        stmt.withPrefix(prefix.withWhitespace("\n" + prefix.getWhitespace()));
+            }
                 }
         );
     }

--- a/src/test/java/org/openrewrite/java/testing/mockito/ReplaceInitMockToOpenMockTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/ReplaceInitMockToOpenMockTest.java
@@ -677,6 +677,78 @@ class ReplaceInitMockToOpenMockTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2831")
+    @Test
+    void kotlinNestedInnerClassBacktickNamesAndExtensionFunctions() {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder()
+            .classpathFromResources(new InMemoryExecutionContext(), "junit-jupiter-api-5", "mockito-core")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.junit.jupiter.api.BeforeEach
+              import org.junit.jupiter.api.Nested
+              import org.junit.jupiter.api.Test
+              import org.mockito.Mock
+              import org.mockito.MockitoAnnotations
+
+              class MyServiceTest {
+                  @Mock
+                  private lateinit var myService: String
+
+                  @BeforeEach
+                  fun setUp() {
+                      MockitoAnnotations.initMocks(this)
+                  }
+
+                  @Nested
+                  inner class WhenServiceIsCalled {
+                      @Test
+                      fun `returns a value`() {
+                      }
+                  }
+
+                  private fun String.twice() = this + this
+              }
+              """,
+            """
+              import org.junit.jupiter.api.AfterEach
+              import org.junit.jupiter.api.BeforeEach
+              import org.junit.jupiter.api.Nested
+              import org.junit.jupiter.api.Test
+              import org.mockito.Mock
+              import org.mockito.MockitoAnnotations
+
+              class MyServiceTest {
+                  private lateinit var mocks: AutoCloseable
+
+                  @Mock
+                  private lateinit var myService: String
+
+                  @BeforeEach
+                  fun setUp() {
+                      mocks = MockitoAnnotations.openMocks(this)
+                  }
+
+                  @Nested
+                  inner class WhenServiceIsCalled {
+                      @Test
+                      fun `returns a value`() {
+                      }
+                  }
+
+                  private fun String.twice() = this + this
+
+                  @AfterEach
+                  fun tearDown() {
+                      mocks.close()
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void noChangesWithJunit4() {
         rewriteRun(


### PR DESCRIPTION
- Follow-up to #1055 for moderneinc/customer-requests#2831.

- `ReplaceInitMockToOpenMock` deliberately skips class-wide autoformatting on Kotlin
  sources, since the Kotlin formatter would reformat unrelated code. Spacing around
  generated members therefore has to be set by hand, which was done for the generated
  `@AfterEach` method but not for the generated field — so the field was glued to
  whatever followed it whenever the class body did not already open with a blank line.
  That prefix handling is now a shared helper applied to both insertion sites.

```diff
 class MyServiceTest {
     private lateinit var mocks: AutoCloseable
+
     @Mock
     private lateinit var myService: String
```

- Adds a Kotlin regression test for the constructs named in the original report —
  `inner class`, backtick method names and extension functions — which the existing
  Kotlin tests did not exercise.

- The `IllegalArgumentException: Could not parse as Java` reported in #2831 was already
- resolved by #1055, which made the recipe branch to `KotlinTemplate`. Verified against
the source from that report: the recipe completes without error, emits no `Markup.Error`,
and produces only the intended changes.
