### PR TITLE
Only remove `MockUtil` declarations whose uses are all migrated

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
@@ -16,13 +16,23 @@
 package org.openrewrite.java.testing.mockito;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.ChangeMethodTargetToStatic;
-import org.openrewrite.java.DeleteStatement;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * In Mockito 1 you use a code snippet like:
@@ -50,8 +60,11 @@ public class MockUtilsToStatic extends Recipe {
     }
 
     public static class MockUtilsToStaticVisitor extends JavaVisitor<ExecutionContext> {
-        private static final MethodMatcher METHOD_MATCHER = new MethodMatcher("org.mockito.internal.util.MockUtil <constructor>()");
-        private final ChangeMethodTargetToStatic changeMethodTargetToStatic = new ChangeMethodTargetToStatic("org.mockito.internal.util.MockUtil *(..)", "org.mockito.internal.util.MockUtil", null, null, false);
+        private static final String MOCK_UTIL = "org.mockito.internal.util.MockUtil";
+        private static final String MOCK_UTIL_METHODS = MOCK_UTIL + " *(..)";
+        private static final MethodMatcher METHOD_MATCHER = new MethodMatcher(MOCK_UTIL + " <constructor>()");
+        private static final MethodMatcher MIGRATED_METHOD_MATCHER = new MethodMatcher(MOCK_UTIL_METHODS);
+        private final ChangeMethodTargetToStatic changeMethodTargetToStatic = new ChangeMethodTargetToStatic(MOCK_UTIL_METHODS, MOCK_UTIL, null, null, false);
 
         @Override
         public J visitCompilationUnit(J.CompilationUnit compilationUnit, ExecutionContext ctx) {
@@ -60,21 +73,161 @@ public class MockUtilsToStatic extends Recipe {
         }
 
         @Override
-        public J visitNewClass(J.NewClass newClass, ExecutionContext ctx) {
-            if (METHOD_MATCHER.matches(newClass)) {
-                // Check to see if the new MockUtil() is being assigned to a variable or field, like
-                // MockUtil util = new MockUtil();
-                // If it is, then we'll get rid of it
-
-                Cursor parent = getCursor().dropParentUntil(J.class::isInstance);
-                if (parent.getValue() instanceof J.VariableDeclarations.NamedVariable) {
-                    Object namedVar = parent.dropParentUntil(J.class::isInstance).getValue();
-                    if (namedVar instanceof J.VariableDeclarations) {
-                        doAfterVisit(new DeleteStatement<>((J.VariableDeclarations) namedVar));
-                    }
-                }
+        public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+            J.VariableDeclarations vd = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
+            // Declarations of `new MockUtil()` are only obsolete once every use of the declared variable in this
+            // compilation unit is the receiver of a call that is migrated to its static form; every other use would
+            // be left undefined. Uses of a visible field from another source file are not analysed.
+            J.CompilationUnit scope = getCursor().firstEnclosing(J.CompilationUnit.class);
+            if (scope == null) {
+                return vd;
             }
-            return super.visitNewClass(newClass, ctx);
+
+            List<JRightPadded<J.VariableDeclarations.NamedVariable>> variables =
+                    ListUtils.map(vd.getPadding().getVariables(), v -> isObsoleteMockUtilInstance(v.getElement(), scope) ? null : v);
+            if (variables.size() == vd.getVariables().size()) {
+                return vd;
+            }
+            if (variables.isEmpty()) {
+                if (getCursor().getParentTreeCursor().getValue() instanceof J.Block) {
+                    maybeRemoveImport(MOCK_UTIL);
+                    //noinspection DataFlowIssue
+                    return null;
+                }
+                return vd;
+            }
+            if (vd.getVariables().get(0) != variables.get(0).getElement()) {
+                // Removing the first declarator leaves the next one to carry the separation from the type expression
+                variables = ListUtils.mapFirst(variables, v -> v.getElement().getPrefix().isEmpty() ?
+                        v.withElement(v.getElement().withPrefix(Space.SINGLE_SPACE)) : v);
+            }
+            return vd.getPadding().withVariables(variables);
+        }
+
+        private static boolean isObsoleteMockUtilInstance(J.VariableDeclarations.NamedVariable variable, J.CompilationUnit scope) {
+            if (!(variable.getInitializer() instanceof J.NewClass) || !METHOD_MATCHER.matches((J.NewClass) variable.getInitializer())) {
+                return false;
+            }
+            JavaType.Variable variableType = variable.getVariableType();
+            // Without symbol attribution the uses of the variable can not be proven obsolete
+            return variableType != null &&
+                    !new FindUnmigratedUses(variableType, variable.getSimpleName()).reduce(scope, new AtomicBoolean()).get();
+        }
+
+        @RequiredArgsConstructor
+        private static class FindUnmigratedUses extends JavaIsoVisitor<AtomicBoolean> {
+            private final JavaType.Variable variableType;
+            private final String name;
+
+            @Override
+            public @Nullable J visit(@Nullable Tree tree, AtomicBoolean found) {
+                return found.get() ? (J) tree : super.visit(tree, found);
+            }
+
+            @Override
+            public J.Package visitPackage(J.Package pkg, AtomicBoolean found) {
+                // Package and import name segments are not uses of the variable
+                return pkg;
+            }
+
+            @Override
+            public J.Import visitImport(J.Import anImport, AtomicBoolean found) {
+                return anImport;
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
+                if (!name.equals(identifier.getSimpleName()) ||
+                        identifier.getFieldType() != null && !variableType.equals(identifier.getFieldType())) {
+                    return identifier;
+                }
+                Cursor parent = getCursor().getParentTreeCursor();
+                if (!isNeverVariableReference(identifier, parent) && !isMigratedUse(identifier, parent)) {
+                    found.set(true);
+                }
+                return identifier;
+            }
+
+            /**
+             * An identifier in these positions declares a variable or names a method, constructor, type,
+             * label, enum constant, or annotation element, or resolved to a type or a package or type
+             * segment of a qualified name, so it is never a reference to the variable under analysis.
+             */
+            private static boolean isNeverVariableReference(J.Identifier identifier, Cursor parentCursor) {
+                if (identifier.getFieldType() == null &&
+                        (identifier.getType() instanceof JavaType.Class || identifier.getType() instanceof JavaType.GenericTypeVariable)) {
+                    // Resolved to a type: a same-named class or type variable used as a static receiver or in a type position
+                    return true;
+                }
+                Object parent = parentCursor.getValue();
+                if (parent instanceof J.VariableDeclarations.NamedVariable) {
+                    return ((J.VariableDeclarations.NamedVariable) parent).getName() == identifier;
+                }
+                if (parent instanceof J.MethodInvocation) {
+                    return ((J.MethodInvocation) parent).getName() == identifier;
+                }
+                if (parent instanceof J.MethodDeclaration) {
+                    return ((J.MethodDeclaration) parent).getName() == identifier;
+                }
+                if (parent instanceof J.ClassDeclaration) {
+                    return ((J.ClassDeclaration) parent).getName() == identifier;
+                }
+                if (parent instanceof J.MemberReference) {
+                    return ((J.MemberReference) parent).getReference() == identifier;
+                }
+                if (parent instanceof J.Label) {
+                    return ((J.Label) parent).getLabel() == identifier;
+                }
+                if (parent instanceof J.Break) {
+                    return ((J.Break) parent).getLabel() == identifier;
+                }
+                if (parent instanceof J.Continue) {
+                    return ((J.Continue) parent).getLabel() == identifier;
+                }
+                if (parent instanceof J.EnumValue) {
+                    return ((J.EnumValue) parent).getName() == identifier;
+                }
+                if (parent instanceof J.TypeParameter) {
+                    return ((J.TypeParameter) parent).getName() == identifier;
+                }
+                if (parent instanceof J.Assignment) {
+                    // The left side of an annotation element assignment names the element, not a variable
+                    return ((J.Assignment) parent).getVariable() == identifier &&
+                            parentCursor.getParentTreeCursor().getValue() instanceof J.Annotation;
+                }
+                if (parent instanceof J.FieldAccess) {
+                    // Package and type segments of a qualified name carry no field type; a reference to
+                    // the analysed variable always does, because its declaration is attributed
+                    return identifier.getFieldType() == null;
+                }
+                return false;
+            }
+
+            /**
+             * True when the identifier is the receiver of a call that `ChangeMethodTargetToStatic` rewrites
+             * to its static form, either bare (`util.isMock(..)`, `util::isMock`) or as the final name of a
+             * field access receiver (`this.util.isMock(..)`, `this.util::isMock`). The rewrite replaces the
+             * whole receiver with the class name, so such a use no longer needs the instance.
+             */
+            private static boolean isMigratedUse(J.Identifier identifier, Cursor parent) {
+                Object parentValue = parent.getValue();
+                if (parentValue instanceof J.FieldAccess && ((J.FieldAccess) parentValue).getName() == identifier) {
+                    return isMigratedReceiver((J.FieldAccess) parentValue, parent.getParentTreeCursor().getValue());
+                }
+                return isMigratedReceiver(identifier, parentValue);
+            }
+
+            private static boolean isMigratedReceiver(Expression receiver, Object parent) {
+                if (parent instanceof J.MethodInvocation) {
+                    J.MethodInvocation method = (J.MethodInvocation) parent;
+                    return method.getSelect() == receiver && MIGRATED_METHOD_MATCHER.matches(method);
+                }
+                if (parent instanceof J.MemberReference) {
+                    J.MemberReference reference = (J.MemberReference) parent;
+                    return reference.getContaining() == receiver && MIGRATED_METHOD_MATCHER.matches(reference);
+                }
+                return false;
+            }
         }
     }
 }

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
@@ -75,17 +75,16 @@ public class MockUtilsToStatic extends Recipe {
         @Override
         public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
             J.VariableDeclarations vd = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-            // Declarations of `new MockUtil()` are only obsolete once every use of the declared variable in this
-            // compilation unit is the receiver of a call that is migrated to its static form; every other use would
-            // be left undefined. Uses of a visible field from another source file are not analysed.
+            // Uses of a visible field from another source file are not analysed
             J.CompilationUnit scope = getCursor().firstEnclosing(J.CompilationUnit.class);
             if (scope == null) {
                 return vd;
             }
 
+            List<JRightPadded<J.VariableDeclarations.NamedVariable>> original = vd.getPadding().getVariables();
             List<JRightPadded<J.VariableDeclarations.NamedVariable>> variables =
-                    ListUtils.map(vd.getPadding().getVariables(), v -> isObsoleteMockUtilInstance(v.getElement(), scope) ? null : v);
-            if (variables.size() == vd.getVariables().size()) {
+                    ListUtils.map(original, v -> isObsoleteMockUtilInstance(v.getElement(), scope) ? null : v);
+            if (variables.size() == original.size()) {
                 return vd;
             }
             if (variables.isEmpty()) {
@@ -96,10 +95,15 @@ public class MockUtilsToStatic extends Recipe {
                 }
                 return vd;
             }
-            if (vd.getVariables().get(0) != variables.get(0).getElement()) {
-                // Removing the first declarator leaves the next one to carry the separation from the type expression
-                variables = ListUtils.mapFirst(variables, v -> v.getElement().getPrefix().isEmpty() ?
+            if (original.get(0) != variables.get(0)) {
+                // The next declarator now carries the separation from the type expression
+                variables = ListUtils.mapFirst(variables, v -> v.getElement().getPrefix().getComments().isEmpty() ?
                         v.withElement(v.getElement().withPrefix(Space.SINGLE_SPACE)) : v);
+            }
+            JRightPadded<J.VariableDeclarations.NamedVariable> last = original.get(original.size() - 1);
+            if (variables.get(variables.size() - 1) != last) {
+                // The previous declarator now carries the separation from the semicolon
+                variables = ListUtils.mapLast(variables, v -> v.withAfter(last.getAfter()));
             }
             return vd.getPadding().withVariables(variables);
         }
@@ -149,14 +153,13 @@ public class MockUtilsToStatic extends Recipe {
             }
 
             /**
-             * An identifier in these positions declares a variable or names a method, constructor, type,
-             * label, enum constant, or annotation element, or resolved to a type or a package or type
-             * segment of a qualified name, so it is never a reference to the variable under analysis.
+             * @return whether the identifier declares a variable or names a method, type, label, enum constant or
+             * annotation element, or is a package or type segment of a qualified name, so that it can never be a
+             * reference to the variable under analysis.
              */
             private static boolean isNeverVariableReference(J.Identifier identifier, Cursor parentCursor) {
                 if (identifier.getFieldType() == null &&
                         (identifier.getType() instanceof JavaType.Class || identifier.getType() instanceof JavaType.GenericTypeVariable)) {
-                    // Resolved to a type: a same-named class or type variable used as a static receiver or in a type position
                     return true;
                 }
                 Object parent = parentCursor.getValue();
@@ -196,18 +199,17 @@ public class MockUtilsToStatic extends Recipe {
                             parentCursor.getParentTreeCursor().getValue() instanceof J.Annotation;
                 }
                 if (parent instanceof J.FieldAccess) {
-                    // Package and type segments of a qualified name carry no field type; a reference to
-                    // the analysed variable always does, because its declaration is attributed
+                    // Package and type segments of a qualified name carry no field type, unlike an attributed variable
                     return identifier.getFieldType() == null;
                 }
                 return false;
             }
 
             /**
-             * True when the identifier is the receiver of a call that `ChangeMethodTargetToStatic` rewrites
-             * to its static form, either bare (`util.isMock(..)`, `util::isMock`) or as the final name of a
-             * field access receiver (`this.util.isMock(..)`, `this.util::isMock`). The rewrite replaces the
-             * whole receiver with the class name, so such a use no longer needs the instance.
+             * @return whether the identifier is the receiver of a call that {@link ChangeMethodTargetToStatic}
+             * rewrites to its static form, either bare (`util.isMock(..)`, `util::isMock`) or as the final name of
+             * a field access receiver (`this.util.isMock(..)`); the rewrite replaces the whole receiver with the
+             * class name, so such a use no longer needs the instance.
              */
             private static boolean isMigratedUse(J.Identifier identifier, Cursor parent) {
                 Object parentValue = parent.getValue();

--- a/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/MockUtilsToStatic.java
@@ -113,7 +113,7 @@ public class MockUtilsToStatic extends Recipe {
                 return false;
             }
             JavaType.Variable variableType = variable.getVariableType();
-            // Without symbol attribution the uses of the variable can not be proven obsolete
+            // Without symbol attribution the uses cannot be proven obsolete
             return variableType != null &&
                     !new FindUnmigratedUses(variableType, variable.getSimpleName()).reduce(scope, new AtomicBoolean()).get();
         }
@@ -153,9 +153,8 @@ public class MockUtilsToStatic extends Recipe {
             }
 
             /**
-             * @return whether the identifier declares a variable or names a method, type, label, enum constant or
-             * annotation element, or is a package or type segment of a qualified name, so that it can never be a
-             * reference to the variable under analysis.
+             * @return whether the identifier declares a variable or names something in another namespace, so that
+             * it can never reference the variable under analysis.
              */
             private static boolean isNeverVariableReference(J.Identifier identifier, Cursor parentCursor) {
                 if (identifier.getFieldType() == null &&
@@ -199,17 +198,15 @@ public class MockUtilsToStatic extends Recipe {
                             parentCursor.getParentTreeCursor().getValue() instanceof J.Annotation;
                 }
                 if (parent instanceof J.FieldAccess) {
-                    // Package and type segments of a qualified name carry no field type, unlike an attributed variable
+                    // Package and type segments carry no field type, unlike an attributed variable
                     return identifier.getFieldType() == null;
                 }
                 return false;
             }
 
             /**
-             * @return whether the identifier is the receiver of a call that {@link ChangeMethodTargetToStatic}
-             * rewrites to its static form, either bare (`util.isMock(..)`, `util::isMock`) or as the final name of
-             * a field access receiver (`this.util.isMock(..)`); the rewrite replaces the whole receiver with the
-             * class name, so such a use no longer needs the instance.
+             * @return whether the identifier is the receiver of a call {@link ChangeMethodTargetToStatic} makes
+             * static, bare or through a field access, in which case the rewrite drops it and the instance with it.
              */
             private static boolean isMigratedUse(J.Identifier identifier, Cursor parent) {
                 Object parentValue = parent.getValue();

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
@@ -367,6 +367,97 @@ class MockUtilsToStaticTest implements RewriteTest {
     }
 
     @Test
+    void removeFirstDeclaratorSpanningMultipleLines() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil(),
+                              observed = createObserved();
+                      observe(observed);
+                      return util.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved();
+                      observe(observed);
+                      return MockUtil.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeLastDeclaratorWithSpaceBeforeComma() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved() , util = new MockUtil();
+                      observe(observed);
+                      return util.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved();
+                      observe(observed);
+                      return MockUtil.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeFirstDeclaratorWithoutSpaceAfterComma() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
@@ -129,4 +129,763 @@ class MockUtilsToStaticTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void retainLocalVariableUsedAsMethodArgument() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      observe(util);
+                      return util.isMock(value);
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      observe(util);
+                      return MockUtil.isMock(value);
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainFieldUsedAsReturnValue() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private MockUtil util = new MockUtil();
+
+                  MockUtil expose() {
+                      return util;
+                  }
+
+                  boolean test(Object value) {
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private MockUtil util = new MockUtil();
+
+                  MockUtil expose() {
+                      return util;
+                  }
+
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainStaticFieldUsedInComparison() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private static MockUtil util = new MockUtil();
+
+                  static boolean isShared(MockUtil other) {
+                      return other == util;
+                  }
+
+                  static boolean test(Object value) {
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private static MockUtil util = new MockUtil();
+
+                  static boolean isShared(MockUtil other) {
+                      return other == util;
+                  }
+
+                  static boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainVariableUsedToInitializeAnAlias() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      MockUtil alias = util;
+                      return alias.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      MockUtil alias = util;
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFirstDeclaratorOnlyPreservingSiblingEvaluation() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil(), observed = createObserved();
+                      observe(observed);
+                      return util.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved();
+                      observe(observed);
+                      return MockUtil.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeLastDeclaratorOnlyPreservingSiblingEvaluation() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved(), util = new MockUtil();
+                      observe(observed);
+                      return util.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved();
+                      observe(observed);
+                      return MockUtil.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFirstDeclaratorWithoutSpaceAfterComma() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil(),observed = createObserved();
+                      observe(observed);
+                      return util.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil observed = createObserved();
+                      observe(observed);
+                      return MockUtil.isMock(value);
+                  }
+
+                  MockUtil createObserved() {
+                      return new MockUtil();
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFieldWhoseUsesAreMigratedThroughThisReceiver() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private MockUtil util = new MockUtil();
+                  private MockUtil kept = new MockUtil();
+
+                  MockUtil expose() {
+                      return kept;
+                  }
+
+                  boolean test(Object value) {
+                      return this.util.isMock(value);
+                  }
+
+                  boolean keptTest(Object value) {
+                      return kept.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  private MockUtil kept = new MockUtil();
+
+                  MockUtil expose() {
+                      return kept;
+                  }
+
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+
+                  boolean keptTest(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeVariableWhoseNameCollidesWithMethodDeclarationTypeDeclarationAndLabelNames() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class util {
+                  }
+
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      MockUtil kept = new MockUtil();
+                      observe(kept);
+                      boolean result = util.isMock(value) && kept.isMock(value);
+                      util();
+                      util:
+                      while (result) {
+                          break util;
+                      }
+                      return result;
+                  }
+
+                  void util() {
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class util {
+                  }
+
+                  boolean test(Object value) {
+                      MockUtil kept = new MockUtil();
+                      observe(kept);
+                      boolean result = MockUtil.isMock(value) && MockUtil.isMock(value);
+                      util();
+                      util:
+                      while (result) {
+                          break util;
+                      }
+                      return result;
+                  }
+
+                  void util() {
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeVariableWhoseUseIsAMigratedMethodReference() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.function.Predicate;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      MockUtil kept = new MockUtil();
+                      observe(kept);
+                      Predicate<Object> isMock = util::isMock;
+                      return isMock.test(value) && kept.isMock(value);
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.function.Predicate;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil kept = new MockUtil();
+                      observe(kept);
+                      Predicate<Object> isMock = MockUtil::isMock;
+                      return isMock.test(value) && MockUtil.isMock(value);
+                  }
+
+                  void observe(Object value) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFieldWhoseUseIsAMigratedMethodReferenceThroughThisReceiver() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.function.Predicate;
+
+              class Test {
+                  private MockUtil util = new MockUtil();
+                  private MockUtil kept = new MockUtil();
+
+                  MockUtil expose() {
+                      return kept;
+                  }
+
+                  Predicate<Object> checker() {
+                      return this.util::isMock;
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.function.Predicate;
+
+              class Test {
+                  private MockUtil kept = new MockUtil();
+
+                  MockUtil expose() {
+                      return kept;
+                  }
+
+                  Predicate<Object> checker() {
+                      return MockUtil::isMock;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDeclarationDespiteSameNamedPackageSegment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      java.util.Date date = new java.util.Date();
+                      return util.isMock(value) && date.getTime() >= 0L;
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      java.util.Date date = new java.util.Date();
+                      return MockUtil.isMock(value) && date.getTime() >= 0L;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeFullyQualifiedDeclarationDespiteSameNamedPackageSegment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  boolean test(Object value) {
+                      org.mockito.internal.util.MockUtil util = new org.mockito.internal.util.MockUtil();
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDeclarationDespiteSameNamedEnumConstant() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  enum Kind { util, other }
+
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      return util.isMock(value) && Kind.util != Kind.other;
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  enum Kind { util, other }
+
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value) && Kind.util != Kind.other;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDeclarationDespiteSameNamedAnnotationAttribute() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  @interface Marker {
+                      String util();
+                  }
+
+                  @Marker(util = "x")
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  @interface Marker {
+                      String util();
+                  }
+
+                  @Marker(util = "x")
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDeclarationDespiteSameNamedNestedTypeUsedAsStaticReceiver() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class util {
+                      static boolean flag() {
+                          return true;
+                      }
+                  }
+
+                  boolean other() {
+                      return util.flag();
+                  }
+
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class util {
+                      static boolean flag() {
+                          return true;
+                      }
+                  }
+
+                  boolean other() {
+                      return util.flag();
+                  }
+
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDeclarationDespiteSameNamedTypeParameter() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.List;
+
+              class Test {
+                  <util> util pick(List<util> items) {
+                      return items.get(0);
+                  }
+
+                  boolean test(Object value) {
+                      MockUtil util = new MockUtil();
+                      return util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              import java.util.List;
+
+              class Test {
+                  <util> util pick(List<util> items) {
+                      return items.get(0);
+                  }
+
+                  boolean test(Object value) {
+                      return MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeImportWithLastDeclaration() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  void test() {
+                      MockUtil util = new MockUtil();
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotRemoveDeclarationsOfSimilarlyNamedTypes() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class FakeUtil {
+                      boolean isMock(Object value) {
+                          return true;
+                      }
+                  }
+
+                  boolean test(Object value) {
+                      FakeUtil fake = new FakeUtil();
+                      MockUtil util = new MockUtil();
+                      return fake.isMock(value) && util.isMock(value);
+                  }
+              }
+              """,
+            """
+              import org.mockito.internal.util.MockUtil;
+
+              class Test {
+                  static class FakeUtil {
+                      boolean isMock(Object value) {
+                          return true;
+                      }
+                  }
+
+                  boolean test(Object value) {
+                      FakeUtil fake = new FakeUtil();
+                      return fake.isMock(value) && MockUtil.isMock(value);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.java.testing.mockito;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
@@ -276,228 +278,40 @@ class MockUtilsToStaticTest implements RewriteTest {
         );
     }
 
-    @Test
-    void removeFirstDeclaratorOnlyPreservingSiblingEvaluation() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "MockUtil util = new MockUtil(), observed = createObserved();",
+      "MockUtil observed = createObserved(), util = new MockUtil();",
+      """
+        MockUtil util = new MockUtil(),
+                observed = createObserved();""",
+      "MockUtil observed = createObserved() , util = new MockUtil();",
+      "MockUtil util = new MockUtil(),observed = createObserved();"
+    })
+    void removeOnlyTheMigratedDeclarator(String declaration) {
         //language=java
+        var source = """
+          import org.mockito.internal.util.MockUtil;
+
+          class Test {
+              boolean test(Object value) {
+                  %s
+                  observe(observed);
+                  return %s;
+              }
+
+              MockUtil createObserved() {
+                  return new MockUtil();
+              }
+
+              void observe(Object value) {
+              }
+          }
+          """;
         rewriteRun(
           java(
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil util = new MockUtil(), observed = createObserved();
-                      observe(observed);
-                      return util.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """,
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved();
-                      observe(observed);
-                      return MockUtil.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeLastDeclaratorOnlyPreservingSiblingEvaluation() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved(), util = new MockUtil();
-                      observe(observed);
-                      return util.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """,
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved();
-                      observe(observed);
-                      return MockUtil.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeFirstDeclaratorSpanningMultipleLines() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil util = new MockUtil(),
-                              observed = createObserved();
-                      observe(observed);
-                      return util.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """,
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved();
-                      observe(observed);
-                      return MockUtil.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeLastDeclaratorWithSpaceBeforeComma() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved() , util = new MockUtil();
-                      observe(observed);
-                      return util.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """,
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved();
-                      observe(observed);
-                      return MockUtil.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void removeFirstDeclaratorWithoutSpaceAfterComma() {
-        //language=java
-        rewriteRun(
-          java(
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil util = new MockUtil(),observed = createObserved();
-                      observe(observed);
-                      return util.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """,
-            """
-              import org.mockito.internal.util.MockUtil;
-
-              class Test {
-                  boolean test(Object value) {
-                      MockUtil observed = createObserved();
-                      observe(observed);
-                      return MockUtil.isMock(value);
-                  }
-
-                  MockUtil createObserved() {
-                      return new MockUtil();
-                  }
-
-                  void observe(Object value) {
-                  }
-              }
-              """
+            source.formatted(declaration, "util.isMock(value)"),
+            source.formatted("MockUtil observed = createObserved();", "MockUtil.isMock(value)")
           )
         );
     }


### PR DESCRIPTION
**Suggested review order:** 48 of 52 (Score: 1)
**Review first:** https://github.com/openrewrite/rewrite-testing-frameworks/pull/1088

## What's changed?

[`MockUtilsToStatic`](https://docs.openrewrite.org/recipes/java/testing/mockito/mockutilstostatic) now removes a `MockUtil` declaration only when every use of that variable in the same file is one the migration rewrites away: the variable is the receiver of a call to a `MockUtil` method (`util.isMock(x)`, `this.util.isMock(x)`) or the qualifier of a method reference to one (`util::isMock`, `this.util::isMock`). Those uses become `MockUtil.isMock(x)` and `MockUtil::isMock` and no longer need the instance. Any other use of the variable anywhere in the file keeps the declaration.

The rule is applied per declared variable, so in `MockUtil util = new MockUtil(), observed = createObserved();` only `util` is dropped, `observed` keeps its initializer and `createObserved()` is still evaluated; the statement itself goes only when no declared variable is left in it. The `MockUtil` import is removed only when nothing in the file still needs it. For example, the import remains when the recipe's output names the type in `MockUtil.isMock(x)`.

### Before

```java
import org.mockito.internal.util.MockUtil;

class Test {
    boolean test(Object value) {
        MockUtil util = new MockUtil();
        observe(util);
        return util.isMock(value);
    }

    void observe(Object value) {
    }
}
```

### Actual after the recipe

Using main today. The declaration of `util` has been deleted, so the `observe(util)` line no longer compiles:

```java
import org.mockito.internal.util.MockUtil;

class Test {
    boolean test(Object value) {
        observe(util);
        return MockUtil.isMock(value);
    }

    void observe(Object value) {
    }
}
```

### Expected after the recipe

The declaration stays, because `observe(util)` is a use that the migration does not rewrite away:

```java
import org.mockito.internal.util.MockUtil;

class Test {
    boolean test(Object value) {
        MockUtil util = new MockUtil();
        observe(util);
        return MockUtil.isMock(value);
    }

    void observe(Object value) {
    }
}
```

Rewriting the calls themselves is still left to [`ChangeMethodTargetToStatic`](https://docs.openrewrite.org/recipes/java/changemethodtargettostatic), exactly as before; `MockUtilsToStatic` only decides which declarations to remove. The two cannot disagree about which calls count as rewritten: both are driven by the same method pattern, `"org.mockito.internal.util.MockUtil *(..)"`, held in a single constant that the recipe passes to `ChangeMethodTargetToStatic` and also uses to build its own `MethodMatcher`.

The removal has also moved. The `visitNewClass` override that handed the enclosing statement to `DeleteStatement` is deleted, and with it the last use and the import of `DeleteStatement`; a new `visitVariableDeclarations` override can drop a single declared variable out of a statement that declares several, preserving the spacing that the removed declarator carried around the comma and the semicolon.

## What's your motivation?

**Recipe:** `org.openrewrite.java.testing.mockito.MockUtilsToStatic`.

Main deletes the whole declaration statement as soon as it sees `new MockUtil()` as an initializer, without checking whether the variable is still used anywhere, so the output above does not compile. With several declarators more than a name is lost: given `MockUtil util = new MockUtil(), observed = createObserved();` the whole statement disappears, so `createObserved()` is never called. That output reaches users through the `Mockito1to3Migration` composite in `mockito.yml` as well as through a direct run of the recipe. Reproduced on 3.43.0 and on 3.44.0-SNAPSHOT built from main at 96ec8d6e.

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed: the three existing tests are untouched.

Three limits are worth knowing:

- The analysis reads one file at a time, so it cannot see uses of a field from other source files. A field whose only uses are elsewhere is therefore removed even though those uses stop compiling. That is unsound, and this change does not fix it: main removes such a field too, so the outcome there is unchanged rather than correct.
- A declaration statement whose parent is not a block is never removed as a whole. Statements written after `case 1:` in an old style `switch` are where this shows up: they hang off the `case`, not off a block, so a `MockUtil` declaration there stays even when every use of the variable is rewritten away, as it does on main. Where such a statement declares more than one variable, the `MockUtil` variable is still dropped from it.
- This one is new with this change, and it is the price of the fix. Where a use is not rewritten away, the declaration stays and so does its `new MockUtil()` initializer, which does not compile against Mockito 2 and later, where that constructor is private, and `Mockito1to3Migration` bumps Mockito to 3.x in the same run. Main deletes the declaration and with it that call, so this change trades one declaration to fix by hand for a name that was undefined at every use site.

## Have you considered any alternatives or workarounds?

The analysis of uses lives in a private static nested class of this recipe's visitor, `FindUnmigratedUses`. The only thing it reads from this repository is the `MethodMatcher` constant of the enclosing visitor. Moving it as a shared helper into the `rewrite-java` module of `openrewrite/rewrite` requires making that matcher a constructor parameter, opening a separate pull request there first, and rebasing this change onto the helper. Say so in review and I will open it; otherwise `FindUnmigratedUses` stays where it is.

## Any additional context

This change adds 17 test methods to `MockUtilsToStaticTest`. The parameterized `removeOnlyTheMigratedDeclarator` method supplies 5 declaration layouts, so the focused class reports 24 executions: 21 added executions plus the 3 existing tests. Without the code change, 13 added executions fail. Four check that a declaration is kept when some use of the variable is not rewritten away. The parameterized cases cover removal of the first or last declarator and preserve comma and line-break formatting. The remaining cases guard against keeping a declaration because the name `util` also appears as a package segment, enum constant, annotation attribute, nested type or type parameter.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
