### PR TITLE
Keep `MockUtil` declarations used across files and switch labels

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockUtilsToStaticTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.testing.mockito;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -91,6 +92,79 @@ class MockUtilsToStaticTest implements RewriteTest {
               public class MockitoMockUtils {
                   public void isMockExample() {
                       MockUtil.isMock("I am a real String");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled("The single-file use analysis removes a MockUtil field still referenced from another source file, so that file no longer compiles")
+    @Test
+    void doNotRemoveFieldUsedInAnotherClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package mockito.example;
+
+              import org.mockito.internal.util.MockUtil;
+
+              public class MockitoMockUtils {
+                  public MockUtil util = new MockUtil();
+              }
+              """
+          ),
+          java(
+            """
+              package mockito.example;
+
+              public class MockitoMockUtilsUser {
+                  public boolean isMockUtilSet(MockitoMockUtils utils) {
+                      return utils.util != null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Disabled("A fully migrated MockUtil declaration directly under a case label is not removed because its parent is the case, not a block")
+    @Test
+    void mockUtilsVariableInSwitchCaseToStatic() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              package mockito.example;
+
+              import org.mockito.internal.util.MockUtil;
+
+              public class MockitoMockUtils {
+                  public boolean isMockExample(int mode, Object value) {
+                      switch (mode) {
+                          case 1:
+                              MockUtil util = new MockUtil();
+                              return util.isMock(value);
+                          default:
+                              return false;
+                      }
+                  }
+              }
+              """,
+            """
+              package mockito.example;
+
+              import org.mockito.internal.util.MockUtil;
+
+              public class MockitoMockUtils {
+                  public boolean isMockExample(int mode, Object value) {
+                      switch (mode) {
+                          case 1:
+                              return MockUtil.isMock(value);
+                          default:
+                              return false;
+                      }
                   }
               }
               """


### PR DESCRIPTION
**Suggested review order:** 50 of 52 (Score: 1)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1197

## What's changed?

Adds 2 known-failing tests to `MockUtilsToStaticTest` that reproduce two defects in `MockUtilsToStatic`: the recipe removes a `MockUtil` field that another source file still uses, and it never removes a fully migrated `MockUtil` declaration that sits directly under a `case` label. No recipe code changes. The tests are marked `@Disabled` so the suite stays green; removing the annotation shows the failures. The class had 3 tests on main and has 5 with this change; the 3 pre-existing tests still pass.

## What's your motivation?

**Recipe:** `org.openrewrite.java.testing.mockito.MockUtilsToStatic`.

### Case 1: cross-file field use

#### Before

The recipe decides per file whether a `MockUtil` variable is still needed. It never sees uses from other compilation units. Given these two files in one run:

```java
package mockito.example;

import org.mockito.internal.util.MockUtil;

public class MockitoMockUtils {
    public MockUtil util = new MockUtil();
}
```

```java
package mockito.example;

public class MockitoMockUtilsUser {
    public boolean isMockUtilSet(MockitoMockUtils utils) {
        return utils.util != null;
    }
}
```

#### Actual after the recipe

Using current main. the first file becomes an empty class, `public class MockitoMockUtils {\n}`, with the field and the import removed. The second file is unchanged and still reads `utils.util`. Compiling the output pair with javac fails with:

```
error: cannot find symbol
  symbol:   variable util
  location: variable utils of type MockitoMockUtils
```

After the recipe runs, the code should still compile, so the field should stay when another file uses it. Test: `doNotRemoveFieldUsedInAnotherClass`.

#### Expected after the recipe

`(unchanged)`

### Case 2: declaration under a case label

#### Before

Given an old-style switch:

```java
switch (mode) {
    case 1:
        MockUtil util = new MockUtil();
        return util.isMock(value);
    default:
        return false;
}
```

#### Actual after the recipe

Using current main, the call is migrated to `MockUtil.isMock(value)`, but the now-unused `MockUtil util = new MockUtil();` line stays. The `DeleteStatement` scheduled from `visitNewClass` only removes statements whose parent is a `J.Block`; statements after `case 1:` hang off the `J.Case` instead, so the dead declaration is left behind. Test: `mockUtilsVariableInSwitchCaseToStatic`.

#### Expected after the recipe

The call MUST be migrated and the unused declaration MUST be removed.

Found while preparing #1084, which rewrites the removal logic in this recipe but deliberately does not fix these two behaviors, as its description discloses.

## Anything in particular you'd like reviewers to focus on?

I think defect 1 is a genuine bug, because the recipe produces code that does not compile. Defect 2 is more of an improvement: the output compiles, it just keeps a dead statement. If you agree this should change, I would gladly prepare the fix. If this behavior is intended, feel free to close this and I know it is settled.

## Any additional context

Pre-existing tests changed: None.

Related open PR of mine touching the same recipe: #1084. It does not fix either behavior here; its removal logic also handles only declarations whose parent is a block, so the case-label gap persists with it.

This reproduction was prepared with AI assistance (Claude Code). I reviewed the tests and this description.

The added reproduction tests and the existing suite together cover changed and unchanged behavior. The known-failing tests remain disabled until implementation. The formatter run was calibrated per file; untouched lines were not reformatted.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch