### PR TITLE
ExpectedExceptionToAssertThrows: inline single-use reassigned locals 

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -88,25 +88,26 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-            doAfterVisit(new LambdaBlockToExpression().getVisitor());
 
             // A method that could not be migrated still needs the rule, so leave the field and its imports in place.
-            if (getCursor().getMessage(CANNOT_MIGRATE) != null) {
-                return cd;
+            if (getCursor().getMessage(CANNOT_MIGRATE) == null) {
+                cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
+                    if (statement instanceof J.VariableDeclarations) {
+                        //noinspection ConstantConditions
+                        if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
+                                "org.junit.rules.ExpectedException")) {
+                            maybeRemoveImport("org.junit.Rule");
+                            maybeRemoveImport("org.junit.rules.ExpectedException");
+                            return null;
+                        }
+                    }
+                    return statement;
+                })));
             }
 
-            cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
-                if (statement instanceof J.VariableDeclarations) {
-                    //noinspection ConstantConditions
-                    if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
-                            "org.junit.rules.ExpectedException")) {
-                        maybeRemoveImport("org.junit.Rule");
-                        maybeRemoveImport("org.junit.rules.ExpectedException");
-                        return null;
-                    }
-                }
-                return statement;
-            })));
+            if (cd != classDecl) {
+                doAfterVisit(new LambdaBlockToExpression().getVisitor());
+            }
             return cd;
         }
 
@@ -391,7 +392,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     boolean selfReferencing = countReferences(rhs, local) > 0;
                     boolean reassignedOnce = countAssignments(statements.subList(0, expectIndex), local) == 1;
                     boolean touchedBetween = countReferences(between, local) > 0;
-                    if (selfReferencing || !reassignedOnce || touchedBetween || !safeToDefer(rhs, between)) {
+                    if (selfReferencing || !reassignedOnce || touchedBetween) {
                         continue;
                     }
                     J.Block updated = inlineAtSingleUse(block, statements, i, expectIndex, local, rhs);
@@ -488,12 +489,14 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         }
 
         /**
-         * Inlining moves the right hand side past the statements between the assignment and expect*(),
-         * so only defer values those statements can not change: literals and local variables that are
-         * not themselves reassigned in between, without any side effects of their own.
+         * Inlining moves the right hand side past every statement between the assignment and the use
+         * site it is spliced into -- both those before expect*() and those that end up ahead of it in
+         * the assertThrows(...) lambda -- so only defer values those statements can not change:
+         * literals and local variables that are not themselves reassigned, without side effects of
+         * their own.
          */
-        private static boolean safeToDefer(Expression rhs, List<Statement> between) {
-            if (between.isEmpty()) {
+        private static boolean safeToDefer(Expression rhs, List<Statement> deferredOver) {
+            if (deferredOver.isEmpty()) {
                 return true;
             }
             return new JavaIsoVisitor<AtomicBoolean>() {
@@ -540,7 +543,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean acc) {
                     JavaType.Variable fieldType = identifier.getFieldType();
                     if (fieldType != null &&
-                            (!(fieldType.getOwner() instanceof JavaType.Method) || countAssignments(between, fieldType) > 0)) {
+                            (!(fieldType.getOwner() instanceof JavaType.Method) || countAssignments(deferredOver, fieldType) > 0)) {
                         acc.set(false);
                     }
                     return identifier;
@@ -566,6 +569,12 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 }
             }
             if (uses != 1) {
+                return null;
+            }
+            // expect*() itself is replaced by assertThrows(...) at the same point, so it is not deferred over.
+            if (!safeToDefer(rhs, ListUtils.concatAll(
+                    statements.subList(assignmentIndex + 1, expectIndex),
+                    statements.subList(expectIndex + 1, afterIndex)))) {
                 return null;
             }
             Statement rewritten = inlineReferenceInStatement(statements.get(afterIndex), variable, rhs);
@@ -644,7 +653,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         }
 
         // Only is(X.class) is treated as an instanceof check, to avoid false positives on is("string") or is(someVariable).
-        private Expression extractClassLiteralFromInstanceOfMatcher(J.MethodInvocation matcherCall) {
+        private @Nullable Expression extractClassLiteralFromInstanceOfMatcher(J.MethodInvocation matcherCall) {
             if (matcherCall.getArguments().isEmpty()) {
                 return null;
             }

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -71,6 +71,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         private static final String STATEMENTS_AFTER_EXPECT_EXCEPTION = "statementsAfterExpectException";
         private static final String HAS_MATCHER = "hasMatcher";
         private static final String EXCEPTION_CLASS = "exceptionClass";
+        private static final String CANNOT_MIGRATE = "cannotMigrate";
 
         private static final MethodMatcher EXPECTED_EXCEPTION_ALL_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expect*(..)");
         private static final MethodMatcher EXPECTED_EXCEPTION_CLASS_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expect(java.lang.Class)");
@@ -87,6 +88,12 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+            doAfterVisit(new LambdaBlockToExpression().getVisitor());
+
+            // A method that could not be migrated still needs the rule, so leave the field and its imports in place.
+            if (getCursor().getMessage(CANNOT_MIGRATE) != null) {
+                return cd;
+            }
 
             cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
                 if (statement instanceof J.VariableDeclarations) {
@@ -100,13 +107,15 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 }
                 return statement;
             })));
-            doAfterVisit(new LambdaBlockToExpression().getVisitor());
             return cd;
         }
 
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+            if (getCursor().getMessage(CANNOT_MIGRATE) != null) {
+                return m;
+            }
             if (getCursor().pollMessage("hasExpectException") != null) {
                 List<NameTree> thrown = m.getThrows();
                 if (thrown != null && !thrown.isEmpty()) {
@@ -172,6 +181,11 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             List<Statement> statementsAfterExpectException = getCursor().pollMessage(STATEMENTS_AFTER_EXPECT_EXCEPTION);
             if (statementsAfterExpectException == null) {
                 return b;
+            }
+            if (capturesNonEffectivelyFinalLocal(statementsAfterExpectException, getCursor())) {
+                getCursor().putMessageOnFirstEnclosing(J.MethodDeclaration.class, CANNOT_MIGRATE, true);
+                getCursor().putMessageOnFirstEnclosing(J.ClassDeclaration.class, CANNOT_MIGRATE, true);
+                return block;
             }
             J.Block statementsAfterExpectExceptionBlock = new J.Block(randomId(), Space.EMPTY,
                     Markers.EMPTY, new JRightPadded<>(false, Space.EMPTY, Markers.EMPTY),
@@ -303,6 +317,50 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 cursor = cursor.getParentTreeCursor();
             }
             return successorStatements;
+        }
+
+        /**
+         * The statements moving into the assertThrows(...) lambda may only capture effectively final
+         * locals, so a local they read that is assigned anywhere in the method -- before expect*(), or
+         * by the moved statements themselves -- means the migration would not compile. Inlining removes
+         * the read for the shapes it handles; anything left is reported here so the method is left alone
+         * rather than rewritten into a lambda javac rejects.
+         */
+        private static boolean capturesNonEffectivelyFinalLocal(List<Statement> moved, Cursor cursor) {
+            J.MethodDeclaration method = cursor.firstEnclosing(J.MethodDeclaration.class);
+            if (method == null) {
+                return false;
+            }
+            List<JavaType.Variable> declaredInMoved = new ArrayList<>();
+            List<JavaType.Variable> capturedLocals = new ArrayList<>();
+            JavaIsoVisitor<Integer> collector = new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer p) {
+                    if (variable.getVariableType() != null) {
+                        declaredInMoved.add(variable.getVariableType());
+                    }
+                    return super.visitVariable(variable, p);
+                }
+
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                    JavaType.Variable fieldType = identifier.getFieldType();
+                    if (fieldType != null && fieldType.getOwner() instanceof JavaType.Method) {
+                        capturedLocals.add(fieldType);
+                    }
+                    return super.visitIdentifier(identifier, p);
+                }
+            };
+            for (Statement statement : moved) {
+                collector.visit(statement, 0);
+            }
+            for (JavaType.Variable local : capturedLocals) {
+                boolean declaredInLambda = declaredInMoved.stream().anyMatch(declared -> TypeUtils.isOfType(declared, local));
+                if (!declaredInLambda && countAssignments(method, local) > 0) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /**

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -24,6 +24,7 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.ParenthesizeVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
@@ -373,8 +374,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         }
 
         private static int countAssignments(J tree, JavaType.Variable variable) {
-            AtomicInteger count = new AtomicInteger();
-            new JavaIsoVisitor<AtomicInteger>() {
+            return new JavaIsoVisitor<AtomicInteger>() {
                 @Override
                 public J.Assignment visitAssignment(J.Assignment assignment, AtomicInteger acc) {
                     if (isReferenceTo(assignment.getVariable(), variable)) {
@@ -398,8 +398,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     }
                     return super.visitUnary(unary, acc);
                 }
-            }.visit(tree, count);
-            return count.get();
+            }.reduce(tree, new AtomicInteger()).get();
         }
 
         private static int countAssignments(List<? extends J> trees, JavaType.Variable variable) {
@@ -411,8 +410,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         }
 
         private static int countReferences(J tree, JavaType.Variable variable) {
-            AtomicInteger count = new AtomicInteger();
-            new JavaIsoVisitor<AtomicInteger>() {
+            return new JavaIsoVisitor<AtomicInteger>() {
                 @Override
                 public J.Identifier visitIdentifier(J.Identifier identifier, AtomicInteger acc) {
                     if (isReferenceTo(identifier, variable)) {
@@ -420,8 +418,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     }
                     return super.visitIdentifier(identifier, acc);
                 }
-            }.visit(tree, count);
-            return count.get();
+            }.reduce(tree, new AtomicInteger()).get();
         }
 
         private static int countReferences(List<? extends J> trees, JavaType.Variable variable) {
@@ -441,8 +438,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             if (between.isEmpty()) {
                 return true;
             }
-            AtomicBoolean safe = new AtomicBoolean(true);
-            new JavaIsoVisitor<AtomicBoolean>() {
+            return new JavaIsoVisitor<AtomicBoolean>() {
                 @Override
                 public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean acc) {
                     acc.set(false);
@@ -491,8 +487,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                     }
                     return identifier;
                 }
-            }.visit(rhs, safe);
-            return safe.get();
+            }.reduce(rhs, new AtomicBoolean(true)).get();
         }
 
         // Deletes the reassignment at statements[assignmentIndex] and splices its RHS in place of
@@ -516,9 +511,6 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 return null;
             }
             Statement rewritten = inlineReferenceInStatement(statements.get(afterIndex), variable, rhs);
-            if (rewritten == null) {
-                return null;
-            }
             int finalAfterIndex = afterIndex;
             return block.withStatements(ListUtils.map(statements, (i, s) -> {
                 if (i == assignmentIndex) {
@@ -529,50 +521,18 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         }
 
         // Replaces the sole reference to `variable` in `statement` with `replacement`.
-        private static @Nullable Statement inlineReferenceInStatement(Statement statement, JavaType.Variable variable,
+        private static Statement inlineReferenceInStatement(Statement statement, JavaType.Variable variable,
                 Expression replacement) {
-            AtomicBoolean done = new AtomicBoolean(false);
-            J result = new JavaVisitor<AtomicBoolean>() {
+            return (Statement) new JavaVisitor<Integer>() {
                 @Override
-                public J visitIdentifier(J.Identifier identifier, AtomicBoolean acc) {
-                    if (acc.get() || !isReferenceTo(identifier, variable)) {
+                public J visitIdentifier(J.Identifier identifier, Integer p) {
+                    if (!isReferenceTo(identifier, variable)) {
                         return identifier;
                     }
-                    acc.set(true);
-                    Expression inlined = replacement.withPrefix(Space.EMPTY);
-                    if (needsParentheses(identifier, replacement, getCursor())) {
-                        inlined = new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
-                                new JRightPadded<>(inlined, Space.EMPTY, Markers.EMPTY));
-                    }
-                    return inlined.withPrefix(identifier.getPrefix());
+                    return ParenthesizeVisitor.maybeParenthesize(replacement.withPrefix(Space.EMPTY), getCursor())
+                            .withPrefix(identifier.getPrefix());
                 }
-            }.visit(statement, done);
-            return done.get() ? (Statement) result : null;
-        }
-
-        private static boolean needsParentheses(J.Identifier identifier, Expression replacement, Cursor cursor) {
-            if (!(replacement instanceof J.Binary || replacement instanceof J.Ternary ||
-                    replacement instanceof J.InstanceOf || replacement instanceof J.TypeCast ||
-                    replacement instanceof J.Lambda || replacement instanceof J.Assignment ||
-                    replacement instanceof J.AssignmentOperation)) {
-                return false;
-            }
-            Object parent = cursor.getParentTreeCursor().getValue();
-            if (parent instanceof J.MethodInvocation) {
-                return isSameElement(((J.MethodInvocation) parent).getSelect(), identifier);
-            }
-            if (parent instanceof J.FieldAccess) {
-                return isSameElement(((J.FieldAccess) parent).getTarget(), identifier);
-            }
-            if (parent instanceof J.ArrayAccess) {
-                return isSameElement(((J.ArrayAccess) parent).getIndexed(), identifier);
-            }
-            return parent instanceof J.Binary || parent instanceof J.Unary || parent instanceof J.TypeCast ||
-                    parent instanceof J.InstanceOf || parent instanceof J.Ternary || parent instanceof J.MemberReference;
-        }
-
-        private static boolean isSameElement(@Nullable J maybeElement, J element) {
-            return maybeElement != null && maybeElement.getId().equals(element.getId());
+            }.visit(statement, 0);
         }
 
         private Optional<JavaTemplate> getExpectExceptionTemplate(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.staticanalysis.LambdaBlockToExpression;
+import org.openrewrite.trait.Comments;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +73,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         private static final String HAS_MATCHER = "hasMatcher";
         private static final String EXCEPTION_CLASS = "exceptionClass";
         private static final String CANNOT_MIGRATE = "cannotMigrate";
+        private static final String CANNOT_MIGRATE_COMMENT = " TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.";
 
         private static final MethodMatcher EXPECTED_EXCEPTION_ALL_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expect*(..)");
         private static final MethodMatcher EXPECTED_EXCEPTION_CLASS_MATCHER = new MethodMatcher("org.junit.rules.ExpectedException expect(java.lang.Class)");
@@ -88,27 +90,34 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
         @Override
         public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
             J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-
-            // A method that could not be migrated still needs the rule, so leave the field and its imports in place.
-            if (getCursor().getMessage(CANNOT_MIGRATE) == null) {
-                cd = cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
-                    if (statement instanceof J.VariableDeclarations) {
-                        //noinspection ConstantConditions
-                        if (TypeUtils.isOfClassType(((J.VariableDeclarations) statement).getTypeExpression().getType(),
-                                "org.junit.rules.ExpectedException")) {
-                            maybeRemoveImport("org.junit.Rule");
-                            maybeRemoveImport("org.junit.rules.ExpectedException");
-                            return null;
-                        }
-                    }
-                    return statement;
-                })));
-            }
-
+            // Only a migrated method can have produced the lambda that needs collapsing.
             if (cd != classDecl) {
                 doAfterVisit(new LambdaBlockToExpression().getVisitor());
             }
-            return cd;
+
+            // A method that could not be migrated still needs the rule, so leave the field and its imports in place.
+            boolean cannotMigrate = getCursor().getMessage(CANNOT_MIGRATE) != null;
+            Cursor bodyCursor = new Cursor(getCursor(), cd.getBody());
+            return cd.withBody(cd.getBody().withStatements(ListUtils.map(cd.getBody().getStatements(), statement -> {
+                if (!isExpectedExceptionField(statement)) {
+                    return statement;
+                }
+                if (cannotMigrate) {
+                    return Comments.of(new Cursor(bodyCursor, statement)).comment(CANNOT_MIGRATE_COMMENT);
+                }
+                maybeRemoveImport("org.junit.Rule");
+                maybeRemoveImport("org.junit.rules.ExpectedException");
+                return null;
+            })));
+        }
+
+        private static boolean isExpectedExceptionField(Statement statement) {
+            if (!(statement instanceof J.VariableDeclarations)) {
+                return false;
+            }
+            TypeTree typeExpression = ((J.VariableDeclarations) statement).getTypeExpression();
+            return typeExpression != null &&
+                    TypeUtils.isOfClassType(typeExpression.getType(), "org.junit.rules.ExpectedException");
         }
 
         @Override

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -309,7 +310,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
          * the assertThrows(...) lambda -- inline the RHS at that use site instead of leaving a
          * non-effectively-final capture. Chains and multi-use reads are left untouched.
          */
-        private J.Block inlineSingleUseReassignedLocals(J.Block block) {
+        private static J.Block inlineSingleUseReassignedLocals(J.Block block) {
             for (boolean changed = true; changed; ) {
                 changed = false;
                 List<Statement> statements = block.getStatements();
@@ -322,18 +323,19 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                         continue;
                     }
                     J.Assignment assignment = (J.Assignment) statements.get(i);
-                    if (!(assignment.getVariable() instanceof J.Identifier)) {
+                    JavaType.Variable local = localVariable(assignment.getVariable());
+                    if (local == null) {
                         continue;
                     }
-                    String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
                     Expression rhs = assignment.getAssignment();
-                    boolean selfReferencing = countIdentifier(rhs, name) > 0;
-                    boolean reassignedOnce = countAssignmentsTo(statements.subList(0, expectIndex), name) == 1;
-                    boolean readBetween = countIdentifier(statements.subList(i + 1, expectIndex), name) > 0;
-                    if (selfReferencing || !reassignedOnce || readBetween) {
+                    List<Statement> between = statements.subList(i + 1, expectIndex);
+                    boolean selfReferencing = countReferences(rhs, local) > 0;
+                    boolean reassignedOnce = countAssignments(statements.subList(0, expectIndex), local) == 1;
+                    boolean touchedBetween = countReferences(between, local) > 0;
+                    if (selfReferencing || !reassignedOnce || touchedBetween || !safeToDefer(rhs, between)) {
                         continue;
                     }
-                    J.Block updated = inlineAtSingleUse(block, statements, i, expectIndex, name, rhs);
+                    J.Block updated = inlineAtSingleUse(block, statements, i, expectIndex, local, rhs);
                     if (updated != null) {
                         block = updated;
                         changed = true;
@@ -353,25 +355,67 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             return -1;
         }
 
-        private static int countAssignmentsTo(List<Statement> statements, String name) {
-            int count = 0;
-            for (Statement s : statements) {
-                if (s instanceof J.Assignment) {
-                    Expression target = ((J.Assignment) s).getVariable();
-                    if (target instanceof J.Identifier && name.equals(((J.Identifier) target).getSimpleName())) {
-                        count++;
-                    }
+        // Only local variables are inlined; a field assignment can be observed outside this method.
+        private static JavaType.@Nullable Variable localVariable(Expression target) {
+            if (target instanceof J.Identifier) {
+                JavaType.Variable fieldType = ((J.Identifier) target).getFieldType();
+                if (fieldType != null && fieldType.getOwner() instanceof JavaType.Method) {
+                    return fieldType;
                 }
             }
-            return count;
+            return null;
         }
 
-        private static int countIdentifier(J tree, String name) {
+        private static boolean isReferenceTo(@Nullable Expression expression, JavaType.Variable variable) {
+            return expression instanceof J.Identifier &&
+                    ((J.Identifier) expression).getFieldType() != null &&
+                    TypeUtils.isOfType(((J.Identifier) expression).getFieldType(), variable);
+        }
+
+        private static int countAssignments(J tree, JavaType.Variable variable) {
+            AtomicInteger count = new AtomicInteger();
+            new JavaIsoVisitor<AtomicInteger>() {
+                @Override
+                public J.Assignment visitAssignment(J.Assignment assignment, AtomicInteger acc) {
+                    if (isReferenceTo(assignment.getVariable(), variable)) {
+                        acc.incrementAndGet();
+                    }
+                    return super.visitAssignment(assignment, acc);
+                }
+
+                @Override
+                public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, AtomicInteger acc) {
+                    if (isReferenceTo(assignOp.getVariable(), variable)) {
+                        acc.incrementAndGet();
+                    }
+                    return super.visitAssignmentOperation(assignOp, acc);
+                }
+
+                @Override
+                public J.Unary visitUnary(J.Unary unary, AtomicInteger acc) {
+                    if (unary.getOperator().isModifying() && isReferenceTo(unary.getExpression(), variable)) {
+                        acc.incrementAndGet();
+                    }
+                    return super.visitUnary(unary, acc);
+                }
+            }.visit(tree, count);
+            return count.get();
+        }
+
+        private static int countAssignments(List<? extends J> trees, JavaType.Variable variable) {
+            int total = 0;
+            for (J tree : trees) {
+                total += countAssignments(tree, variable);
+            }
+            return total;
+        }
+
+        private static int countReferences(J tree, JavaType.Variable variable) {
             AtomicInteger count = new AtomicInteger();
             new JavaIsoVisitor<AtomicInteger>() {
                 @Override
                 public J.Identifier visitIdentifier(J.Identifier identifier, AtomicInteger acc) {
-                    if (name.equals(identifier.getSimpleName())) {
+                    if (isReferenceTo(identifier, variable)) {
                         acc.incrementAndGet();
                     }
                     return super.visitIdentifier(identifier, acc);
@@ -380,22 +424,89 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             return count.get();
         }
 
-        private static int countIdentifier(List<? extends J> trees, String name) {
+        private static int countReferences(List<? extends J> trees, JavaType.Variable variable) {
             int total = 0;
             for (J tree : trees) {
-                total += countIdentifier(tree, name);
+                total += countReferences(tree, variable);
             }
             return total;
         }
 
+        /**
+         * Inlining moves the right hand side past the statements between the assignment and expect*(),
+         * so only defer values those statements can not change: literals and local variables that are
+         * not themselves reassigned in between, without any side effects of their own.
+         */
+        private static boolean safeToDefer(Expression rhs, List<Statement> between) {
+            if (between.isEmpty()) {
+                return true;
+            }
+            AtomicBoolean safe = new AtomicBoolean(true);
+            new JavaIsoVisitor<AtomicBoolean>() {
+                @Override
+                public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, AtomicBoolean acc) {
+                    acc.set(false);
+                    return method;
+                }
+
+                @Override
+                public J.NewClass visitNewClass(J.NewClass newClass, AtomicBoolean acc) {
+                    acc.set(false);
+                    return newClass;
+                }
+
+                @Override
+                public J.ArrayAccess visitArrayAccess(J.ArrayAccess arrayAccess, AtomicBoolean acc) {
+                    acc.set(false);
+                    return arrayAccess;
+                }
+
+                @Override
+                public J.Assignment visitAssignment(J.Assignment assignment, AtomicBoolean acc) {
+                    acc.set(false);
+                    return assignment;
+                }
+
+                @Override
+                public J.AssignmentOperation visitAssignmentOperation(J.AssignmentOperation assignOp, AtomicBoolean acc) {
+                    acc.set(false);
+                    return assignOp;
+                }
+
+                @Override
+                public J.Unary visitUnary(J.Unary unary, AtomicBoolean acc) {
+                    if (unary.getOperator().isModifying()) {
+                        acc.set(false);
+                        return unary;
+                    }
+                    return super.visitUnary(unary, acc);
+                }
+
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean acc) {
+                    JavaType.Variable fieldType = identifier.getFieldType();
+                    if (fieldType != null &&
+                            (!(fieldType.getOwner() instanceof JavaType.Method) || countAssignments(between, fieldType) > 0)) {
+                        acc.set(false);
+                    }
+                    return identifier;
+                }
+            }.visit(rhs, safe);
+            return safe.get();
+        }
+
         // Deletes the reassignment at statements[assignmentIndex] and splices its RHS in place of
-        // the single successor statement referencing `name`; null if there isn't exactly one use.
-        private J.Block inlineAtSingleUse(J.Block block, List<Statement> statements, int assignmentIndex,
-                int expectIndex, String name, Expression rhs) {
+        // the single successor statement reading the variable; null if there isn't exactly one read.
+        private static J.@Nullable Block inlineAtSingleUse(J.Block block, List<Statement> statements, int assignmentIndex,
+                int expectIndex, JavaType.Variable variable, Expression rhs) {
             int afterIndex = -1;
             int uses = 0;
             for (int j = expectIndex + 1; j < statements.size(); j++) {
-                int hits = countIdentifier(statements.get(j), name);
+                Statement statement = statements.get(j);
+                if (countAssignments(statement, variable) > 0) {
+                    return null;
+                }
+                int hits = countReferences(statement, variable);
                 uses += hits;
                 if (hits > 0) {
                     afterIndex = j;
@@ -404,7 +515,7 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             if (uses != 1) {
                 return null;
             }
-            Statement rewritten = inlineIdentifierInStatement(getCursor(), statements.get(afterIndex), name, rhs);
+            Statement rewritten = inlineReferenceInStatement(statements.get(afterIndex), variable, rhs);
             if (rewritten == null) {
                 return null;
             }
@@ -417,26 +528,51 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
             }));
         }
 
-        // Replaces the sole occurrence of identifier `name` in `statement` with `replacement`.
-        private Statement inlineIdentifierInStatement(Cursor parentCursor, Statement statement, String name,
+        // Replaces the sole reference to `variable` in `statement` with `replacement`.
+        private static @Nullable Statement inlineReferenceInStatement(Statement statement, JavaType.Variable variable,
                 Expression replacement) {
             AtomicBoolean done = new AtomicBoolean(false);
-            JavaVisitor<Integer> inliner = new JavaVisitor<Integer>() {
+            J result = new JavaVisitor<AtomicBoolean>() {
                 @Override
-                public J visitIdentifier(J.Identifier identifier, Integer p) {
-                    if (done.get() || !name.equals(identifier.getSimpleName())) {
+                public J visitIdentifier(J.Identifier identifier, AtomicBoolean acc) {
+                    if (acc.get() || !isReferenceTo(identifier, variable)) {
                         return identifier;
                     }
-                    done.set(true);
-                    String text = replacement.printTrimmed(getCursor());
-                    return JavaTemplate.builder(text)
-                            .javaParser(JavaParser.fromJavaVersion())
-                            .build()
-                            .apply(getCursor(), identifier.getCoordinates().replace());
+                    acc.set(true);
+                    Expression inlined = replacement.withPrefix(Space.EMPTY);
+                    if (needsParentheses(identifier, replacement, getCursor())) {
+                        inlined = new J.Parentheses<>(randomId(), Space.EMPTY, Markers.EMPTY,
+                                new JRightPadded<>(inlined, Space.EMPTY, Markers.EMPTY));
+                    }
+                    return inlined.withPrefix(identifier.getPrefix());
                 }
-            };
-            J result = inliner.visit(statement, 0, parentCursor);
+            }.visit(statement, done);
             return done.get() ? (Statement) result : null;
+        }
+
+        private static boolean needsParentheses(J.Identifier identifier, Expression replacement, Cursor cursor) {
+            if (!(replacement instanceof J.Binary || replacement instanceof J.Ternary ||
+                    replacement instanceof J.InstanceOf || replacement instanceof J.TypeCast ||
+                    replacement instanceof J.Lambda || replacement instanceof J.Assignment ||
+                    replacement instanceof J.AssignmentOperation)) {
+                return false;
+            }
+            Object parent = cursor.getParentTreeCursor().getValue();
+            if (parent instanceof J.MethodInvocation) {
+                return isSameElement(((J.MethodInvocation) parent).getSelect(), identifier);
+            }
+            if (parent instanceof J.FieldAccess) {
+                return isSameElement(((J.FieldAccess) parent).getTarget(), identifier);
+            }
+            if (parent instanceof J.ArrayAccess) {
+                return isSameElement(((J.ArrayAccess) parent).getIndexed(), identifier);
+            }
+            return parent instanceof J.Binary || parent instanceof J.Unary || parent instanceof J.TypeCast ||
+                    parent instanceof J.InstanceOf || parent instanceof J.Ternary || parent instanceof J.MemberReference;
+        }
+
+        private static boolean isSameElement(@Nullable J maybeElement, J element) {
+            return maybeElement != null && maybeElement.getId().equals(element.getId());
         }
 
         private Optional<JavaTemplate> getExpectExceptionTemplate(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrows.java
@@ -21,6 +21,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
 import static org.openrewrite.Tree.randomId;
@@ -162,7 +164,9 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
 
         @Override
         public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
-            J.Block b = super.visitBlock(block, ctx);
+            J.Block simplified = inlineSingleUseReassignedLocals(block);
+            updateCursor(simplified);
+            J.Block b = super.visitBlock(simplified, ctx);
             List<Statement> statementsAfterExpectException = getCursor().pollMessage(STATEMENTS_AFTER_EXPECT_EXCEPTION);
             if (statementsAfterExpectException == null) {
                 return b;
@@ -297,6 +301,142 @@ public class ExpectedExceptionToAssertThrows extends Recipe {
                 cursor = cursor.getParentTreeCursor();
             }
             return successorStatements;
+        }
+
+        /**
+         * Narrow case: a local reassigned exactly once before expect*() (RHS not self-referencing),
+         * not read again before expect*(), and read exactly once among the statements moving into
+         * the assertThrows(...) lambda -- inline the RHS at that use site instead of leaving a
+         * non-effectively-final capture. Chains and multi-use reads are left untouched.
+         */
+        private J.Block inlineSingleUseReassignedLocals(J.Block block) {
+            for (boolean changed = true; changed; ) {
+                changed = false;
+                List<Statement> statements = block.getStatements();
+                int expectIndex = findExpectIndex(statements);
+                if (expectIndex <= 0) {
+                    return block;
+                }
+                for (int i = 0; i < expectIndex && !changed; i++) {
+                    if (!(statements.get(i) instanceof J.Assignment)) {
+                        continue;
+                    }
+                    J.Assignment assignment = (J.Assignment) statements.get(i);
+                    if (!(assignment.getVariable() instanceof J.Identifier)) {
+                        continue;
+                    }
+                    String name = ((J.Identifier) assignment.getVariable()).getSimpleName();
+                    Expression rhs = assignment.getAssignment();
+                    boolean selfReferencing = countIdentifier(rhs, name) > 0;
+                    boolean reassignedOnce = countAssignmentsTo(statements.subList(0, expectIndex), name) == 1;
+                    boolean readBetween = countIdentifier(statements.subList(i + 1, expectIndex), name) > 0;
+                    if (selfReferencing || !reassignedOnce || readBetween) {
+                        continue;
+                    }
+                    J.Block updated = inlineAtSingleUse(block, statements, i, expectIndex, name, rhs);
+                    if (updated != null) {
+                        block = updated;
+                        changed = true;
+                    }
+                }
+            }
+            return block;
+        }
+
+        private static int findExpectIndex(List<Statement> statements) {
+            for (int i = 0; i < statements.size(); i++) {
+                if (statements.get(i) instanceof J.MethodInvocation &&
+                        EXPECTED_EXCEPTION_ALL_MATCHER.matches((J.MethodInvocation) statements.get(i))) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static int countAssignmentsTo(List<Statement> statements, String name) {
+            int count = 0;
+            for (Statement s : statements) {
+                if (s instanceof J.Assignment) {
+                    Expression target = ((J.Assignment) s).getVariable();
+                    if (target instanceof J.Identifier && name.equals(((J.Identifier) target).getSimpleName())) {
+                        count++;
+                    }
+                }
+            }
+            return count;
+        }
+
+        private static int countIdentifier(J tree, String name) {
+            AtomicInteger count = new AtomicInteger();
+            new JavaIsoVisitor<AtomicInteger>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, AtomicInteger acc) {
+                    if (name.equals(identifier.getSimpleName())) {
+                        acc.incrementAndGet();
+                    }
+                    return super.visitIdentifier(identifier, acc);
+                }
+            }.visit(tree, count);
+            return count.get();
+        }
+
+        private static int countIdentifier(List<? extends J> trees, String name) {
+            int total = 0;
+            for (J tree : trees) {
+                total += countIdentifier(tree, name);
+            }
+            return total;
+        }
+
+        // Deletes the reassignment at statements[assignmentIndex] and splices its RHS in place of
+        // the single successor statement referencing `name`; null if there isn't exactly one use.
+        private J.Block inlineAtSingleUse(J.Block block, List<Statement> statements, int assignmentIndex,
+                int expectIndex, String name, Expression rhs) {
+            int afterIndex = -1;
+            int uses = 0;
+            for (int j = expectIndex + 1; j < statements.size(); j++) {
+                int hits = countIdentifier(statements.get(j), name);
+                uses += hits;
+                if (hits > 0) {
+                    afterIndex = j;
+                }
+            }
+            if (uses != 1) {
+                return null;
+            }
+            Statement rewritten = inlineIdentifierInStatement(getCursor(), statements.get(afterIndex), name, rhs);
+            if (rewritten == null) {
+                return null;
+            }
+            int finalAfterIndex = afterIndex;
+            return block.withStatements(ListUtils.map(statements, (i, s) -> {
+                if (i == assignmentIndex) {
+                    return null;
+                }
+                return i == finalAfterIndex ? rewritten : s;
+            }));
+        }
+
+        // Replaces the sole occurrence of identifier `name` in `statement` with `replacement`.
+        private Statement inlineIdentifierInStatement(Cursor parentCursor, Statement statement, String name,
+                Expression replacement) {
+            AtomicBoolean done = new AtomicBoolean(false);
+            JavaVisitor<Integer> inliner = new JavaVisitor<Integer>() {
+                @Override
+                public J visitIdentifier(J.Identifier identifier, Integer p) {
+                    if (done.get() || !name.equals(identifier.getSimpleName())) {
+                        return identifier;
+                    }
+                    done.set(true);
+                    String text = replacement.printTrimmed(getCursor());
+                    return JavaTemplate.builder(text)
+                            .javaParser(JavaParser.fromJavaVersion())
+                            .build()
+                            .apply(getCursor(), identifier.getCoordinates().replace());
+                }
+            };
+            J result = inliner.visit(statement, 0, parentCursor);
+            return done.get() ? (Statement) result : null;
         }
 
         private Optional<JavaTemplate> getExpectExceptionTemplate(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -978,7 +978,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     }
 
     @Test
-    void doesNotInlineSelfReferencingReassignment() {
+    void doesNotMigrateSelfReferencingReassignment() {
         //language=java
         rewriteRun(
           java(
@@ -1004,34 +1004,13 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                       throw new NullPointerException();
                   }
               }
-              """,
-            """
-              import org.junit.Test;
-
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-
-              public class MyTest {
-
-                  @Test
-                  public void testMapping() {
-                      int counter = 0;
-                      counter = counter + 1;
-
-                      assertThrows(NullPointerException.class, () ->
-                          map(counter));
-                  }
-
-                  void map(int i) {
-                      throw new NullPointerException();
-                  }
-              }
               """
           )
         );
     }
 
     @Test
-    void doesNotInlineWhenReadAgainBeforeExpect() {
+    void doesNotMigrateWhenReadAgainBeforeExpect() {
         //language=java
         rewriteRun(
           java(
@@ -1058,35 +1037,13 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                       throw new NullPointerException();
                   }
               }
-              """,
-            """
-              import org.junit.Test;
-
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-
-              public class MyTest {
-
-                  @Test
-                  public void testMapping() {
-                      String input = "valid";
-                      input = "invalid";
-                      System.out.println(input);
-
-                      assertThrows(NullPointerException.class, () ->
-                          map(input));
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
               """
           )
         );
     }
 
     @Test
-    void doesNotInlineWhenUsedMultipleTimesAfterExpect() {
+    void doesNotMigrateWhenUsedMultipleTimesAfterExpect() {
         //language=java
         rewriteRun(
           java(
@@ -1113,36 +1070,13 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                       throw new NullPointerException();
                   }
               }
-              """,
-            """
-              import org.junit.Test;
-
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-
-              public class MyTest {
-
-                  @Test
-                  public void testMapping() {
-                      String input = "valid";
-                      input = "invalid";
-
-                      assertThrows(NullPointerException.class, () -> {
-                          map(input);
-                          map(input);
-                      });
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
               """
           )
         );
     }
 
     @Test
-    void doesNotInlineChainedReassignment() {
+    void doesNotMigrateChainedReassignment() {
         //language=java
         rewriteRun(
           java(
@@ -1163,32 +1097,6 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
 
                       thrown.expect(NullPointerException.class);
                       map(input);
-                  }
-
-                  String update(String s) {
-                      return s;
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
-              """,
-            """
-              import org.junit.Test;
-
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-
-              public class MyTest {
-
-                  @Test
-                  public void testMapping() {
-                      String input = "valid";
-                      input = update(input);
-                      input = update(input);
-
-                      assertThrows(NullPointerException.class, () ->
-                          map(input));
                   }
 
                   String update(String s) {
@@ -1435,7 +1343,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     }
 
     @Test
-    void doesNotInlineWhenAssignedAgainAfterExpect() {
+    void doesNotMigrateWhenAssignedAgainAfterExpect() {
         //language=java
         rewriteRun(
           java(
@@ -1460,34 +1368,13 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   void map(String s) {
                   }
               }
-              """,
-            """
-              import org.junit.Test;
-
-              import static org.junit.jupiter.api.Assertions.assertThrows;
-
-              public class MyTest {
-
-                  @Test
-                  public void testMapping() {
-                      String input = "valid";
-                      map(input);
-                      input = "invalid";
-                      assertThrows(NullPointerException.class, () -> {
-                          input = "other";
-                      });
-                  }
-
-                  void map(String s) {
-                  }
-              }
               """
           )
         );
     }
 
     @Test
-    void doesNotInlineValueThatCouldChangeBeforeExpect() {
+    void doesNotMigrateValueThatCouldChangeBeforeExpect() {
         //language=java
         rewriteRun(
           java(
@@ -1519,26 +1406,71 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                       throw new NullPointerException();
                   }
               }
-              """,
-            """
-              import java.util.ArrayList;
-              import java.util.List;
+              """
+          )
+        );
+    }
 
-              import static org.junit.jupiter.api.Assertions.assertThrows;
+    @Test
+    void keepsRuleWhenOnlySomeMethodsMigrate() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
               import org.junit.Test;
+              import org.junit.rules.ExpectedException;
 
               public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
 
                   @Test
-                  public void testMapping() {
-                      List<String> list = new ArrayList<>();
-                      list.add("invalid");
+                  public void capturesReassignedLocal() throws Exception {
                       String input = "valid";
                       map(input);
-                      input = list.get(0);
-                      list.clear();
+                      input = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                      map(input);
+                  }
+
+                  @Test
+                  public void migrates() throws Exception {
+                      thrown.expect(NullPointerException.class);
+                      map("valid");
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void capturesReassignedLocal() throws Exception {
+                      String input = "valid";
+                      map(input);
+                      input = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                      map(input);
+                  }
+
+                  @Test
+                  public void migrates() {
                       assertThrows(NullPointerException.class, () ->
-                          map(input));
+                          map("valid"));
                   }
 
                   void map(String s) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.junit5;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -978,141 +979,6 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     }
 
     @Test
-    void doesNotMigrateSelfReferencingReassignment() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() throws Exception {
-                      int counter = 0;
-                      counter = counter + 1;
-
-                      thrown.expect(NullPointerException.class);
-                      map(counter);
-                  }
-
-                  void map(int i) {
-                      throw new NullPointerException();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotMigrateWhenReadAgainBeforeExpect() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() throws Exception {
-                      String input = "valid";
-                      input = "invalid";
-                      System.out.println(input);
-
-                      thrown.expect(NullPointerException.class);
-                      map(input);
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotMigrateWhenUsedMultipleTimesAfterExpect() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() throws Exception {
-                      String input = "valid";
-                      input = "invalid";
-
-                      thrown.expect(NullPointerException.class);
-                      map(input);
-                      map(input);
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotMigrateChainedReassignment() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() throws Exception {
-                      String input = "valid";
-                      input = update(input);
-                      input = update(input);
-
-                      thrown.expect(NullPointerException.class);
-                      map(input);
-                  }
-
-                  String update(String s) {
-                      return s;
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void inlinedValueRetainsTypeAttribution() {
         //language=java
         rewriteRun(
@@ -1343,75 +1209,6 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     }
 
     @Test
-    void doesNotMigrateWhenAssignedAgainAfterExpect() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() {
-                      String input = "valid";
-                      map(input);
-                      input = "invalid";
-                      thrown.expect(NullPointerException.class);
-                      input = "other";
-                  }
-
-                  void map(String s) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void doesNotMigrateValueThatCouldChangeBeforeExpect() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.util.ArrayList;
-              import java.util.List;
-
-              import org.junit.Rule;
-              import org.junit.Test;
-              import org.junit.rules.ExpectedException;
-
-              public class MyTest {
-                  @Rule
-                  public ExpectedException thrown = ExpectedException.none();
-
-                  @Test
-                  public void testMapping() {
-                      List<String> list = new ArrayList<>();
-                      list.add("invalid");
-                      String input = "valid";
-                      map(input);
-                      input = list.get(0);
-                      list.clear();
-                      thrown.expect(NullPointerException.class);
-                      map(input);
-                  }
-
-                  void map(String s) {
-                      throw new NullPointerException();
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
     void keepsRuleWhenOnlySomeMethodsMigrate() {
         //language=java
         rewriteRun(
@@ -1480,5 +1277,213 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Nested
+    class NoChanges {
+
+        @Test
+        void doesNotMigrateSelfReferencingReassignment() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          int counter = 0;
+                          counter = counter + 1;
+
+                          thrown.expect(NullPointerException.class);
+                          map(counter);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void doesNotMigrateWhenReadAgainBeforeExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = "invalid";
+                          System.out.println(input);
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void doesNotMigrateWhenUsedMultipleTimesAfterExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = "invalid";
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void doesNotMigrateChainedReassignment() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = update(input);
+                          input = update(input);
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      String update(String s) {
+                          return s;
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void doesNotMigrateWhenAssignedAgainAfterExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          String input = "valid";
+                          map(input);
+                          input = "invalid";
+                          thrown.expect(NullPointerException.class);
+                          input = "other";
+                      }
+
+                      void map(String s) {
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void doesNotMigrateValueThatCouldChangeBeforeExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import java.util.ArrayList;
+                  import java.util.List;
+
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          List<String> list = new ArrayList<>();
+                          list.add("invalid");
+                          String input = "valid";
+                          map(input);
+                          input = list.get(0);
+                          list.clear();
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -1251,6 +1251,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
               import static org.junit.jupiter.api.Assertions.assertThrows;
 
               public class MyTest {
+                  // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                   @Rule
                   public ExpectedException thrown = ExpectedException.none();
 
@@ -1280,7 +1281,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     }
 
     @Nested
-    class NoChanges {
+    class CannotMigrate {
 
         @Test
         void selfReferencingReassignment() {
@@ -1293,6 +1294,30 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   import org.junit.rules.ExpectedException;
 
                   public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          int counter = 0;
+                          counter = counter + 1;
+
+                          thrown.expect(NullPointerException.class);
+                          map(counter);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                       @Rule
                       public ExpectedException thrown = ExpectedException.none();
 
@@ -1342,6 +1367,31 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                           throw new NullPointerException();
                       }
                   }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = "invalid";
+                          System.out.println(input);
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
                   """
               )
             );
@@ -1358,6 +1408,31 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   import org.junit.rules.ExpectedException;
 
                   public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = "invalid";
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                       @Rule
                       public ExpectedException thrown = ExpectedException.none();
 
@@ -1412,6 +1487,35 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                           throw new NullPointerException();
                       }
                   }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          String input = "valid";
+                          input = update(input);
+                          input = update(input);
+
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      String update(String s) {
+                          return s;
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
                   """
               )
             );
@@ -1428,6 +1532,29 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   import org.junit.rules.ExpectedException;
 
                   public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          String input = "valid";
+                          map(input);
+                          input = "invalid";
+                          thrown.expect(NullPointerException.class);
+                          input = "other";
+                      }
+
+                      void map(String s) {
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                       @Rule
                       public ExpectedException thrown = ExpectedException.none();
 
@@ -1462,6 +1589,36 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   import org.junit.rules.ExpectedException;
 
                   public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          List<String> list = new ArrayList<>();
+                          list.add("invalid");
+                          String input = "valid";
+                          map(input);
+                          input = list.get(0);
+                          list.clear();
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """,
+                """
+                  import java.util.ArrayList;
+                  import java.util.List;
+
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                       @Rule
                       public ExpectedException thrown = ExpectedException.none();
 
@@ -1518,6 +1675,35 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                           throw new NullPointerException();
                       }
                   }
+                  """,
+                """
+                  import java.util.ArrayList;
+                  import java.util.List;
+
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          List<String> list = new ArrayList<>();
+                          list.add("a");
+                          int size = 0;
+                          size = list.size();
+                          thrown.expect(NullPointerException.class);
+                          list.add("b");
+                          map(size);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
                   """
               )
             );
@@ -1552,6 +1738,32 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                           throw new NullPointerException();
                       }
                   }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      private int counter = 1;
+
+                      @Test
+                      public void testMapping() {
+                          int size = 0;
+                          size = counter;
+                          thrown.expect(NullPointerException.class);
+                          counter = 5;
+                          map(size);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
                   """
               )
             );
@@ -1568,6 +1780,33 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                   import org.junit.rules.ExpectedException;
 
                   public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          Runnable r = () -> {
+                              System.out.println("hi");
+                          };
+                          String input = "valid";
+                          input = "invalid";
+                          thrown.expect(NullPointerException.class);
+                          map(input);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """,
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      // TODO Migrate by hand and remove this rule: a test below reads a reassigned local, which the `assertThrows(..)` lambda can not capture.
                       @Rule
                       public ExpectedException thrown = ExpectedException.none();
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -1203,4 +1203,350 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void inlinedValueRetainsTypeAttribution() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.hamcrest.CoreMatchers;
+              import org.hamcrest.Matcher;
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() {
+                      Matcher<String> matcher = null;
+                      map(matcher);
+                      matcher = CoreMatchers.is("invalid");
+                      thrown.expect(NullPointerException.class);
+                      map(matcher);
+                  }
+
+                  void map(Matcher<String> m) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.hamcrest.CoreMatchers;
+              import org.hamcrest.Matcher;
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      Matcher<String> matcher = null;
+                      map(matcher);
+                      assertThrows(NullPointerException.class, () ->
+                          map(CoreMatchers.is("invalid")));
+                  }
+
+                  void map(Matcher<String> m) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void parenthesizesInlinedValueWhenNeeded() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      map(input);
+                      input = "a" + "b";
+                      thrown.expect(NullPointerException.class);
+                      map(input.trim());
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      map(input);
+                      assertThrows(NullPointerException.class, () ->
+                          map(("a" + "b").trim()));
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineFieldAssignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  private String input;
+
+                  @Test
+                  public void testMapping() {
+                      input = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  private String input;
+
+                  @Test
+                  public void testMapping() {
+                      input = "invalid";
+                      assertThrows(NullPointerException.class, () ->
+                          map(input));
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineIntoSameNamedMethodOrField() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  static class Holder {
+                      String value = "x";
+                  }
+
+                  @Test
+                  public void testMapping() {
+                      Holder holder = new Holder();
+                      String value = "valid";
+                      map(value);
+                      value = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      value(holder.value);
+                  }
+
+                  void value(String s) {
+                      throw new NullPointerException();
+                  }
+
+                  void map(String s) {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  static class Holder {
+                      String value = "x";
+                  }
+
+                  @Test
+                  public void testMapping() {
+                      Holder holder = new Holder();
+                      String value = "valid";
+                      map(value);
+                      value = "invalid";
+                      assertThrows(NullPointerException.class, () ->
+                          value(holder.value));
+                  }
+
+                  void value(String s) {
+                      throw new NullPointerException();
+                  }
+
+                  void map(String s) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineWhenAssignedAgainAfterExpect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      map(input);
+                      input = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      input = "other";
+                  }
+
+                  void map(String s) {
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      map(input);
+                      input = "invalid";
+                      assertThrows(NullPointerException.class, () -> {
+                          input = "other";
+                      });
+                  }
+
+                  void map(String s) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineValueThatCouldChangeBeforeExpect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() {
+                      List<String> list = new ArrayList<>();
+                      list.add("invalid");
+                      String input = "valid";
+                      map(input);
+                      input = list.get(0);
+                      list.clear();
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+              import org.junit.Test;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      List<String> list = new ArrayList<>();
+                      list.add("invalid");
+                      String input = "valid";
+                      map(input);
+                      input = list.get(0);
+                      list.clear();
+                      assertThrows(NullPointerException.class, () ->
+                          map(input));
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -1283,7 +1283,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
     class NoChanges {
 
         @Test
-        void doesNotMigrateSelfReferencingReassignment() {
+        void selfReferencingReassignment() {
             //language=java
             rewriteRun(
               java(
@@ -1315,7 +1315,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         }
 
         @Test
-        void doesNotMigrateWhenReadAgainBeforeExpect() {
+        void whenReassignedLocalReadAgainBeforeExpect() {
             //language=java
             rewriteRun(
               java(
@@ -1348,7 +1348,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         }
 
         @Test
-        void doesNotMigrateWhenUsedMultipleTimesAfterExpect() {
+        void whenUsedMultipleTimesAfterExpect() {
             //language=java
             rewriteRun(
               java(
@@ -1381,7 +1381,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         }
 
         @Test
-        void doesNotMigrateChainedReassignment() {
+        void chainedReassignment() {
             //language=java
             rewriteRun(
               java(
@@ -1418,7 +1418,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         }
 
         @Test
-        void doesNotMigrateWhenAssignedAgainAfterExpect() {
+        void whenAssignedAgainAfterExpect() {
             //language=java
             rewriteRun(
               java(
@@ -1449,7 +1449,7 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
         }
 
         @Test
-        void doesNotMigrateValueThatCouldChangeBeforeExpect() {
+        void valueThatCouldChangeBeforeExpect() {
             //language=java
             rewriteRun(
               java(
@@ -1474,6 +1474,112 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
                           input = list.get(0);
                           list.clear();
                           thrown.expect(NullPointerException.class);
+                          map(input);
+                      }
+
+                      void map(String s) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void valueThatCouldChangeAfterExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import java.util.ArrayList;
+                  import java.util.List;
+
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() {
+                          List<String> list = new ArrayList<>();
+                          list.add("a");
+                          int size = 0;
+                          size = list.size();
+                          thrown.expect(NullPointerException.class);
+                          list.add("b");
+                          map(size);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fieldReadThatCouldChangeAfterExpect() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      private int counter = 1;
+
+                      @Test
+                      public void testMapping() {
+                          int size = 0;
+                          size = counter;
+                          thrown.expect(NullPointerException.class);
+                          counter = 5;
+                          map(size);
+                      }
+
+                      void map(int i) {
+                          throw new NullPointerException();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void unrelatedLambdaLeftAloneWhenNothingMigrates() {
+            //language=java
+            rewriteRun(
+              java(
+                """
+                  import org.junit.Rule;
+                  import org.junit.Test;
+                  import org.junit.rules.ExpectedException;
+
+                  public class MyTest {
+                      @Rule
+                      public ExpectedException thrown = ExpectedException.none();
+
+                      @Test
+                      public void testMapping() throws Exception {
+                          Runnable r = () -> {
+                              System.out.println("hi");
+                          };
+                          String input = "valid";
+                          input = "invalid";
+                          thrown.expect(NullPointerException.class);
+                          map(input);
                           map(input);
                       }
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ExpectedExceptionToAssertThrowsTest.java
@@ -919,4 +919,288 @@ class ExpectedExceptionToAssertThrowsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void inlinesSingleUseReassignedLocalBeforeExpect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() throws Exception {
+                      String input = "valid";
+                      map(input);
+
+                      input = "invalid";
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                  }
+
+                  void map(String s) {
+                      if (s.equals("invalid")) {
+                          throw new NullPointerException();
+                      }
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      map(input);
+                      assertThrows(NullPointerException.class, () ->
+                          map("invalid"));
+                  }
+
+                  void map(String s) {
+                      if (s.equals("invalid")) {
+                          throw new NullPointerException();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineSelfReferencingReassignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() throws Exception {
+                      int counter = 0;
+                      counter = counter + 1;
+
+                      thrown.expect(NullPointerException.class);
+                      map(counter);
+                  }
+
+                  void map(int i) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      int counter = 0;
+                      counter = counter + 1;
+
+                      assertThrows(NullPointerException.class, () ->
+                          map(counter));
+                  }
+
+                  void map(int i) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineWhenReadAgainBeforeExpect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() throws Exception {
+                      String input = "valid";
+                      input = "invalid";
+                      System.out.println(input);
+
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      input = "invalid";
+                      System.out.println(input);
+
+                      assertThrows(NullPointerException.class, () ->
+                          map(input));
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineWhenUsedMultipleTimesAfterExpect() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() throws Exception {
+                      String input = "valid";
+                      input = "invalid";
+
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                      map(input);
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      input = "invalid";
+
+                      assertThrows(NullPointerException.class, () -> {
+                          map(input);
+                          map(input);
+                      });
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotInlineChainedReassignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.Test;
+              import org.junit.rules.ExpectedException;
+
+              public class MyTest {
+                  @Rule
+                  public ExpectedException thrown = ExpectedException.none();
+
+                  @Test
+                  public void testMapping() throws Exception {
+                      String input = "valid";
+                      input = update(input);
+                      input = update(input);
+
+                      thrown.expect(NullPointerException.class);
+                      map(input);
+                  }
+
+                  String update(String s) {
+                      return s;
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertThrows;
+
+              public class MyTest {
+
+                  @Test
+                  public void testMapping() {
+                      String input = "valid";
+                      input = update(input);
+                      input = update(input);
+
+                      assertThrows(NullPointerException.class, () ->
+                          map(input));
+                  }
+
+                  String update(String s) {
+                      return s;
+                  }
+
+                  void map(String s) {
+                      throw new NullPointerException();
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?                                                                                                                                                                                                                    
  <!-- A brief description of the changes in this pull request -->                                                                                                                                                                      
                                                                                                                                                                                                                                        
  A local reassigned via `=` before ExpectedException.expect*() and then read by the statement(s) that get spliced into the assertThrows(...) lambda fails to compile: Java lambdas require captured locals to be effectively final, and
  a reassignment (even one before the capture point) disqualifies it.                                                                                                                                                                   
                                                                                                                                                                                                                                        
  For the narrow, common shape -- reassigned exactly once, RHS doesn't reference itself, not read again before expect*(), and read exactly once in the moved statements -- delete the reassignment and inline its RHS at that single use
  site instead. Chains and multi-use reads are left untouched for now.                                                                                                                                                                  
                                                                                                                                                                                                                                        
  `ExpectedExceptionToAssertThrows` now inlines a reassigned local at its splice site instead of letting the recipe emit a lambda that captures a non-effectively-final variable. Scope is deliberately narrow: only fires when the     
  local is reassigned exactly once before `expect*()`, the RHS of that reassignment doesn't reference the local itself, the local isn't read again before `expect*()`, and it's read exactly once among the statements moving into the  
  `assertThrows(...)` lambda. Chained reassignments and multi-use reads after `expect*()` are left exactly as they behave today -- not fixed here, but not made worse either.                                                           
                                                                                                                                                                                                                                        
  ## What's your motivation?                                                                                                                                                                                                            
  <!-- This can link to close a separate issue, or be described on the pull request itself -->                                                                                                                                          
                                                                                                                                                                                                                                        
  Ran into this while migrating a large JUnit 4 codebase off `ExpectedException`: the recipe silently produced non-compiling output whenever a captured local had been reassigned earlier in the method. This fixes the common          
  single-reassignment/single-use shape without touching the harder chained/multi-use shapes, which need a different fix (capturing into a fresh `final` local rather than inlining) and are left for a follow-up.                       
                                                                                                                                                                                                                                        
  ## Anything in particular you'd like reviewers to focus on?                                                                                                                                                                           
  <!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->                                                                                                                      
                                                                                                                                                                                                                                        
  The `updateCursor(simplified)` call before delegating to `super.visitBlock` -- without it, the existing splice logic reads a stale statement list via the cursor-message mechanism (`findSuccessorStatements`), since                 
  `super.visitBlock` doesn't automatically rebind the visitor's cursor to a block passed in as a plain parameter.                                                                                                                       
                                                                                                                                                                                                                                        
  ## Anyone you would like to review specifically?                                                                                                                                                                                      
  <!-- @mention them here -->                                                                                                                                                                                                           
                                                                                                                                                                                                                                        
  ## Have you considered any alternatives or workarounds?                                                                                                                                                                               
  <!-- Any other ways to solve the problem, or ways to work around the problem. -->                                                                                                                                                     
                                                                                                                                                                                                                                        
  Considered generalizing this to always capture the value into a fresh `final` local (handles chains and multi-use too), but that's a larger, separate change -- left for a follow-up PR to keep this one focused and easy to review.  
                                                                                                                                                                                                                                        
  ## Any additional context                                                                                                                                                                                                             
  <!-- Any thoughts you would like to share in addition to the above. -->                                                                                                                                                               
                                                                              
  ### Checklist
 - [x] I've added unit tests to cover both positive and negative cases                                                                                                                                                                 
 - [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)                                                                         
 - [x] I've used the IntelliJ IDEA auto-formatter on affected files                                                                                                                                                                    
  