### PR TITLE
Do not wrap class level `mockStatic` fields in try-with-resources

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocks.java
@@ -175,11 +175,11 @@ public class CloseUnclosedStaticMocks extends Recipe {
         @Override
         public J visitBlock(J.Block block, ExecutionContext ctx) {
             J.Block b = (J.Block) super.visitBlock(block, ctx);
-            if (insideLifecycleMethod()) {
+            if (insideLifecycleMethod() || isClassBody()) {
                 return b;
             }
             AtomicBoolean removeStatement = new AtomicBoolean(false);
-            J.Block b1 = block.withStatements(ListUtils.map(b.getStatements(), statement -> {
+            J.Block b1 = b.withStatements(ListUtils.map(b.getStatements(), statement -> {
                 if (!removeStatement.get() && shouldUseTryWithResources(statement)) {
                     J.Try tryWithResource = toTryWithResource(b, statement, ctx);
                     if (tryWithResource != null) {
@@ -206,11 +206,15 @@ public class CloseUnclosedStaticMocks extends Recipe {
             if (code == null) {
                 return null;
             }
-            J.Try tryWithResources = JavaTemplate.builder(code)
+            J applied = JavaTemplate.builder(code)
                     .contextSensitive()
                     .imports("org.mockito.MockedStatic")
                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "mockito-core-5"))
                     .build().apply(new Cursor(getCursor(), statement), statement.getCoordinates().replace(), statement);
+            if (!(applied instanceof J.Try)) {
+                return null;
+            }
+            J.Try tryWithResources = (J.Try) applied;
             return maybeAutoFormat(tryWithResources, tryWithResources.withBody(findSuccessorStatements(statement, block)), ctx);
         }
 
@@ -252,6 +256,11 @@ public class CloseUnclosedStaticMocks extends Recipe {
 
         private String generateMockedVarName(String mockedClassName) {
             return generateVariableName("mockedStatic" + mockedClassName.replace(".", "_"), getCursor(), INCREMENT_NUMBER);
+        }
+
+        private boolean isClassBody() {
+            Object parent = getCursor().getParentTreeCursor().getValue();
+            return parent instanceof J.ClassDeclaration || parent instanceof J.NewClass;
         }
 
         private boolean insideLifecycleMethod() {

--- a/src/test/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/CloseUnclosedStaticMocksTest.java
@@ -514,4 +514,29 @@ class CloseUnclosedStaticMocksTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotWrapClassLevelField() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.mockito.MockedStatic;
+              import org.mockito.Mockito;
+
+              import static org.junit.jupiter.api.Assertions.assertEquals;
+
+              class TestClass {
+                  private static final MockedStatic<A> MOCKED_STATIC = Mockito.mockStatic(A.class);
+
+                  @Test
+                  void test() {
+                      assertEquals(A.getNumber(), 42);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`CloseUnclosedStaticMocks` crashed with `ClassCastException: J$Erroneous cannot be cast to J$Try` on any test class holding a field like `private static final MockedStatic<Foo> MOCKED_STATIC = Mockito.mockStatic(Foo.class);`.

`visitBlock` walked the statements of every `J.Block`, including class bodies where those statements are field declarations, so it spliced a field declaration into a try-with-resources resource slot; that does not parse, the template returned `J.Erroneous`, and the implicit cast threw. This skips class bodies (both `J.ClassDeclaration` and anonymous `J.NewClass` bodies) and additionally guards `toTryWithResource` to return `null` on a non-`J.Try` result, so any future template failure degrades to a skip rather than a crash. Also fixed an adjacent latent lost-edit path where mapped statements from the visited block were attached back to the unvisited block.

Seen 31 times across `spring-cloud/spring-cloud-kubernetes`; added a regression test reproducing the reported shape.