### PR TITLE
Preserve parameterized toString assertions

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertion.java
@@ -123,6 +123,10 @@ public class SimplifyChainedAssertJAssertion extends Recipe {
                 if (!chainedAssertMatcher.matches(assertThatArg)) {
                     return mi;
                 }
+                // Parameterized toString overloads have no equivalent hasToString assertion.
+                if ("toString".equals(chainedAssertion) && !(assertThatArg.getArguments().get(0) instanceof J.Empty)) {
+                    return mi;
+                }
 
                 // Extract the actual argument for the new assertThat call
                 Expression actual = assertThatArg.getSelect() != null ? assertThatArg.getSelect() : assertThatArg;

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifyChainedAssertJAssertionsTest.java
@@ -467,4 +467,24 @@ class SimplifyChainedAssertJAssertionsTest implements RewriteTest {
             );
         }
     }
+
+    @Test
+    void doesNotRewriteParameterizedByteArrayOutputStreamToString() {
+        rewriteRun(
+          java(
+            """
+              import java.io.ByteArrayOutputStream;
+              import java.nio.charset.StandardCharsets;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void verify(ByteArrayOutputStream stdout, String expected) {
+                      assertThat(stdout.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
**Suggested review order:** 19 of 52 (Score: 6.5)
**Review first:** https://github.com/openrewrite/rewrite-migrate-java/pull/1206

## What's changed?

Leaves parameterized `toString` assertions unchanged. The existing simplification remains active for zero-argument `toString()` calls whose semantics match AssertJ's `hasToString(String)` assertion.

## What's your motivation?

**Recipe:** [`org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions`](https://docs.openrewrite.org/recipes/java/testing/assertj/simplifychainedassertjassertion).

I found this by running `org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions` from `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0` on [`LocalLogTailerTest.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/setup/LocalLogTailerTest.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`. `./mvnw -DskipTests test-compile` then fails because AssertJ has no overload accepting the generated arguments.

### Before

```java
assertThat(stdout.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
```

### Actual after the recipe

```java
assertThat(stdout).hasToString(StandardCharsets.UTF_8, expected);
```

### Expected after the recipe

`(unchanged)`

The generated call passes a `Charset` where AssertJ expects the single expected `String`. The transformed target fails compilation with `incompatible types: Charset cannot be converted to String`.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`LocalLogTailerTest.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/setup/LocalLogTailerTest.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the zero-argument boundary. A parameterized `toString` call performs conversion work that `hasToString` does not represent.

## Have you considered any alternatives or workarounds?

Dropping the charset would change behavior because `ByteArrayOutputStream.toString(Charset)` does not use the same conversion contract as `Object.toString()`.

## Any additional context

Pre-existing tests changed: `SimplifyChainedAssertJAssertionsTest.java.collectionReplacements` (updated).

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martinfrancois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`
- Focused tests: `SimplifyChainedAssertJAssertionsTest`

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
