### PR TITLE
Preserve CharSequence assertions in sequenced collections

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertions.java
@@ -30,7 +30,14 @@ import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.TypeUtils;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class SimplifySequencedCollectionAssertions extends Recipe {
+
+    // Object-equality assertions come from AbstractAssert, so they do not depend on CharSequence behavior
+    private static final Set<String> OBJECT_EQUALITY_ASSERTIONS = new HashSet<>(Arrays.asList("isEqualTo", "isNotEqualTo"));
 
     private static final MethodMatcher ASSERT_THAT_MATCHER = new MethodMatcher("org.assertj.core.api.Assertions assertThat(..)");
     private static final MethodMatcher GET_FIRST_MATCHER = new MethodMatcher("java.util.* getFirst()");
@@ -103,7 +110,7 @@ public class SimplifySequencedCollectionAssertions extends Recipe {
                     }
 
                     private boolean isCharSequenceSpecificAssertion(J.MethodInvocation assertion) {
-                        if ("isEqualTo".equals(assertion.getSimpleName()) || "isNotEqualTo".equals(assertion.getSimpleName())) {
+                        if (OBJECT_EQUALITY_ASSERTIONS.contains(assertion.getSimpleName())) {
                             return false;
                         }
                         return assertion.getMethodType() != null && TypeUtils.isAssignableTo(

--- a/src/main/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertions.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertions.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.testing.assertj;
 
 import lombok.Getter;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -27,6 +28,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
 
 public class SimplifySequencedCollectionAssertions extends Recipe {
 
@@ -63,14 +65,49 @@ public class SimplifySequencedCollectionAssertions extends Recipe {
                         if (arg instanceof J.MethodInvocation) {
                             // Check if the method is getFirst() or getLast() on a SequencedCollection
                             if (GET_FIRST_MATCHER.matches(arg)) {
+                                if (usesCharSequenceSpecificAssertion((J.MethodInvocation) arg)) {
+                                    return mi;
+                                }
                                 return assertThat(mi, (J.MethodInvocation) arg, "first", ctx);
                             }
                             if (GET_LAST_MATCHER.matches(arg)) {
+                                if (usesCharSequenceSpecificAssertion((J.MethodInvocation) arg)) {
+                                    return mi;
+                                }
                                 return assertThat(mi, (J.MethodInvocation) arg, "last", ctx);
                             }
                         }
 
                         return mi;
+                    }
+
+                    private boolean usesCharSequenceSpecificAssertion(J.MethodInvocation elementAccess) {
+                        if (!TypeUtils.isAssignableTo("java.lang.CharSequence", elementAccess.getType())) {
+                            return false;
+                        }
+                        J.MethodInvocation selected = getCursor().getValue();
+                        Cursor assertionCursor = getCursor().getParentTreeCursor();
+                        while (assertionCursor != null && assertionCursor.getValue() instanceof J.MethodInvocation) {
+                            J.MethodInvocation assertion = assertionCursor.getValue();
+                            if (!(assertion.getSelect() instanceof J.MethodInvocation) ||
+                                    !selected.getId().equals(((J.MethodInvocation) assertion.getSelect()).getId())) {
+                                break;
+                            }
+                            if (isCharSequenceSpecificAssertion(assertion)) {
+                                return true;
+                            }
+                            selected = assertion;
+                            assertionCursor = assertionCursor.getParentTreeCursor();
+                        }
+                        return false;
+                    }
+
+                    private boolean isCharSequenceSpecificAssertion(J.MethodInvocation assertion) {
+                        if ("isEqualTo".equals(assertion.getSimpleName()) || "isNotEqualTo".equals(assertion.getSimpleName())) {
+                            return false;
+                        }
+                        return assertion.getMethodType() != null && TypeUtils.isAssignableTo(
+                                "org.assertj.core.api.AbstractCharSequenceAssert", assertion.getMethodType().getDeclaringType());
                     }
 
                     private J.MethodInvocation assertThat(J.MethodInvocation mi, J.MethodInvocation argMethod, String dedicatedAssertion, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/SimplifySequencedCollectionAssertionsTest.java
@@ -127,8 +127,70 @@ class SimplifySequencedCollectionAssertionsTest implements RewriteTest {
                   void testMethod() {
                       List<String> list = List.of("a", "b", "c");
                       assertThat(list).last().isNotNull();
-                      assertThat(list).first().isNotEmpty();
-                      assertThat(list).last().contains("c");
+                      assertThat(list.getFirst()).isNotEmpty();
+                      assertThat(list.getLast()).contains("c");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainsCharSequenceSpecificAssertions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class FirstElementTest {
+                  void verify(List<String> command) {
+                      assertThat(command.getFirst()).endsWith("setsid");
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class NullableElementTest {
+                  void verify(List<String> values) {
+                      assertThat(values.getFirst()).usingComparator(String.CASE_INSENSITIVE_ORDER).isNull();
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class ConfiguredAssertionTest {
+                  void verify(List<String> values) {
+                      assertThat(values.getFirst()).as("value").startsWith("a");
+                  }
+              }
+              """
+          ),
+          //language=java
+          java(
+            """
+              import java.util.List;
+
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class CharSequenceElementTest {
+                  void verify(List<StringBuilder> values) {
+                      assertThat(values.getFirst()).startsWith("a");
                   }
               }
               """


### PR DESCRIPTION
**Suggested review order:** 20 of 52 (Score: 6.5)
**Review first:** https://github.com/openrewrite/rewrite-testing-frameworks/pull/1094

## What's changed?

Leaves a sequenced-collection assertion unchanged when the selected element uses a CharSequence-specific AssertJ assertion. Assertions supported by the generic element assertion continue to use `.first()` or `.last()`.

## What's your motivation?

**Recipe:** [`org.openrewrite.java.testing.assertj.SimplifySequencedCollectionAssertions`](https://docs.openrewrite.org/recipes/java/testing/assertj/simplifysequencedcollectionassertions).

I found this by running `org.openrewrite.java.testing.assertj.SimplifySequencedCollectionAssertions` from `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0` on [`TrelloClientTest.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/tracker/TrelloClientTest.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`. `./mvnw -DskipTests test-compile` then fails because `.first()` returns `ObjectAssert<String>`, which has no `startsWith(String)` method.

### Before

```java
assertThat(readRequests.getFirst())
        .startsWith("GET /1/boards/board-1/cards/open?")
        .contains("fields=")
        .doesNotContain("actions=");
```

### Actual after the recipe

```java
assertThat(readRequests).first()
        .startsWith("GET /1/boards/board-1/cards/open?")
        .contains("fields=")
        .doesNotContain("actions=");
```

### Expected after the recipe

`(unchanged)`

The rewrite changes the AssertJ assertion type from a string assertion to a generic object assertion. The fluent string methods are then unavailable, so the transformed target does not compile.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`TrelloClientTest.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/tracker/TrelloClientTest.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review the assertion-chain scan and the distinction between generic equality assertions and CharSequence-specific operations.

## Have you considered any alternatives or workarounds?

Adding another AssertJ narrowing operation would make the result more complex than the original. Leaving this chain unchanged is both shorter and type-safe.

## Any additional context

Pre-existing tests changed: `SimplifySequencedCollectionAssertionsTest.java.withDifferentAssertions` (updated).

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martinfrancois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`
- Upstream reproduction commit: [`openrewrite/rewrite-testing-frameworks@23a04efc`](https://github.com/openrewrite/rewrite-testing-frameworks/commit/23a04efce49f8241af44bc71377089e4939290be)
- Focused tests: `SimplifySequencedCollectionAssertionsTest`

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
