### PR TITLE
Emit `threadMode = SEPARATE_THREAD` when migrating `@Test(timeout = N)`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotation.java
@@ -157,7 +157,9 @@ public class UpdateTestAnnotation extends Recipe {
                     }
                 }
                 if (cta.timeout != null) {
-                    m = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS)")
+                    // JUnit 4 ran `@Test(timeout = N)` bodies in a separate daemon thread, so a hanging test never
+                    // blocked the runner; `@Timeout` defaults to the same thread, where a non-interruptible body hangs.
+                    m = JavaTemplate.builder("@Timeout(value = #{any(long)}, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)")
                             .javaParser(javaParser)
                             .imports("org.junit.jupiter.api.Timeout", "java.util.concurrent.TimeUnit")
                             .build()

--- a/src/test/java/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/EnclosedToNestedTest.java
@@ -163,7 +163,7 @@ class EnclosedToNestedTest implements RewriteTest {
                   @Nested
                   public class InnerTest {
                       @Test
-                      @Timeout(value = 10, unit = TimeUnit.MILLISECONDS)
+                      @Timeout(value = 10, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
                       public void test() {
                       }
                   }
@@ -211,7 +211,7 @@ class EnclosedToNestedTest implements RewriteTest {
                   public class InnerTest {
 
                       @Test
-                      @Timeout(value = 10, unit = TimeUnit.MILLISECONDS)
+                      @Timeout(value = 10, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
                       public void test() {
                       }
                   }

--- a/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/UpdateTestAnnotationTest.java
@@ -359,7 +359,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
 
                   @Test
-                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
+                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
                   public void test() {
                   }
               }
@@ -442,7 +442,7 @@ class UpdateTestAnnotationTest implements RewriteTest {
               public class MyTest {
 
                   @Test
-                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
+                  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
                   public void test() {
                       assertThrows(IllegalArgumentException.class, () -> {
                           throw new IllegalArgumentException("boom");


### PR DESCRIPTION
- Fixes #1073

JUnit 4's `@Test(timeout = N)` runs the test body in a separate daemon thread via `FailOnTimeout`, so a hanging test fails the method without ever blocking the runner.

`UpdateTestAnnotation` migrated that to a bare `@Timeout(value = N, unit = TimeUnit.MILLISECONDS)`, which inherits `ThreadMode.INFERRED` and resolves to `SAME_THREAD`. In that mode a test body that does not respond to interruption (infinite loop, lock contention without a blocking call) never returns, and the runner thread blocks indefinitely — the build hangs instead of failing.

Now emitting:

```java
@Timeout(value = 500, unit = TimeUnit.MILLISECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
```

This restores the JUnit 4 execution model exactly. Any test that passed under `@Test(timeout = N)` was already running thread-isolated, so this cannot introduce threading issues that did not already exist.

One thing worth flagging: `Timeout.ThreadMode` was added in JUnit Jupiter 5.9, so projects pinned to an older Jupiter would not compile the emitted annotation. The migration recipes upgrade Jupiter alongside this, so it should not bite in practice.

Tests in `UpdateTestAnnotationTest` and `EnclosedToNestedTest` updated accordingly.