### PR TITLE
Retain assertTrue/assertFalse(a.equals(null)) as is

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThat.java
@@ -60,6 +60,11 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
                 List<Expression> args = mi.getArguments();
                 Expression expected = args.get(0);
                 Expression actual = args.get(1);
+                if (isNullLiteral(actual) && !isNullLiteral(expected)) {
+                    // `assertThat(null)` is an ambiguous method call; asserting on the other argument calls the same `equals`
+                    expected = actual;
+                    actual = args.get(0);
+                }
                 if (args.size() == 2) {
                     return JavaTemplate.builder("assertThat(#{any()}).isEqualTo(#{any()});")
                             .staticImports(ASSERTJ + ".assertThat")
@@ -127,6 +132,10 @@ public class JUnitAssertEqualsToAssertThat extends Recipe {
                     return "within(#{any()})";
                 }
                 return "within((" + paramType.getKeyword() + ") #{any()})";
+            }
+
+            private boolean isNullLiteral(Expression expression) {
+                return J.Literal.isLiteralValue(expression.unwrap(), null);
             }
 
             private JavaType.Primitive floatingPointDeltaType(J.MethodInvocation mi) {

--- a/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThat.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThat.java
@@ -60,6 +60,11 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                 List<Expression> args = mi.getArguments();
                 Expression expected = args.get(0);
                 Expression actual = args.get(1);
+                if (isNullLiteral(actual) && !isNullLiteral(expected)) {
+                    // `assertThat(null)` is an ambiguous method call; asserting on the other argument calls the same `equals`
+                    expected = actual;
+                    actual = args.get(0);
+                }
                 if (args.size() == 2) {
                     return JavaTemplate.builder("assertThat(#{any()}).isNotEqualTo(#{any()});")
                             .staticImports(ASSERTJ + ".assertThat")
@@ -92,6 +97,10 @@ public class JUnitAssertNotEqualsToAssertThat extends Recipe {
                         .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "assertj-core-3"))
                         .build()
                         .apply(getCursor(), method.getCoordinates().replace(), actual, message, expected, args.get(2));
+            }
+
+            private boolean isNullLiteral(Expression expression) {
+                return J.Literal.isLiteralValue(expression.unwrap(), null);
             }
 
             private boolean isFloatingPointType(Expression expression) {

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualsToAssertNotEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualsToAssertNotEquals.java
@@ -88,7 +88,16 @@ public class AssertFalseEqualsToAssertNotEquals extends Recipe {
                 J.MethodInvocation methodInvocation = (J.MethodInvocation) expr;
 
                 return "equals".equals(methodInvocation.getName().getSimpleName()) &&
-                        methodInvocation.getArguments().size() == 1;
+                        methodInvocation.getArguments().size() == 1 &&
+                        !isNullLiteral(methodInvocation.getArguments().get(0));
+            }
+
+            private boolean isNullLiteral(Expression expr) {
+                Expression unwrapped = expr.unwrap();
+                while (unwrapped instanceof J.TypeCast) {
+                    unwrapped = ((J.TypeCast) unwrapped).getExpression().unwrap();
+                }
+                return unwrapped instanceof J.Literal && ((J.Literal) unwrapped).getValue() == null;
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualsToAssertNotEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualsToAssertNotEquals.java
@@ -97,7 +97,7 @@ public class AssertFalseEqualsToAssertNotEquals extends Recipe {
                 while (unwrapped instanceof J.TypeCast) {
                     unwrapped = ((J.TypeCast) unwrapped).getExpression().unwrap();
                 }
-                return unwrapped instanceof J.Literal && ((J.Literal) unwrapped).getValue() == null;
+                return J.Literal.isLiteralValue(unwrapped, null);
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
@@ -90,7 +90,16 @@ public class AssertTrueEqualsToAssertEquals extends Recipe {
                 J.MethodInvocation methodInvocation = (J.MethodInvocation) expr;
 
                 return "equals".equals(methodInvocation.getName().getSimpleName()) &&
-                        methodInvocation.getArguments().size() == 1;
+                        methodInvocation.getArguments().size() == 1 &&
+                        !isNullLiteral(methodInvocation.getArguments().get(0));
+            }
+
+            private boolean isNullLiteral(Expression expr) {
+                Expression unwrapped = expr.unwrap();
+                while (unwrapped instanceof J.TypeCast) {
+                    unwrapped = ((J.TypeCast) unwrapped).getExpression().unwrap();
+                }
+                return unwrapped instanceof J.Literal && ((J.Literal) unwrapped).getValue() == null;
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEquals.java
@@ -99,7 +99,7 @@ public class AssertTrueEqualsToAssertEquals extends Recipe {
                 while (unwrapped instanceof J.TypeCast) {
                     unwrapped = ((J.TypeCast) unwrapped).getExpression().unwrap();
                 }
-                return unwrapped instanceof J.Literal && ((J.Literal) unwrapped).getValue() == null;
+                return J.Literal.isLiteralValue(unwrapped, null);
             }
         });
     }

--- a/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
+++ b/src/main/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrder.java
@@ -64,6 +64,16 @@ public class AssertionsArgumentOrder extends Recipe {
     // `assertNull("message", result())` should be `assertNull(result(), "message")`
     private static final MethodMatcher jupiterAssertNullMatcher = new MethodMatcher("org.junit.jupiter.api.Assertions assert*Null(Object, String)");
 
+    // Moving a null literal into the expected position short circuits the equality check, rather than calling equals
+    private static final MethodMatcher[] equalityMatchers = new MethodMatcher[]{
+            new MethodMatcher("org.junit.jupiter.api.Assertions assertEquals(..)"),
+            new MethodMatcher("org.junit.jupiter.api.Assertions assertNotEquals(..)"),
+            new MethodMatcher("org.junit.Assert assertEquals(..)"),
+            new MethodMatcher("org.junit.Assert assertNotEquals(..)"),
+            new MethodMatcher("org.testng.Assert assertEquals(..)"),
+            new MethodMatcher("org.testng.Assert assertNotEquals(..)")
+    };
+
     private static final MethodMatcher[] testNgMatcher = new MethodMatcher[]{
             new MethodMatcher("org.testng.Assert assertSame(..)"),
             new MethodMatcher("org.testng.Assert assertNotSame(..)"),
@@ -125,6 +135,10 @@ public class AssertionsArgumentOrder extends Recipe {
                 return mi;
             }
 
+            if (isEqualityAssertion(mi) && (isNullLiteral(expected) || isNullLiteral(actual))) {
+                return mi;
+            }
+
             if (!isCorrectOrder(expected, actual, mi)) {
                 mi = maybeAutoFormat(mi, mi.withArguments(ListUtils.map(mi.getArguments(), arg -> {
                     if (arg.equals(actual)) {
@@ -137,6 +151,23 @@ public class AssertionsArgumentOrder extends Recipe {
                 })), ctx, getCursor().getParentOrThrow());
             }
             return mi;
+        }
+
+        private boolean isEqualityAssertion(J.MethodInvocation mi) {
+            for (MethodMatcher equalityMatcher : equalityMatchers) {
+                if (equalityMatcher.matches(mi)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isNullLiteral(Expression expression) {
+            Expression unwrapped = expression.unwrap();
+            while (unwrapped instanceof J.TypeCast) {
+                unwrapped = ((J.TypeCast) unwrapped).getExpression().unwrap();
+            }
+            return J.Literal.isLiteralValue(unwrapped, null);
         }
 
         private boolean isCorrectOrder(Expression expected, Expression actual, J.MethodInvocation mi) {

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertEqualsToAssertThatTest.java
@@ -518,4 +518,46 @@ class JUnitAssertEqualsToAssertThatTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/492")
+    @Test
+    void nullArgumentAssertedOnNonNullArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertEquals(notification(), null);
+                      assertEquals(notification(), null, "These should be equal");
+                  }
+                  private String notification() {
+                      return "joe";
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertThat(notification()).isEqualTo(null);
+                      assertThat(notification()).as("These should be equal").isEqualTo(null);
+                  }
+                  private String notification() {
+                      return "joe";
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThatTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/JUnitAssertNotEqualsToAssertThatTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.assertj;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -352,6 +353,48 @@ class JUnitAssertNotEqualsToAssertThatTest implements RewriteTest {
                   }
                   private File notification() {
                       return new File("someFile");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/492")
+    @Test
+    void nullArgumentAssertedOnNonNullArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertNotEquals(notification(), null);
+                      assertNotEquals(notification(), null, "These should not be equal");
+                  }
+                  private String notification() {
+                      return "joe";
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertThat(notification()).isNotEqualTo(null);
+                      assertThat(notification()).as("These should not be equal").isNotEqualTo(null);
+                  }
+                  private String notification() {
+                      return "joe";
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualToAssertNotEqualsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertFalseEqualToAssertNotEqualsTest.java
@@ -122,4 +122,29 @@ class AssertFalseEqualToAssertNotEqualsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
+    @SuppressWarnings({"ConstantConditions", "SimplifiableAssertion"})
+    @Test
+    void retainEqualsNull() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              import static org.junit.jupiter.api.Assertions.assertFalse;
+
+              public class Test {
+                  void test() {
+                      String a = "a";
+                      assertFalse(a.equals(null));
+                      assertFalse(a.equals(null), "message");
+                      Assertions.assertFalse(a.equals((Object) null));
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertTrueEqualsToAssertEqualsTest.java
@@ -147,4 +147,29 @@ class AssertTrueEqualsToAssertEqualsTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
+    @SuppressWarnings({"ConstantConditions", "SimplifiableAssertion"})
+    @Test
+    void retainEqualsNull() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              public class Test {
+                  void test() {
+                      String a = "a";
+                      assertTrue(a.equals(null));
+                      assertTrue(a.equals(null), "message");
+                      Assertions.assertTrue(a.equals((Object) null));
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
+++ b/src/test/java/org/openrewrite/java/testing/cleanup/AssertionsArgumentOrderTest.java
@@ -504,4 +504,87 @@ class AssertionsArgumentOrderTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
+    @Test
+    void retainNullLiteralArgumentOfEqualityAssertions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+              import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+              class MyTest {
+                  void someTest() {
+                      assertEquals(someString(), null);
+                      assertNotEquals(someString(), null);
+                      assertNotEquals(someString(), null, "message");
+                      assertNotEquals(someString(), (Object) null);
+                  }
+                  String someString() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
+    @Test
+    void retainNullLiteralArgumentOfJunit4AndTestNgEqualityAssertions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              class MyTest {
+                  void someTest() {
+                      org.junit.Assert.assertEquals(someString(), null);
+                      org.junit.Assert.assertEquals("message", someString(), null);
+                      org.testng.Assert.assertEquals(null, someString());
+                      org.testng.Assert.assertNotEquals(null, someString());
+                  }
+                  String someString() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
+    @Test
+    void stillReorderNullLiteralArgumentOfReferenceAssertions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import static org.junit.jupiter.api.Assertions.assertSame;
+
+              class MyTest {
+                  void someTest() {
+                      assertSame(someString(), null);
+                  }
+                  String someString() {
+                      return null;
+                  }
+              }
+              """,
+            """
+              import static org.junit.jupiter.api.Assertions.assertSame;
+
+              class MyTest {
+                  void someTest() {
+                      assertSame(null, someString());
+                  }
+                  String someString() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.testing.junit5;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -96,8 +97,9 @@ class CleanupAssertionsTest implements RewriteTest {
           ));
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
     @Test
-    void assertFalseNegatedEqualsNullToAssertNull() {
+    void assertFalseNegatedEqualsNullToAssertTrue() {
         //language=java
         rewriteRun(
           java(
@@ -119,7 +121,7 @@ class CleanupAssertionsTest implements RewriteTest {
               class ExampleTest {
                   @Test
                   void test() {
-                      Assertions.assertNull("");
+                      Assertions.assertTrue("".equals(null));
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/CleanupAssertionsTest.java
@@ -129,8 +129,9 @@ class CleanupAssertionsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1071")
     @Test
-    void assertNotEqualsInverted() {
+    void assertNotEqualsNullRetained() {
         //language=java
         rewriteRun(
           java(
@@ -146,21 +147,6 @@ class CleanupAssertionsTest implements RewriteTest {
                             B myVariable = new B();
 
                             Assertions.assertNotEquals(myVariable, null);
-                        }
-                    }
-                    """,
-            """
-                    import org.junit.jupiter.api.Assertions;
-                    import org.junit.jupiter.api.Test;
-
-                    class A {
-                        class B {}
-
-                        @Test
-                        public void FlippedParams(){
-                            B myVariable = new B();
-
-                            Assertions.assertNotEquals(null, myVariable);
                         }
                     }
                     """


### PR DESCRIPTION
- Fixes #1071

Three recipes in the JUnit 4 → 5 pipeline conspired to turn `assertFalse(a.equals(null))` into `assertNotEquals(null, a)`, which never calls `a.equals(null)` — `Assertions.objectsAreEqual` short circuits when its first argument is `null`. Tests written to cover the null contract of a custom `equals()` then pass unconditionally.

- `AssertTrueEqualsToAssertEquals` and `AssertFalseEqualsToAssertNotEquals` no longer convert when the argument to `.equals()` is a `null` literal (also when parenthesized or cast).
- `AssertionsArgumentOrder` no longer reorders `assertEquals` / `assertNotEquals` arguments when either compared argument is a `null` literal. Reference assertions such as `assertSame` are still reordered, as `==` is symmetric.

That argument flip was added in #492 to keep the AssertJ migration compiling: `assertNotEquals(myVariable, null)` would otherwise migrate to `assertThat(null).isNotEqualTo(myVariable)`, an ambiguous method call. `JUnitAssertEqualsToAssertThat` and `JUnitAssertNotEqualsToAssertThat` now handle that directly by asserting on the non-null argument — `assertThat(myVariable).isNotEqualTo(null)` — which both compiles and still calls `myVariable.equals(null)` through AssertJ's `Objects.areEqual`.

Two existing expectations in `CleanupAssertionsTest` changed as a result, both now asserting the more conservative outcome:
- `assertFalse(!"".equals(null))` stops at `assertTrue("".equals(null))` instead of collapsing to `assertNull("")`.
- `assertNotEquals(myVariable, null)` is left as is instead of being flipped.