### PR TITLE
Preserve comments before collapsed AssertJ chains

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/assertj/CollapseConsecutiveAssertThatStatements.java
+++ b/src/main/java/org/openrewrite/java/testing/assertj/CollapseConsecutiveAssertThatStatements.java
@@ -161,12 +161,13 @@ public class CollapseConsecutiveAssertThatStatements extends Recipe {
                     J.MethodInvocation assertThat = (J.MethodInvocation) assertion.getSelect();
                     assert assertThat != null;
                     J.MethodInvocation newSelect = collapsed == null ? assertThat : collapsed;
+                    List<Comment> chainedComments = collapsed == null ? emptyList() : st.getPrefix().getComments();
 
                     collapsed = assertion.getPadding().withSelect(JRightPadded
                             .build((Expression) newSelect.withPrefix(Space.EMPTY))
-                            .withAfter(Space.build(chainedIndent, ListUtils.map(st.getPrefix().getComments(), c -> c.withSuffix(chainedIndent)))));
+                            .withAfter(Space.build(chainedIndent, ListUtils.map(chainedComments, c -> c.withSuffix(chainedIndent)))));
                 }
-                return requireNonNull(collapsed).withPrefix(originalPrefix.withComments(emptyList()));
+                return requireNonNull(collapsed).withPrefix(originalPrefix);
             }
         });
     }

--- a/src/test/java/org/openrewrite/java/testing/assertj/CollapseConsecutiveAssertThatStatementsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/assertj/CollapseConsecutiveAssertThatStatementsTest.java
@@ -108,8 +108,8 @@ class CollapseConsecutiveAssertThatStatementsTest implements RewriteTest {
               class MyTest {
                   void test() {
                       List<String> listA = Arrays.asList("a", "b", "c");
+                      // Comment nor whitespace below duplicated
                       assertThat(listA)
-                              // Comment nor whitespace below duplicated
                               .isNotNull()
                               .hasSize(3)
                               .containsExactly("a", "b", "c");
@@ -444,13 +444,44 @@ class CollapseConsecutiveAssertThatStatementsTest implements RewriteTest {
               class MyTest {
                   void test() {
                       List<String> listA = Arrays.asList("a", "b", "c");
+                      // Check not null
                       assertThat(listA)
-                              // Check not null
                               .isNotNull()
                               // Check size is 3
                               .hasSize(3)
                               // Check exact contents
                               .containsExactly("a", "b", "c");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preservesSectionCommentBeforeCollapsedChain() {
+        rewriteRun(
+          java(
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void verify(String value) {
+                      // then
+                      assertThat(value).isNotNull();
+                      assertThat(value).isEqualTo("expected");
+                  }
+              }
+              """,
+            """
+              import static org.assertj.core.api.Assertions.assertThat;
+
+              class Test {
+                  void verify(String value) {
+                      // then
+                      assertThat(value)
+                              .isNotNull()
+                              .isEqualTo("expected");
                   }
               }
               """


### PR DESCRIPTION
**Suggested review order:** 25 of 52 (Score: 5)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/980

## What's changed?

Keeps the first assertion's prefix and comments on the collapsed `assertThat(...)` call. Comments between later compatible assertions remain attached to their corresponding chained assertion.

## What's your motivation?

**Recipe:** [`org.openrewrite.java.testing.assertj.CollapseConsecutiveAssertThatStatements`](https://docs.openrewrite.org/recipes/java/testing/assertj/collapseconsecutiveassertthatstatements).

I found this by running `org.openrewrite.java.testing.assertj.CollapseConsecutiveAssertThatStatements` from `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0` on [`TestConventionTest.java` in Symphony-Trello at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/TestConventionTest.java). I reproduced the same result with the latest released recipe artifact, `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`.

### Before

```java
// then
assertThat(pom).contains("<jspecify.version>1.0.0</jspecify.version>");
assertThat(pom).contains(dependency);
assertThat(pom).doesNotContain("<artifactId>jspecify</artifactId>");
```

### Actual after the recipe

```java
assertThat(pom)
        // then
        .contains("<jspecify.version>1.0.0</jspecify.version>")
        .contains(dependency)
        .doesNotContain("<artifactId>jspecify</artifactId>");
```

### Expected after the recipe

```java
// then
assertThat(pom)
        .contains("<jspecify.version>1.0.0</jspecify.version>")
        .contains(dependency)
        .doesNotContain("<artifactId>jspecify</artifactId>");
```

The `// then` comment marks the start of the assertion phase. Moving it inside the fluent chain attaches it to the first `.contains(...)` call instead of the assertion block.

### Confirmed real-world execution

- Project: [Symphony-Trello](https://github.com/martin-francois/symphony-trello).
- Location: [`TestConventionTest.java` at `a8013f27`](https://github.com/martin-francois/symphony-trello/blob/a8013f278fd81dfb1d7dfa636c87363f5dfe613d/src/test/java/ch/fmartin/symphony/trello/TestConventionTest.java).
- Discovery checkout: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martin-francois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d).

## Anything in particular you'd like reviewers to focus on?

Please review comment ownership at the collapse boundary and the behavior when later assertions also have comments.

## Have you considered any alternatives or workarounds?

Leaving all commented sequences uncollapsed would avoid movement but would reject safe cases where only later assertion comments need to remain on their calls.

## Any additional context

Pre-existing tests changed: `CollapseConsecutiveAssertThatStatementsTest.java.collapseIfMultipleConsecutiveAssertThatPresent` (updated), `CollapseConsecutiveAssertThatStatementsTest.java.preserveCommentsWhenCollapsingAssertions` (updated).

- Target commit: [`martinfrancois/symphony-trello@a8013f27`](https://github.com/martinfrancois/symphony-trello/commit/a8013f278fd81dfb1d7dfa636c87363f5dfe613d)
- Discovery release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.42.0`
- Latest verification release: `org.openrewrite.recipe:rewrite-testing-frameworks:3.44.0`
- Upstream reproduction commit: [`openrewrite/rewrite-testing-frameworks@23a04efc`](https://github.com/openrewrite/rewrite-testing-frameworks/commit/23a04efce49f8241af44bc71377089e4939290be)
- Focused test: `CollapseConsecutiveAssertThatStatementsTest.preservesSectionCommentBeforeCollapsedChain`

This change was prepared with AI assistance. I reviewed the target execution evidence, implementation, tests, and contribution text.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
