### PR TITLE
Do not convert constructors of types nested in a parameterized test class

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -270,10 +270,18 @@ public class ParameterizedRunnerToParameterized extends Recipe {
             return cd;
         }
 
+        /**
+         * Members of a type nested inside the parameterized test class have that class as an ancestor, but must not be
+         * rewritten; only members declared directly in the parameterized test class itself are in scope.
+         */
+        private boolean isDeclaredInScope() {
+            return scope.isScope(getCursor().firstEnclosing(J.ClassDeclaration.class));
+        }
+
         @Override
         public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             J.VariableDeclarations vdecls = super.visitVariableDeclarations(multiVariable, ctx);
-            if (!getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).isScopeInPath(scope)) {
+            if (!isDeclaredInScope()) {
                 return vdecls;
             }
 
@@ -294,7 +302,7 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         @Override
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
             J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
-            if (!getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).isScopeInPath(scope)) {
+            if (!isDeclaredInScope()) {
                 return m;
             }
             // Replace @Test with @ParameterizedTest

--- a/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterized.java
@@ -271,8 +271,8 @@ public class ParameterizedRunnerToParameterized extends Recipe {
         }
 
         /**
-         * Members of a type nested inside the parameterized test class have that class as an ancestor, but must not be
-         * rewritten; only members declared directly in the parameterized test class itself are in scope.
+         * Identity, not ancestry: members of a type nested inside the parameterized test class have that class as an
+         * ancestor, but are not themselves members of it, and must be left alone.
          */
         private boolean isDeclaredInScope() {
             return scope.isScope(getCursor().firstEnclosing(J.ClassDeclaration.class));

--- a/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
@@ -722,6 +722,11 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
                       Helper(String name) {
                           this.name = name;
                       }
+
+                      @Test
+                      public void helperTest() {
+                          assert name != null;
+                      }
                   }
 
                   @Test
@@ -731,6 +736,7 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
               }
               """,
             """
+              import org.junit.Test;
               import org.junit.jupiter.params.ParameterizedTest;
               import org.junit.jupiter.params.provider.MethodSource;
 
@@ -765,6 +771,11 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
 
                       Helper(String name) {
                           this.name = name;
+                      }
+
+                      @Test
+                      public void helperTest() {
+                          assert name != null;
                       }
                   }
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/ParameterizedRunnerToParameterizedTest.java
@@ -674,4 +674,109 @@ class ParameterizedRunnerToParameterizedTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1080")
+    @Test
+    void constructorsOfNestedTypesAreNotConverted() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import org.junit.Test;
+              import org.junit.runner.RunWith;
+              import org.junit.runners.Parameterized;
+              import org.junit.runners.Parameterized.Parameters;
+
+              import java.util.Arrays;
+              import java.util.List;
+
+              @RunWith(Parameterized.class)
+              public class MyTest {
+
+                  private String input;
+
+                  public MyTest(String input) {
+                      this.input = input;
+                  }
+
+                  @Parameters
+                  public static List<Object[]> data() {
+                      return Arrays.asList(new Object[][]{{"a"}, {"b"}});
+                  }
+
+                  enum Status {
+                      OK("ok"),
+                      BAD("bad");
+
+                      private final String label;
+
+                      Status(String label) {
+                          this.label = label;
+                      }
+                  }
+
+                  static class Helper {
+                      private final String name;
+
+                      Helper(String name) {
+                          this.name = name;
+                      }
+                  }
+
+                  @Test
+                  public void test() {
+                      assert input != null;
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.params.ParameterizedTest;
+              import org.junit.jupiter.params.provider.MethodSource;
+
+              import java.util.Arrays;
+              import java.util.List;
+
+              public class MyTest {
+
+                  private String input;
+
+                  public void initMyTest(String input) {
+                      this.input = input;
+                  }
+
+                  public static List<Object[]> data() {
+                      return Arrays.asList(new Object[][]{{"a"}, {"b"}});
+                  }
+
+                  enum Status {
+                      OK("ok"),
+                      BAD("bad");
+
+                      private final String label;
+
+                      Status(String label) {
+                          this.label = label;
+                      }
+                  }
+
+                  static class Helper {
+                      private final String name;
+
+                      Helper(String name) {
+                          this.name = name;
+                      }
+                  }
+
+                  @MethodSource("data")
+                  @ParameterizedTest
+                  public void test(String input) {
+                      initMyTest(input);
+                      assert input != null;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #1080

`ParameterizedRunnerToParameterizedTestsVisitor` guarded `visitMethodDeclaration` and `visitVariableDeclarations` with `getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).isScopeInPath(scope)`. `isScopeInPath` asks whether the scope appears anywhere in the cursor *path* — ancestry, not identity — so members of a type nested inside the `@RunWith(Parameterized.class)` class passed the guard.

For constructor injection that meant a nested class or enum constructor was renamed to `init<TestClassName>` and given a `void` return type:

```java
enum Status {
    OK("ok"), BAD("bad");
    private final String label;
    void initMyTest(String label) { // was: Status(String label)
        this.label = label;
    }
}
```

which leaves both the enum constants and the assignment to the `final` field uncompilable. This reproduces through `JUnit4to5Migration` as well; no later recipe in the chain repairs it.

Both guards now require the enclosing class declaration to *be* the scope, matching what `visitClassDeclaration` already did with `scope.isScope(classDecl)`. Thanks @mattdepaula for the precise diagnosis.