### PR TITLE
Keep an explicit JUnit owner when migrating a qualified `assertTrue(x instanceof Y)`

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -39,9 +39,11 @@ import static java.util.Collections.singletonList;
 
 public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
 
-    // Template prefixes for the emitted call's qualifier, including the trailing dot
-    private static final String SIMPLE_ASSERTIONS_QUALIFIER = "Assertions.";
-    private static final String FULLY_QUALIFIED_ASSERTIONS_QUALIFIER = "org.junit.jupiter.api.Assertions.";
+    private static final String SIMPLE_ASSERTIONS_QUALIFIER = "Assertions";
+    private static final String FULLY_QUALIFIED_ASSERTIONS_QUALIFIER = "org.junit.jupiter.api.Assertions";
+
+    private static final String ASSERT_INSTANCE_OF_TEMPLATE = "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)})";
+    private static final String ASSERT_INSTANCE_OF_WITH_REASON_TEMPLATE = "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}, #{any(java.lang.String)})";
 
     @Getter
     final String displayName = "`assertTrue(x instanceof y)` to `assertInstanceOf(y.class, x)`";
@@ -68,8 +70,6 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 // subtype can hide `assertInstanceOf`, and a bare `Assertions` can be shadowed several ways
                 Expression retainedSelect = isAssertionsClassReference(select) ? select : null;
                 boolean unqualifiedCall = retainedSelect == null && select == null;
-                String owner = retainedSelect != null ? SIMPLE_ASSERTIONS_QUALIFIER :
-                        unqualifiedCall ? "" : FULLY_QUALIFIED_ASSERTIONS_QUALIFIER;
 
                 if (junit5Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
@@ -119,8 +119,13 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
 
 
                 // An unqualified call is left unqualified; a same-named declaration in scope can still capture it
+                String templateCode = reason != null ? ASSERT_INSTANCE_OF_WITH_REASON_TEMPLATE : ASSERT_INSTANCE_OF_TEMPLATE;
+                if (!unqualifiedCall) {
+                    String qualifier = retainedSelect != null ? SIMPLE_ASSERTIONS_QUALIFIER : FULLY_QUALIFIED_ASSERTIONS_QUALIFIER;
+                    templateCode = qualifier + "." + templateCode;
+                }
                 JavaTemplate.Builder templateBuilder = JavaTemplate
-                    .builder(owner + "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
+                    .builder(templateCode)
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"));
                 if (unqualifiedCall) {
                     templateBuilder.staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf");

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -58,12 +58,9 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 Expression expression;
                 Expression reason;
                 Expression select = mi.getSelect();
-                // A qualified call keeps an explicit owner, so that the emitted `assertInstanceOf` resolves to
-                // JUnit's declaration rather than to one the calling class declares or inherits. The selector is
-                // reused only when it names `Assertions` itself; any other selector is replaced by the fully
-                // qualified name, as a subtype can hide `assertInstanceOf` with a declaration of its own, and a
-                // bare `Assertions` could be shadowed by a member type, an inherited member type, a field, or a
-                // same-package type.
+                // Keep an explicit owner so the emitted call resolves to JUnit's declaration rather than one the
+                // calling class declares or inherits. Only a selector naming `Assertions` itself is reused; a
+                // subtype can hide `assertInstanceOf`, and a bare `Assertions` can be shadowed several ways
                 Expression retainedSelect = isAssertionsClassReference(select) ? select : null;
                 String owner = retainedSelect != null ? "Assertions." :
                         select == null ? "" : "org.junit.jupiter.api.Assertions.";
@@ -145,8 +142,8 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
             }
 
             /**
-             * @return whether the selector references {@code org.junit.jupiter.api.Assertions} itself, spelled as
-             * a simple or fully qualified type name; a subtype or a variable is rejected.
+             * @return whether the selector names {@code org.junit.jupiter.api.Assertions} itself, simple or fully
+             * qualified; a subtype or a variable is rejected.
              */
             private boolean isAssertionsClassReference(@Nullable Expression select) {
                 if (select instanceof J.Identifier) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -38,6 +38,11 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
+
+    // Template prefixes for the emitted call's qualifier, including the trailing dot
+    private static final String SIMPLE_ASSERTIONS_QUALIFIER = "Assertions.";
+    private static final String FULLY_QUALIFIED_ASSERTIONS_QUALIFIER = "org.junit.jupiter.api.Assertions.";
+
     @Getter
     final String displayName = "`assertTrue(x instanceof y)` to `assertInstanceOf(y.class, x)`";
 
@@ -62,8 +67,9 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 // calling class declares or inherits. Only a selector naming `Assertions` itself is reused; a
                 // subtype can hide `assertInstanceOf`, and a bare `Assertions` can be shadowed several ways
                 Expression retainedSelect = isAssertionsClassReference(select) ? select : null;
-                String owner = retainedSelect != null ? "Assertions." :
-                        select == null ? "" : "org.junit.jupiter.api.Assertions.";
+                boolean unqualifiedCall = retainedSelect == null && select == null;
+                String owner = retainedSelect != null ? SIMPLE_ASSERTIONS_QUALIFIER :
+                        unqualifiedCall ? "" : FULLY_QUALIFIED_ASSERTIONS_QUALIFIER;
 
                 if (junit5Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
@@ -116,7 +122,7 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 JavaTemplate.Builder templateBuilder = JavaTemplate
                     .builder(owner + "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"));
-                if (owner.isEmpty()) {
+                if (unqualifiedCall) {
                     templateBuilder.staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf");
                     maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
                 } else if (retainedSelect != null) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.junit5;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
@@ -29,6 +30,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JLeftPadded;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.java.tree.TypedTree;
 import org.openrewrite.marker.Markers;
 
@@ -55,9 +57,25 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 TypedTree clazz;
                 Expression expression;
                 Expression reason;
+                Expression select = mi.getSelect();
+                Expression retainedSelect;
+                String owner;
 
                 if (junit5Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
+                    // Reuse the selector only when it names the `Assertions` class itself; there
+                    // `assertInstanceOf` necessarily resolves to JUnit's declaration. A subtype can
+                    // hide `assertInstanceOf` with a declaration of its own, and an instance-typed
+                    // selector resolves against the variable's static type, so both fall back to
+                    // the unqualified call with a static import, as for an unqualified input.
+                    retainedSelect = isAssertionsClassReference(select) ? select : null;
+                    owner = retainedSelect == null ? "" : "Assertions.";
+                    if (retainedSelect == null && select != null) {
+                        JavaType.FullyQualified selectType = TypeUtils.asFullyQualified(select.getType());
+                        if (selectType != null) {
+                            maybeRemoveImport(selectType.getFullyQualifiedName());
+                        }
+                    }
                     Expression argument = mi.getArguments().get(0);
                     if (mi.getArguments().size() == 1) {
                         reason = null;
@@ -76,6 +94,16 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                     }
                 } else if (junit4Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.Assert.assertTrue");
+                    // The selector denotes `Assert`, which does not declare `assertInstanceOf`. A
+                    // qualified call keeps an explicit owner as the fully qualified
+                    // `org.junit.jupiter.api.Assertions.assertInstanceOf`, because a bare
+                    // `Assertions` simple name could itself be shadowed by a member type, an
+                    // inherited member type, a field, or a same-package type.
+                    retainedSelect = null;
+                    owner = select == null ? "" : "org.junit.jupiter.api.Assertions.";
+                    if (select != null) {
+                        maybeRemoveImport("org.junit.Assert");
+                    }
                     Expression argument;
                     if (mi.getArguments().size() == 1) {
                         reason = null;
@@ -99,18 +127,43 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 }
 
 
-                JavaTemplate template = JavaTemplate
-                    .builder("assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
-                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"))
-                    .staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf")
-                    .build();
+                // An unqualified call is left unqualified; a same-named local declaration can still capture
+                // it, which this change does not address (see the PR description).
+                JavaTemplate.Builder templateBuilder = JavaTemplate
+                    .builder(owner + "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"));
+                if (owner.isEmpty()) {
+                    templateBuilder.staticImports("org.junit.jupiter.api.Assertions.assertInstanceOf");
+                    maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
+                } else if (retainedSelect != null) {
+                    templateBuilder.imports("org.junit.jupiter.api.Assertions");
+                }
 
-                maybeAddImport("org.junit.jupiter.api.Assertions", "assertInstanceOf");
                 TypedTree rawClazz = clazz instanceof J.ParameterizedType ? ((J.ParameterizedType) clazz).getClazz() : clazz;
                 Expression classLiteral = toClassLiteral(rawClazz);
-                return reason != null ?
+                JavaTemplate template = templateBuilder.build();
+                J.MethodInvocation replacement = reason != null ?
                     template.apply(getCursor(), mi.getCoordinates().replace(), classLiteral, expression, reason) :
                     template.apply(getCursor(), mi.getCoordinates().replace(), classLiteral, expression);
+                return retainedSelect == null ? replacement : replacement.withSelect(retainedSelect.withPrefix(Space.EMPTY));
+            }
+
+            /**
+             * True only when the selector is a reference to the {@code org.junit.jupiter.api.Assertions}
+             * class itself, spelled as a simple or fully qualified type name. A reference to a subtype or
+             * to a variable is rejected, because the emitted {@code assertInstanceOf} would resolve
+             * against that type, which may hide JUnit's method with a declaration of its own.
+             */
+            private boolean isAssertionsClassReference(@Nullable Expression select) {
+                if (select instanceof J.Identifier) {
+                    return ((J.Identifier) select).getFieldType() == null &&
+                        TypeUtils.isOfClassType(select.getType(), "org.junit.jupiter.api.Assertions");
+                }
+                if (select instanceof J.FieldAccess) {
+                    return ((J.FieldAccess) select).getName().getFieldType() == null &&
+                        TypeUtils.isOfClassType(select.getType(), "org.junit.jupiter.api.Assertions");
+                }
+                return false;
             }
 
             private Expression toClassLiteral(TypedTree clazz) {

--- a/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOf.java
@@ -58,23 +58,20 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 Expression expression;
                 Expression reason;
                 Expression select = mi.getSelect();
-                Expression retainedSelect;
-                String owner;
+                // A qualified call keeps an explicit owner, so that the emitted `assertInstanceOf` resolves to
+                // JUnit's declaration rather than to one the calling class declares or inherits. The selector is
+                // reused only when it names `Assertions` itself; any other selector is replaced by the fully
+                // qualified name, as a subtype can hide `assertInstanceOf` with a declaration of its own, and a
+                // bare `Assertions` could be shadowed by a member type, an inherited member type, a field, or a
+                // same-package type.
+                Expression retainedSelect = isAssertionsClassReference(select) ? select : null;
+                String owner = retainedSelect != null ? "Assertions." :
+                        select == null ? "" : "org.junit.jupiter.api.Assertions.";
 
                 if (junit5Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.jupiter.api.Assertions.assertTrue");
-                    // Reuse the selector only when it names the `Assertions` class itself; there
-                    // `assertInstanceOf` necessarily resolves to JUnit's declaration. A subtype can
-                    // hide `assertInstanceOf` with a declaration of its own, and an instance-typed
-                    // selector resolves against the variable's static type, so both fall back to
-                    // the unqualified call with a static import, as for an unqualified input.
-                    retainedSelect = isAssertionsClassReference(select) ? select : null;
-                    owner = retainedSelect == null ? "" : "Assertions.";
-                    if (retainedSelect == null && select != null) {
-                        JavaType.FullyQualified selectType = TypeUtils.asFullyQualified(select.getType());
-                        if (selectType != null) {
-                            maybeRemoveImport(selectType.getFullyQualifiedName());
-                        }
+                    if (retainedSelect == null) {
+                        maybeRemoveSelectTypeImport(select);
                     }
                     Expression argument = mi.getArguments().get(0);
                     if (mi.getArguments().size() == 1) {
@@ -94,16 +91,7 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                     }
                 } else if (junit4Matcher.matches(mi)) {
                     maybeRemoveImport("org.junit.Assert.assertTrue");
-                    // The selector denotes `Assert`, which does not declare `assertInstanceOf`. A
-                    // qualified call keeps an explicit owner as the fully qualified
-                    // `org.junit.jupiter.api.Assertions.assertInstanceOf`, because a bare
-                    // `Assertions` simple name could itself be shadowed by a member type, an
-                    // inherited member type, a field, or a same-package type.
-                    retainedSelect = null;
-                    owner = select == null ? "" : "org.junit.jupiter.api.Assertions.";
-                    if (select != null) {
-                        maybeRemoveImport("org.junit.Assert");
-                    }
+                    maybeRemoveSelectTypeImport(select);
                     Expression argument;
                     if (mi.getArguments().size() == 1) {
                         reason = null;
@@ -127,8 +115,7 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 }
 
 
-                // An unqualified call is left unqualified; a same-named local declaration can still capture
-                // it, which this change does not address (see the PR description).
+                // An unqualified call is left unqualified; a same-named declaration in scope can still capture it
                 JavaTemplate.Builder templateBuilder = JavaTemplate
                     .builder(owner + "assertInstanceOf(#{any(java.lang.Class)}, #{any(java.lang.Object)}" + (reason != null ? ", #{any(java.lang.String)})" : ")"))
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "junit-jupiter-api-5", "junit-4"));
@@ -148,11 +135,18 @@ public class AssertTrueInstanceofToAssertInstanceOf extends Recipe {
                 return retainedSelect == null ? replacement : replacement.withSelect(retainedSelect.withPrefix(Space.EMPTY));
             }
 
+            private void maybeRemoveSelectTypeImport(@Nullable Expression select) {
+                if (select != null) {
+                    JavaType.FullyQualified selectType = TypeUtils.asFullyQualified(select.getType());
+                    if (selectType != null) {
+                        maybeRemoveImport(selectType.getFullyQualifiedName());
+                    }
+                }
+            }
+
             /**
-             * True only when the selector is a reference to the {@code org.junit.jupiter.api.Assertions}
-             * class itself, spelled as a simple or fully qualified type name. A reference to a subtype or
-             * to a variable is rejected, because the emitted {@code assertInstanceOf} would resolve
-             * against that type, which may hide JUnit's method with a declaration of its own.
+             * @return whether the selector references {@code org.junit.jupiter.api.Assertions} itself, spelled as
+             * a simple or fully qualified type name; a subtype or a variable is rejected.
              */
             private boolean isAssertionsClassReference(@Nullable Expression select) {
                 if (select instanceof J.Identifier) {

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -265,29 +265,81 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
     }
 
     @Test
-    void qualifiedJUnit5NotCapturedBySameClassMethod() {
+    void qualifiedCallsUseJupiterOwner() {
         //language=java
         rewriteRun(
           java(
             """
-              class Test {
+              import java.util.function.Supplier;
+
+              class ATest {
                   static void assertInstanceOf(Class<?> type, Object value) {
                       throw new AssertionError("wrong owner");
+                  }
+
+                  static void assertInstanceOf(String message) {
+                  }
+
+                  static void assertInstanceOf(Class<?> type, Object value, String message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  static void assertInstanceOf(Class<?> type, Object value, Supplier<String> message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  static class Assertions {
+                      static void assertInstanceOf(Class<?> type, Object value) {
+                          throw new AssertionError("wrong owner");
+                      }
                   }
 
                   void test(Object value) {
                       org.junit.jupiter.api.Assertions.assertTrue(value instanceof String);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String, "not a String");
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String, () -> "not a String");
+                      org.junit.Assert.assertTrue(value instanceof String);
+                      org.junit.Assert.assertTrue("not a String", value instanceof String);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof java.util.List<?>);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof java.util.Map.Entry);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String[]);
                   }
               }
               """,
             """
-              class Test {
+              import java.util.function.Supplier;
+
+              class ATest {
                   static void assertInstanceOf(Class<?> type, Object value) {
                       throw new AssertionError("wrong owner");
                   }
 
+                  static void assertInstanceOf(String message) {
+                  }
+
+                  static void assertInstanceOf(Class<?> type, Object value, String message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  static void assertInstanceOf(Class<?> type, Object value, Supplier<String> message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  static class Assertions {
+                      static void assertInstanceOf(Class<?> type, Object value) {
+                          throw new AssertionError("wrong owner");
+                      }
+                  }
+
                   void test(Object value) {
                       org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, () -> "not a String");
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(java.util.List.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(java.util.Map.Entry.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String[].class, value);
                   }
               }
               """
@@ -319,68 +371,6 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               class ATest extends BaseAssert {
                   void test(Object value) {
                       org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
-    void qualifiedJUnit5WithReasonNotCapturedByIncompatibleSameNameMethod() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class ATest {
-                  static void assertInstanceOf(String message) {
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String, "not a String");
-                  }
-              }
-              """,
-            """
-              class ATest {
-                  static void assertInstanceOf(String message) {
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
-    void qualifiedJUnit5WithSupplierReason() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.jupiter.api.Assertions;
-
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value, java.util.function.Supplier<String> message) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      Assertions.assertTrue(value instanceof String, () -> "not a String");
-                  }
-              }
-              """,
-            """
-              import org.junit.jupiter.api.Assertions;
-
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value, java.util.function.Supplier<String> message) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      Assertions.assertInstanceOf(String.class, value, () -> "not a String");
                   }
               }
               """
@@ -517,68 +507,6 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
     }
 
     @Test
-    void qualifiedJUnit4() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.junit.Assert;
-
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      Assert.assertTrue(value instanceof String);
-                  }
-              }
-              """,
-            """
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
-    void qualifiedJUnit4WithReason() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value, String message) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      org.junit.Assert.assertTrue("not a String", value instanceof String);
-                  }
-              }
-              """,
-            """
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value, String message) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
     void qualifiedJUnit4SubtypeSelector() {
         //language=java
         rewriteRun(
@@ -606,40 +534,6 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               package com.sample.test;
 
               class ATest {
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
-    void qualifiedJUnit4NotCapturedByNestedAssertionsClass() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              class ATest {
-                  static class Assertions {
-                      static void assertInstanceOf(Class<?> type, Object value) {
-                          throw new AssertionError("wrong owner");
-                      }
-                  }
-
-                  void test(Object value) {
-                      org.junit.Assert.assertTrue(value instanceof String);
-                  }
-              }
-              """,
-            """
-              class ATest {
-                  static class Assertions {
-                      static void assertInstanceOf(Class<?> type, Object value) {
-                          throw new AssertionError("wrong owner");
-                      }
-                  }
-
                   void test(Object value) {
                       org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
                   }
@@ -680,46 +574,6 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
                   void test(Object value) {
                       Assertions.assertThat(value);
                       org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
-                  }
-              }
-              """
-          ));
-    }
-
-    @Test
-    void qualifiedOwnerWithGenericNestedAndArrayTargets() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import java.util.List;
-              import java.util.Map;
-
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof List<?>);
-                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof Map.Entry);
-                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String[]);
-                  }
-              }
-              """,
-            """
-              import java.util.List;
-              import java.util.Map;
-
-              class ATest {
-                  static void assertInstanceOf(Class<?> type, Object value) {
-                      throw new AssertionError("wrong owner");
-                  }
-
-                  void test(Object value) {
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(List.class, value);
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(Map.Entry.class, value);
-                      org.junit.jupiter.api.Assertions.assertInstanceOf(String[].class, value);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -257,6 +258,477 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
                   void test() {
                       Object obj = new Foo();
                       assertInstanceOf(Foo.class, obj);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5NotCapturedBySameClassMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              class Test {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5NotCapturedByInheritedMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class BaseAssert {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class ATest extends BaseAssert {
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              class ATest extends BaseAssert {
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5WithReasonNotCapturedByIncompatibleSameNameMethod() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class ATest {
+                  static void assertInstanceOf(String message) {
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String, "not a String");
+                  }
+              }
+              """,
+            """
+              class ATest {
+                  static void assertInstanceOf(String message) {
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5WithSupplierReason() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value, java.util.function.Supplier<String> message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      Assertions.assertTrue(value instanceof String, () -> "not a String");
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Assertions;
+
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value, java.util.function.Supplier<String> message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      Assertions.assertInstanceOf(String.class, value, () -> "not a String");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5SubtypeSelectorHidingAssertInstanceOf() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class BaseAssert extends org.junit.jupiter.api.Assertions {
+                  public static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue) {
+                      throw new AssertionError("wrong owner");
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class ATest {
+                  void test(Object value) {
+                      BaseAssert.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  void test(Object value) {
+                      assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5SubtypeSelectorHidingAssertInstanceOfWithReason() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class BaseAssert extends org.junit.jupiter.api.Assertions {
+                  public static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue, String message) {
+                      throw new AssertionError("wrong owner");
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class ATest {
+                  void test(Object value) {
+                      BaseAssert.assertTrue(value instanceof String, "not a String");
+                  }
+              }
+              """,
+            """
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  void test(Object value) {
+                      assertInstanceOf(String.class, value, "not a String");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5InstanceSelector() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              public class BaseAssert extends org.junit.jupiter.api.Assertions {
+                  public static <T> T assertInstanceOf(Class<T> expectedType, Object actualValue) {
+                      throw new AssertionError("wrong owner");
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              class ATest {
+                  void test(BaseAssert base, Object value) {
+                      base.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  void test(BaseAssert base, Object value) {
+                      assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit5SubtypeSelector() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.sample;
+
+              public class MyAssertions extends org.junit.jupiter.api.Assertions {
+              }
+              """
+          ),
+          java(
+            """
+              package com.sample.test;
+
+              import com.sample.MyAssertions;
+
+              class ATest {
+                  void test(Object value) {
+                      MyAssertions.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              package com.sample.test;
+
+              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+              class ATest {
+                  void test(Object value) {
+                      assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit4() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Assert;
+
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      Assert.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit4WithReason() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value, String message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.Assert.assertTrue("not a String", value instanceof String);
+                  }
+              }
+              """,
+            """
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value, String message) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit4NotCapturedByNestedAssertionsClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class ATest {
+                  static class Assertions {
+                      static void assertInstanceOf(Class<?> type, Object value) {
+                          throw new AssertionError("wrong owner");
+                      }
+                  }
+
+                  void test(Object value) {
+                      org.junit.Assert.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              class ATest {
+                  static class Assertions {
+                      static void assertInstanceOf(Class<?> type, Object value) {
+                          throw new AssertionError("wrong owner");
+                      }
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit4DoesNotShadowSamePackageAssertionsHelper() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.example;
+
+              public class Assertions {
+                  public static void assertThat(Object value) {
+                  }
+              }
+              """
+          ),
+          java(
+            """
+              package com.example;
+
+              class ATest {
+                  void test(Object value) {
+                      Assertions.assertThat(value);
+                      org.junit.Assert.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              package com.example;
+
+              class ATest {
+                  void test(Object value) {
+                      Assertions.assertThat(value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedOwnerWithGenericNestedAndArrayTargets() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import java.util.List;
+              import java.util.Map;
+
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof List<?>);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof Map.Entry);
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String[]);
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              import java.util.Map;
+
+              class ATest {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(List.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(Map.Entry.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String[].class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedOutputIsStableOnASecondRun() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  static void assertInstanceOf(Class<?> type, Object value) {
+                      throw new AssertionError("wrong owner");
+                  }
+
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void noChangeWhenAssertTrueIsNotAttributed() {
+        //language=java
+        rewriteRun(
+          spec -> spec
+            .parser(JavaParser.fromJavaVersion())
+            .typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              class Test {
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertTrue(value instanceof String);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertTrueInstanceofToAssertInstanceOfTest.java
@@ -409,11 +409,9 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               }
               """,
             """
-              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
               class ATest {
                   void test(Object value) {
-                      assertInstanceOf(String.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
                   }
               }
               """
@@ -442,11 +440,9 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               }
               """,
             """
-              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
               class ATest {
                   void test(Object value) {
-                      assertInstanceOf(String.class, value, "not a String");
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
                   }
               }
               """
@@ -475,11 +471,9 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
               }
               """,
             """
-              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
               class ATest {
                   void test(BaseAssert base, Object value) {
-                      assertInstanceOf(String.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
                   }
               }
               """
@@ -513,11 +507,9 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
             """
               package com.sample.test;
 
-              import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
               class ATest {
                   void test(Object value) {
-                      assertInstanceOf(String.class, value);
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
                   }
               }
               """
@@ -580,6 +572,42 @@ class AssertTrueInstanceofToAssertInstanceOfTest implements RewriteTest {
 
                   void test(Object value) {
                       org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value, "not a String");
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void qualifiedJUnit4SubtypeSelector() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package com.sample;
+
+              public class MyAssert extends org.junit.Assert {
+              }
+              """
+          ),
+          java(
+            """
+              package com.sample.test;
+
+              import com.sample.MyAssert;
+
+              class ATest {
+                  void test(Object value) {
+                      MyAssert.assertTrue(value instanceof String);
+                  }
+              }
+              """,
+            """
+              package com.sample.test;
+
+              class ATest {
+                  void test(Object value) {
+                      org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
                   }
               }
               """


### PR DESCRIPTION
**Suggested review order:** 37 of 52 (Score: 2)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/974

## What's changed?

A call is qualified when the source writes a qualifier in front of the method name, as in `Assertions.assertTrue(...)`; the recipe's code calls that qualifier the owner. For such a call, [`AssertTrueInstanceofToAssertInstanceOf`](https://docs.openrewrite.org/recipes/java/testing/junit5/asserttrueinstanceoftoassertinstanceof) now writes a qualifier in front of the `assertInstanceOf` call it emits as well, so the emitted call resolves to JUnit's `assertInstanceOf`, as the input call resolved to JUnit's `assertTrue`.

Before this change, the recipe emitted an unqualified `assertInstanceOf` call plus a static import of `org.junit.jupiter.api.Assertions.assertInstanceOf` for every input call, qualified or not. An unqualified call binds to a method declared in or inherited by the enclosing class before a static import of that name is considered ([JLS 6.5.7.1](https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.5.7.1)), so where the calling class has its own `assertInstanceOf`, the emitted call runs that one.

### Before

```java
class Test {
    static void assertInstanceOf(Class<?> type, Object value) {
        throw new AssertionError("wrong owner");
    }

    void test(Object value) {
        org.junit.jupiter.api.Assertions.assertTrue(value instanceof String);
    }
}
```

### Actual after the recipe

Using main today. It compiles, but the emitted call now runs the `assertInstanceOf` method declared in `Test`, not JUnit's:

```java
import static org.junit.jupiter.api.Assertions.assertInstanceOf;

class Test {
    static void assertInstanceOf(Class<?> type, Object value) {
        throw new AssertionError("wrong owner");
    }

    void test(Object value) {
        assertInstanceOf(String.class, value);
    }
}
```

### Expected after the recipe

The emitted call runs JUnit's `assertInstanceOf`:

```java
class Test {
    static void assertInstanceOf(Class<?> type, Object value) {
        throw new AssertionError("wrong owner");
    }

    void test(Object value) {
        org.junit.jupiter.api.Assertions.assertInstanceOf(String.class, value);
    }
}
```

One rule now covers both the JUnit 4 and the JUnit 5 input:

- An unqualified call is migrated as before this change, to an unqualified `assertInstanceOf` plus a static import.
- A call qualified by `Assertions` itself, as a simple or fully qualified name, keeps that qualifier. There `assertInstanceOf` necessarily resolves to JUnit's declaration.
- A call qualified by anything else - `org.junit.Assert`, a subclass of `Assertions`, a variable - is migrated to the fully qualified `org.junit.jupiter.api.Assertions.assertInstanceOf(...)`. Reusing such a qualifier is unsafe: a subclass can hide `assertInstanceOf` with a static declaration of its own ([JLS 8.4.8.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.4.8.2)), and the simple name `Assertions` can resolve to a member type, a field, or a same-package type, which `qualifiedJUnit4NotCapturedByNestedAssertionsClass` and `qualifiedJUnit4DoesNotShadowSamePackageAssertionsHelper` pin down. When dropping the qualifier leaves the import of the qualifier's own type unused, that import is now removed too.

## What's your motivation?

**Recipe:** `org.openrewrite.java.testing.junit5.AssertTrueInstanceofToAssertInstanceOf`.

The output that main produces today compiles, so nothing fails at build time; what changes is the behaviour at run time. Call `test("value")` on the example above: against the input it returns normally, because `"value" instanceof String` is true and JUnit's `assertTrue` passes, and against main's output it throws `AssertionError("wrong owner")`.

Which of the two ways a real suite goes wrong depends on the calling class's own `assertInstanceOf`. One that returns without checking makes the assertion vacuous, so the test keeps passing while no longer testing what it used to; one that throws, as here, fails the test with its own message instead of JUnit's. A migration must not change which method a call binds to. Reproduced on 3.43.0 and on a snapshot from main at 96ec8d6e.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed: the six existing tests are untouched, including the one marked `@DocumentExample`, so the generated `META-INF/rewrite/examples.yml` needs no edit. All six of those inputs call `assertTrue` through a static import, with no qualifier, so the new handling of qualifiers never fires on them.

Three limits:

- An unqualified input call is still not protected: the recipe emits an unqualified call for it both before and after this change, so an `assertInstanceOf` declared in or inherited by the calling class still wins over the static import there. Qualifying those calls too is a separate decision, left out here.
- For an instance qualifier such as `getAssertions().assertTrue(...)`, the receiver expression is dropped, so any side effect of `getAssertions()` is lost. The recipe already did that.
- If a field or a variable named `org` is in scope at the call site, the fully qualified output does not compile, because the leading `org` then resolves to that field or variable rather than to the package ([JLS 6.5.2](https://docs.oracle.com/javase/specs/jls/se21/html/jls-6.html#jls-6.5.2)). This adds no new kind of failure: wherever such a name is in scope, every other fully qualified name starting with `org.` is already unusable in the same way.

Two behaviours here are inherited rather than new. A file carrying no type information matches neither of the recipe's two `MethodMatcher`s and is left alone, which `noChangeWhenAssertTrueIsNotAttributed` pins down; and a JUnit 5 call whose qualifier is not attributed fails the `isAssertionsClassReference` check, so it takes the fully qualified path.

## Any additional context

This change adds 10 test methods to `AssertTrueInstanceofToAssertInstanceOfTest`, taking the focused class from 6 to 16 executions. Those methods cover 16 scenarios. Without the code change, 8 methods fail and represent 14 failing scenarios. `qualifiedCallsUseJupiterOwner` contains the same-class shadowing, JUnit 4, message, supplier, generic, nested and array cases in one source fixture. The other tests cover inherited shadowing, qualified subtypes and instances, same-package shadowing, stable output and missing attribution.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
