### PR TITLE
Make subpackage recursion explicit in the JavaFaker and Fest renames

### DIFF
--- a/src/main/resources/META-INF/rewrite/assertj.yml
+++ b/src/main/resources/META-INF/rewrite/assertj.yml
@@ -581,6 +581,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.fest.assertions.api
       newPackageName: org.assertj.core.api
+      recursive: true
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.fest.assertions.core.Condition
       newFullyQualifiedTypeName: org.assertj.core.api.Condition

--- a/src/main/resources/META-INF/rewrite/datafaker.yml
+++ b/src/main/resources/META-INF/rewrite/datafaker.yml
@@ -34,6 +34,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: com.github.javafaker
       newPackageName: net.datafaker
+      recursive: true
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.github.javafaker
       oldArtifactId: javafaker

--- a/src/test/java/org/openrewrite/java/testing/assertj/FestToAssertJTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/FestToAssertJTest.java
@@ -211,4 +211,25 @@ class FestToAssertJTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void typeInSubpackage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.fest.assertions.api.filter.Filters;
+              class A {
+                  Class<?> type = Filters.class;
+              }
+              """,
+            """
+              import org.assertj.core.api.filter.Filters;
+              class A {
+                  Class<?> type = Filters.class;
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/datafaker/JavaFakerToDataFakerTest.java
+++ b/src/test/java/org/openrewrite/java/testing/datafaker/JavaFakerToDataFakerTest.java
@@ -66,4 +66,25 @@ class JavaFakerToDataFakerTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void typeInSubpackage() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.github.javafaker.service.RandomService;
+              class A {
+                  RandomService random = new RandomService();
+              }
+              """,
+            """
+              import net.datafaker.service.RandomService;
+              class A {
+                  RandomService random = new RandomService();
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Two `ChangePackage` rules omit `recursive` while depending on it, so types in subpackages of `oldPackageName` were never migrated.

I verified this against the published artifacts rather than guessing — every subpackage maps exactly under prefix substitution, so recursion is both safe and required:

**`datafaker.yml`** — javafaker 1.0.2 → datafaker 2.4.2

| old | new |
| --- | --- |
| `com.github.javafaker.idnumbers` | `net.datafaker.idnumbers` |
| `com.github.javafaker.service` | `net.datafaker.service` |
| `com.github.javafaker.service.files` | `net.datafaker.service.files` |

**`assertj.yml`** — fest-assert-core 2.0M10 → assertj-core 3.26.3

| old | new |
| --- | --- |
| `org.fest.assertions.api.filter` | `org.assertj.core.api.filter` |

The sibling `org.fest.assertions.util` and `org.fest.assertions.data` rules are left alone — neither package has subpackages.

## Why the tests didn't catch this

`ChangePackage.recursive` is `@Nullable` with `required = false` and no documented default, and a null was read **two different ways inside the same recipe**: non-recursive by its preconditions, recursive by its visitor. The upshot is that a subpackage type gets renamed only if the file *also* references a type sitting directly in `oldPackageName` — which every existing fixture happens to do. A real source file importing only the subpackage type was never migrated.

- So this is a latent bug being fixed, not a test fixup. openrewrite/rewrite#8382 settles null as non-recursive, which is what surfaced it; I found this while auditing declarative `ChangePackage` usages against the published artifacts.

## Verification

- Full `./gradlew test` green. Each new test fails without the `recursive: true` line and passes with it. Correct on its own merits and safe to merge now, independently of rewrite#8382.
