### PR TITLE
Respect composed JUnit test templates

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotation.java
@@ -33,6 +33,7 @@ import static java.util.stream.Collectors.toList;
 public class AddParameterizedTestAnnotation extends Recipe {
     private static final AnnotationMatcher TEST_ANNOTATION_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.Test");
     private static final AnnotationMatcher PARAM_TEST_MATCHER = new AnnotationMatcher("@org.junit.jupiter.params.ParameterizedTest");
+    private static final AnnotationMatcher TEST_TEMPLATE_MATCHER = new AnnotationMatcher("@org.junit.jupiter.api.TestTemplate", true);
     private static final List<AnnotationMatcher> SOURCE_ANNOTATIONS = Stream.of(
             "ValueSource",
             "CsvSource",
@@ -63,8 +64,8 @@ public class AddParameterizedTestAnnotation extends Recipe {
         public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration md, ExecutionContext ctx) {
             J.MethodDeclaration m = super.visitMethodDeclaration(md, ctx);
 
-            // Return early if already annotated with @ParameterizedTest or not annotated with any @...Source annotation
             if (m.getLeadingAnnotations().stream().anyMatch(PARAM_TEST_MATCHER::matches) ||
+                m.getLeadingAnnotations().stream().anyMatch(TEST_TEMPLATE_MATCHER::matches) ||
                 m.getLeadingAnnotations().stream().noneMatch(ann -> SOURCE_ANNOTATIONS.stream().anyMatch(matcher -> matcher.matches(ann)))) {
                 return m;
             }

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddParameterizedTestAnnotationTest.java
@@ -500,4 +500,73 @@ class AddParameterizedTestAnnotationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotAddParameterizedTestToComposedTestTemplates() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              package direct;
+
+              import java.lang.annotation.Retention;
+              import java.lang.annotation.Target;
+
+              import org.junit.jupiter.api.TestTemplate;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              import static java.lang.annotation.ElementType.METHOD;
+              import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+              @Retention(RUNTIME)
+              @Target(METHOD)
+              @TestTemplate
+              @interface FuzzTest {
+              }
+
+              class Test {
+                  @FuzzTest
+                  @ValueSource(strings = "input")
+                  void fuzz(String input) {
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              package transitive;
+
+              import java.lang.annotation.Retention;
+              import java.lang.annotation.Target;
+
+              import org.junit.jupiter.api.TestTemplate;
+              import org.junit.jupiter.params.provider.ValueSource;
+
+              import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+              import static java.lang.annotation.ElementType.METHOD;
+              import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+              @Retention(RUNTIME)
+              @Target(ANNOTATION_TYPE)
+              @TestTemplate
+              @interface ComposedTestTemplate {
+              }
+
+              @Retention(RUNTIME)
+              @Target(METHOD)
+              @ComposedTestTemplate
+              @interface FuzzTest {
+              }
+
+              class Test {
+                  @FuzzTest
+                  @ValueSource(strings = "input")
+                  void fuzz(String input) {
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 15 of 52 (Score: 7)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/978

## What's changed?

Leaves a method unchanged when an existing annotation is directly or transitively meta-annotated with JUnit's `@TestTemplate`. Methods without an existing test-template annotation still receive `@ParameterizedTest` when they use a supported parameter source.

## What's your motivation?

**Recipe:** [`org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation`](https://docs.openrewrite.org/recipes/java/testing/junit5/addparameterizedtestannotation).

I found this by running `org.openrewrite.java.testing.junit5.AddParameterizedTestAnnotation` from `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0` on [`RepositorySourceResolverFuzzTest.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/repository/RepositorySourceResolverFuzzTest.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`. The selected target tests still pass, but the recipe adds a redundant JUnit test-template annotation beside Jazzer's existing `@FuzzTest`.

### Before

```java
@MethodSource("labelledRepositorySourceValues")
@FuzzTest(maxDuration = "10s", maxExecutions = 20_000)
void labelledRepositorySourceValueCannotBreakSelectionInvariants(String rawValue) {
```

### Actual after the recipe

```java
@ParameterizedTest
@MethodSource("labelledRepositorySourceValues")
@FuzzTest(maxDuration = "10s", maxExecutions = 20_000)
void labelledRepositorySourceValueCannotBreakSelectionInvariants(String rawValue) {
```

### Expected after the recipe

`(unchanged)`

`@FuzzTest` already participates in JUnit through `@TestTemplate`. Adding another test-template annotation does not improve the method and gives two extensions ownership of the same test declaration.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`RepositorySourceResolverFuzzTest.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/repository/RepositorySourceResolverFuzzTest.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the use of `AnnotationMatcher` meta-annotation traversal for Jazzer and repository-defined composed annotations.

## Have you considered any alternatives or workarounds?

Special-casing Jazzer would miss other composed JUnit test templates. Replacing `@FuzzTest` would disable the fuzzing engine, so recognizing the JUnit composition contract is the narrow behavior-preserving rule.

## Any additional context

Pre-existing tests changed: None.

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martinfrancois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`
- Second affected file: `src/test/java/ch/fmartin/symphony/trello/tracker/TrelloCardReferenceParserFuzzTest.java`
- Target verification: the selected transformed tests execute 38 tests successfully; this PR prevents the redundant annotation change
- Focused tests: `AddParameterizedTestAnnotationTest`

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
