### PR TITLE
Handle `MockitoJUnitRunner.StrictStubs` in `MockitoJUnitRunnerToExtension`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtension.java
@@ -15,9 +15,7 @@
  */
 package org.openrewrite.java.testing.mockito;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
@@ -88,7 +86,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                         @Override
                         public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, AtomicReference<Strictness> strictness) {
                             for (Strictness strict : Strictness.values()) {
-                                if (TypeUtils.isOfClassType(fieldAccess.getTarget().getType(), strict.runner)) {
+                                if (strict.runners.stream().anyMatch(runner -> TypeUtils.isOfClassType(fieldAccess.getTarget().getType(), runner))) {
                                     strictness.set(strict);
                                     break;
                                 }
@@ -111,6 +109,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                 List<String> obsoleteRunners = Arrays.asList(
                         "org.mockito.junit.MockitoJUnitRunner.Silent",
                         "org.mockito.junit.MockitoJUnitRunner.Strict",
+                        "org.mockito.junit.MockitoJUnitRunner.StrictStubs",
                         "org.mockito.junit.MockitoJUnitRunner");
                 if (hasMockitoExtensions) {
                     doAfterVisit(new RemoveObsoleteRunners(obsoleteRunners).getVisitor());
@@ -118,7 +117,7 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
                     doAfterVisit(new RunnerToExtension(obsoleteRunners, "org.mockito.junit.jupiter.MockitoExtension").getVisitor());
                 }
                 for (Strictness strictness : Strictness.values()) {
-                    maybeRemoveImport(strictness.runner);
+                    strictness.runners.forEach(this::maybeRemoveImport);
                 }
                 maybeAddImport("org.mockito.quality.Strictness");
                 maybeAddImport("org.mockito.junit.jupiter.MockitoSettings");
@@ -138,13 +137,16 @@ public class MockitoJUnitRunnerToExtension extends Recipe {
         });
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
     private enum Strictness {
         LENIENT("org.mockito.junit.MockitoJUnitRunner.Silent"),
         WARN("org.mockito.junit.MockitoJUnitRunner"),
-        STRICT_STUBS("org.mockito.junit.MockitoJUnitRunner.Strict");
+        STRICT_STUBS("org.mockito.junit.MockitoJUnitRunner.Strict", "org.mockito.junit.MockitoJUnitRunner.StrictStubs");
 
-        final String runner;
+        final List<String> runners;
+
+        Strictness(String... runners) {
+            this.runners = Arrays.asList(runners);
+        }
 
         // Return true, if current strictness is greater than given strictness.
         boolean isGreaterThan(Strictness strictness) {

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoJUnitRunnerToExtensionTest.java
@@ -66,6 +66,31 @@ class MockitoJUnitRunnerToExtensionTest implements RewriteTest {
         );
     }
 
+    @Test
+    void strictStubsMockitoRunnerToExtension() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.runner.RunWith;
+              import org.mockito.junit.MockitoJUnitRunner;
+
+              @RunWith(MockitoJUnitRunner.StrictStubs.class)
+              public class ExternalAPIServiceTest {
+              }
+              """,
+            """
+              import org.junit.jupiter.api.extension.ExtendWith;
+              import org.mockito.junit.jupiter.MockitoExtension;
+
+              @ExtendWith(MockitoExtension.class)
+              public class ExternalAPIServiceTest {
+              }
+              """
+          )
+        );
+    }
+
     @CsvSource({
       "MockitoJUnitRunner.Silent.class,Strictness.LENIENT",
       "MockitoJUnitRunner.class,Strictness.WARN"


### PR DESCRIPTION
- Fixes #1077

`@RunWith(MockitoJUnitRunner.StrictStubs.class)` was left untouched by the recipe, since `StrictStubs` appeared in neither the `Strictness` enum nor the `obsoleteRunners` list. Under `JUnit4to5Migration` that produces non-compiling output, because the same `recipeList` also removes the `junit:junit` dependency while `@RunWith` and its import survive.

As the reporter notes, the enum constant names have to stay exactly the three `org.mockito.quality.Strictness` values because `getTemplate()` interpolates the constant name into the template. So instead of adding a fourth constant, each `Strictness` now carries a list of runner FQNs, and `StrictStubs` joins `Strict` under `STRICT_STUBS`. That maps to a bare `@ExtendWith(MockitoExtension.class)` with no explicit `@MockitoSettings`, matching `MockitoSettings`' `STRICT_STUBS` default.

`StrictStubs` is added to `obsoleteRunners` as well, so the `@RunWith` annotation is actually replaced.