### PR TITLE
Migrate `anyCollectionOf`/`anyIterableOf` to their no-arg replacements

### DIFF
--- a/src/main/resources/META-INF/rewrite/mockito.yml
+++ b/src/main/resources/META-INF/rewrite/mockito.yml
@@ -140,11 +140,17 @@ recipeList:
       methodPattern: org.mockito.ArgumentMatchers anyMap(java.lang.Class)
       argumentIndex: 0
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.mockito.ArgumentMatchers anyCollectionOf()
+      methodPattern: org.mockito.ArgumentMatchers anyCollectionOf(java.lang.Class)
       newMethodName: anyCollection
+  - org.openrewrite.java.DeleteMethodArgument:
+      methodPattern: org.mockito.ArgumentMatchers anyCollection(java.lang.Class)
+      argumentIndex: 0
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.mockito.ArgumentMatchers anyIterableOf()
+      methodPattern: org.mockito.ArgumentMatchers anyIterableOf(java.lang.Class)
       newMethodName: anyIterable
+  - org.openrewrite.java.DeleteMethodArgument:
+      methodPattern: org.mockito.ArgumentMatchers anyIterable(java.lang.Class)
+      argumentIndex: 0
   - org.openrewrite.java.DeleteMethodArgument:
       methodPattern: org.mockito.ArgumentMatchers isNull(java.lang.Class)
       argumentIndex: 0

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoMatchersToArgumentMatchersTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoMatchersToArgumentMatchersTest.java
@@ -18,23 +18,24 @@ package org.openrewrite.java.testing.mockito;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
-import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
 class MockitoMatchersToArgumentMatchersTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.openrewrite.java.testing.mockito.Mockito1to3Migration");
+    }
+
     @DocumentExample
     @Test
     void mockitoAnyListOfToListOf() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion()
-              .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3.12"))
-            .recipe(Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
-              .build()
-              .activateRecipes("org.openrewrite.java.testing.mockito.Mockito1to3Migration")),
+            .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3.12")),
           //language=java
           java(
                 """
@@ -99,11 +100,7 @@ class MockitoMatchersToArgumentMatchersTest implements RewriteTest {
     void qualifiedMockitoAnyOfMatchers() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion()
-              .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3.12"))
-            .recipe(Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
-              .build()
-              .activateRecipes("org.openrewrite.java.testing.mockito.Mockito1to3Migration")),
+            .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3.12")),
           //language=java
           java(
             """
@@ -170,11 +167,7 @@ class MockitoMatchersToArgumentMatchersTest implements RewriteTest {
     void mockitoOneAnyOfMatchers() {
         rewriteRun(
           spec -> spec.parser(JavaParser.fromJavaVersion()
-              .classpathFromResources(new InMemoryExecutionContext(), "mockito-all"))
-            .recipe(Environment.builder()
-              .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
-              .build()
-              .activateRecipes("org.openrewrite.java.testing.mockito.Mockito1to3Migration")),
+            .classpathFromResources(new InMemoryExecutionContext(), "mockito-all")),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/testing/mockito/MockitoMatchersToArgumentMatchersTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/MockitoMatchersToArgumentMatchersTest.java
@@ -94,4 +94,134 @@ class MockitoMatchersToArgumentMatchersTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void qualifiedMockitoAnyOfMatchers() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(), "mockito-core-3.12"))
+            .recipe(Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
+              .build()
+              .activateRecipes("org.openrewrite.java.testing.mockito.Mockito1to3Migration")),
+          //language=java
+          java(
+            """
+              package mockito.example;
+
+              import org.mockito.Mockito;
+
+              import java.util.Collection;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Set;
+
+              public class MockitoVarargMatcherTest {
+                  public static class Foo {
+                      public boolean addList(List<String> strings) { return true; }
+                      public boolean addSet(Set<String> strings) { return true; }
+                      public boolean addMap(Map<String, String> stringStringMap) { return true; }
+                      public boolean addCollection(Collection<String> strings) { return true; }
+                      public boolean addIterable(Iterable<String> strings) { return true; }
+                  }
+                  public void usesVarargMatcher() {
+                      Foo mockFoo = Mockito.mock(Foo.class);
+                      Mockito.when(mockFoo.addList(Mockito.anyListOf(String.class))).thenReturn(true);
+                      Mockito.when(mockFoo.addSet(Mockito.anySetOf(String.class))).thenReturn(true);
+                      Mockito.when(mockFoo.addMap(Mockito.anyMapOf(String.class, String.class))).thenReturn(true);
+                      Mockito.when(mockFoo.addCollection(Mockito.anyCollectionOf(String.class))).thenReturn(true);
+                      Mockito.when(mockFoo.addIterable(Mockito.anyIterableOf(String.class))).thenReturn(true);
+                  }
+              }
+              """,
+            """
+              package mockito.example;
+
+              import org.mockito.Mockito;
+
+              import java.util.Collection;
+              import java.util.List;
+              import java.util.Map;
+              import java.util.Set;
+
+              public class MockitoVarargMatcherTest {
+                  public static class Foo {
+                      public boolean addList(List<String> strings) { return true; }
+                      public boolean addSet(Set<String> strings) { return true; }
+                      public boolean addMap(Map<String, String> stringStringMap) { return true; }
+                      public boolean addCollection(Collection<String> strings) { return true; }
+                      public boolean addIterable(Iterable<String> strings) { return true; }
+                  }
+                  public void usesVarargMatcher() {
+                      Foo mockFoo = Mockito.mock(Foo.class);
+                      Mockito.when(mockFoo.addList(Mockito.anyList())).thenReturn(true);
+                      Mockito.when(mockFoo.addSet(Mockito.anySet())).thenReturn(true);
+                      Mockito.when(mockFoo.addMap(Mockito.anyMap())).thenReturn(true);
+                      Mockito.when(mockFoo.addCollection(Mockito.anyCollection())).thenReturn(true);
+                      Mockito.when(mockFoo.addIterable(Mockito.anyIterable())).thenReturn(true);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void mockitoOneAnyOfMatchers() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion()
+              .classpathFromResources(new InMemoryExecutionContext(), "mockito-all"))
+            .recipe(Environment.builder()
+              .scanRuntimeClasspath("org.openrewrite.java.testing.mockito")
+              .build()
+              .activateRecipes("org.openrewrite.java.testing.mockito.Mockito1to3Migration")),
+          //language=java
+          java(
+            """
+              package mockito.example;
+
+              import org.mockito.Mockito;
+
+              import java.util.Collection;
+              import java.util.List;
+
+              import static org.mockito.Matchers.anyListOf;
+
+              public class MockitoVarargMatcherTest {
+                  public static class Foo {
+                      public boolean addList(List<String> strings) { return true; }
+                      public boolean addCollection(Collection<String> strings) { return true; }
+                  }
+                  public void usesVarargMatcher() {
+                      Foo mockFoo = Mockito.mock(Foo.class);
+                      Mockito.when(mockFoo.addList(anyListOf(String.class))).thenReturn(true);
+                      Mockito.when(mockFoo.addCollection(Mockito.anyCollectionOf(String.class))).thenReturn(true);
+                  }
+              }
+              """,
+            """
+              package mockito.example;
+
+              import org.mockito.Mockito;
+
+              import java.util.Collection;
+              import java.util.List;
+
+              import static org.mockito.ArgumentMatchers.anyList;
+
+              public class MockitoVarargMatcherTest {
+                  public static class Foo {
+                      public boolean addList(List<String> strings) { return true; }
+                      public boolean addCollection(Collection<String> strings) { return true; }
+                  }
+                  public void usesVarargMatcher() {
+                      Foo mockFoo = Mockito.mock(Foo.class);
+                      Mockito.when(mockFoo.addList(anyList())).thenReturn(true);
+                      Mockito.when(mockFoo.addCollection(Mockito.anyCollection())).thenReturn(true);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #1098

`Mockito1to3Migration` already converted `anyListOf`/`anySetOf`/`anyMapOf`, and I've added tests covering both the static-import and `Mockito.`-qualified forms (and `org.mockito.Matchers` on Mockito 1.x) to confirm that.

What was genuinely missing were the sibling matchers `anyCollectionOf(Class)` and `anyIterableOf(Class)`: their method patterns declared no arguments, so they never matched anything, and the `Class` argument was never dropped. Those are the only remaining `ArgumentMatchers` methods that Mockito 4 removed which the migration didn't handle.
