### PR TITLE
Retain `doNothing()` for spies and partial mocks

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
@@ -59,21 +59,23 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
-                        Set<String> mockFieldNames = new HashSet<>();
+                        Set<JavaType.Variable> mockFields = new HashSet<>();
                         for (Statement stmt : classDecl.getBody().getStatements()) {
                             if (stmt instanceof J.VariableDeclarations) {
                                 J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
                                 if (vd.getLeadingAnnotations().stream().anyMatch(this::isDefaultAnswerMock)) {
                                     for (J.VariableDeclarations.NamedVariable var : vd.getVariables()) {
-                                        mockFieldNames.add(var.getSimpleName());
+                                        if (var.getVariableType() != null) {
+                                            mockFields.add(var.getVariableType());
+                                        }
                                     }
                                 }
                             }
                         }
-                        if (!mockFieldNames.isEmpty()) {
-                            mockFieldNames.removeAll(namesAssignedFromSpy(classDecl));
+                        if (!mockFields.isEmpty()) {
+                            mockFields.removeAll(variablesAssignedFromSpy(classDecl));
                         }
-                        getCursor().putMessage("mockFieldNames", mockFieldNames);
+                        getCursor().putMessage("mockFields", mockFields);
                         return super.visitClassDeclaration(classDecl, ctx);
                     }
 
@@ -110,27 +112,41 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                     /**
                      * Fields declared `@Mock` can still be replaced by a spy before the stubbing runs.
                      */
-                    private Set<String> namesAssignedFromSpy(J.ClassDeclaration classDecl) {
-                        return new JavaIsoVisitor<Set<String>>() {
+                    private Set<JavaType.Variable> variablesAssignedFromSpy(J.ClassDeclaration classDecl) {
+                        return new JavaIsoVisitor<Set<JavaType.Variable>>() {
                             @Override
-                            public J.Assignment visitAssignment(J.Assignment assignment, Set<String> acc) {
+                            public J.Assignment visitAssignment(J.Assignment assignment, Set<JavaType.Variable> acc) {
                                 if (SPY_MATCHER.matches(assignment.getAssignment())) {
-                                    String name = simpleName(assignment.getVariable());
-                                    if (name != null) {
-                                        acc.add(name);
+                                    JavaType.Variable target = variableType(assignment.getVariable());
+                                    if (target != null) {
+                                        acc.add(target);
                                     }
                                 }
                                 return super.visitAssignment(assignment, acc);
                             }
 
                             @Override
-                            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<String> acc) {
-                                if (SPY_MATCHER.matches(variable.getInitializer())) {
-                                    acc.add(variable.getSimpleName());
+                            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<JavaType.Variable> acc) {
+                                if (SPY_MATCHER.matches(variable.getInitializer()) && variable.getVariableType() != null) {
+                                    acc.add(variable.getVariableType());
                                 }
                                 return super.visitVariable(variable, acc);
                             }
                         }.reduce(classDecl.getBody(), new HashSet<>());
+                    }
+
+                    /**
+                     * Resolve `mock` or `this.mock` to the variable it declares or references, such that a field and a
+                     * local shadowing it are told apart by {@link JavaType.Variable} owner rather than by name.
+                     */
+                    private JavaType.@Nullable Variable variableType(Expression expression) {
+                        if (expression instanceof J.FieldAccess) {
+                            return ((J.FieldAccess) expression).getName().getFieldType();
+                        }
+                        if (expression instanceof J.Identifier) {
+                            return ((J.Identifier) expression).getFieldType();
+                        }
+                        return null;
                     }
 
                     @Override
@@ -166,16 +182,12 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                             return false;
                         }
                         // Check that the when() argument references a @Mock field
-                        if (whenCall.getArguments().isEmpty() || !(whenCall.getArguments().get(0) instanceof J.Identifier)) {
+                        if (whenCall.getArguments().isEmpty()) {
                             return false;
                         }
-                        J.Identifier mock = (J.Identifier) whenCall.getArguments().get(0);
-                        // A local variable or parameter shadowing a `@Mock` field may well hold a spy instead
-                        if (mock.getFieldType() != null && !(mock.getFieldType().getOwner() instanceof JavaType.FullyQualified)) {
-                            return false;
-                        }
-                        Set<String> mockFieldNames = getCursor().getNearestMessage("mockFieldNames");
-                        if (mockFieldNames == null || !mockFieldNames.contains(mock.getSimpleName())) {
+                        JavaType.Variable mock = variableType(whenCall.getArguments().get(0));
+                        Set<JavaType.Variable> mockFields = getCursor().getNearestMessage("mockFields");
+                        if (mock == null || mockFields == null || !mockFields.contains(mock)) {
                             return false;
                         }
                         // Preserve stubbings whose arguments include ArgumentCaptor.capture(),

--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
@@ -109,8 +109,7 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                      * Fields declared `@Mock` can still be replaced by a spy before the stubbing runs.
                      */
                     private Set<String> namesAssignedFromSpy(J.ClassDeclaration classDecl) {
-                        Set<String> spyNames = new HashSet<>();
-                        new JavaIsoVisitor<Set<String>>() {
+                        return new JavaIsoVisitor<Set<String>>() {
                             @Override
                             public J.Assignment visitAssignment(J.Assignment assignment, Set<String> acc) {
                                 if (SPY_MATCHER.matches(assignment.getAssignment()) &&
@@ -127,8 +126,7 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                                 }
                                 return super.visitVariable(variable, acc);
                             }
-                        }.visit(classDecl.getBody(), spyNames);
-                        return spyNames;
+                        }.reduce(classDecl.getBody(), new HashSet<>());
                     }
 
                     @Override

--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
@@ -27,9 +27,11 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Statement;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -46,7 +48,9 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
     private static final MethodMatcher DO_NOTHING_MATCHER = new MethodMatcher("org.mockito.Mockito doNothing()");
     private static final MethodMatcher STUBBER_WHEN_MATCHER = new MethodMatcher("org.mockito.stubbing.Stubber when(..)");
     private static final MethodMatcher CAPTURE_MATCHER = new MethodMatcher("org.mockito.ArgumentCaptor capture()");
+    private static final MethodMatcher SPY_MATCHER = new MethodMatcher("org.mockito.Mockito spy(..)");
     private static final AnnotationMatcher MOCK_ANNOTATION_MATCHER = new AnnotationMatcher("@org.mockito.Mock");
+    private static final String CALLS_REAL_METHODS = "CALLS_REAL_METHODS";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -59,15 +63,72 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                         for (Statement stmt : classDecl.getBody().getStatements()) {
                             if (stmt instanceof J.VariableDeclarations) {
                                 J.VariableDeclarations vd = (J.VariableDeclarations) stmt;
-                                if (vd.getLeadingAnnotations().stream().anyMatch(MOCK_ANNOTATION_MATCHER::matches)) {
+                                if (vd.getLeadingAnnotations().stream().anyMatch(this::isDefaultAnswerMock)) {
                                     for (J.VariableDeclarations.NamedVariable var : vd.getVariables()) {
                                         mockFieldNames.add(var.getSimpleName());
                                     }
                                 }
                             }
                         }
+                        mockFieldNames.removeAll(namesAssignedFromSpy(classDecl));
                         getCursor().putMessage("mockFieldNames", mockFieldNames);
                         return super.visitClassDeclaration(classDecl, ctx);
+                    }
+
+                    /**
+                     * A `@Mock(answer = Answers.CALLS_REAL_METHODS)` field is a partial mock that runs real code for
+                     * void methods, so `doNothing()` on it changes behavior just like it does for a spy.
+                     */
+                    private boolean isDefaultAnswerMock(J.Annotation annotation) {
+                        if (!MOCK_ANNOTATION_MATCHER.matches(annotation)) {
+                            return false;
+                        }
+                        List<Expression> arguments = annotation.getArguments();
+                        if (arguments != null) {
+                            for (Expression argument : arguments) {
+                                if (argument instanceof J.Assignment &&
+                                        CALLS_REAL_METHODS.equals(simpleName(((J.Assignment) argument).getAssignment()))) {
+                                    return false;
+                                }
+                            }
+                        }
+                        return true;
+                    }
+
+                    private @Nullable String simpleName(Expression expression) {
+                        if (expression instanceof J.FieldAccess) {
+                            return ((J.FieldAccess) expression).getSimpleName();
+                        }
+                        if (expression instanceof J.Identifier) {
+                            return ((J.Identifier) expression).getSimpleName();
+                        }
+                        return null;
+                    }
+
+                    /**
+                     * Fields declared `@Mock` can still be replaced by a spy before the stubbing runs.
+                     */
+                    private Set<String> namesAssignedFromSpy(J.ClassDeclaration classDecl) {
+                        Set<String> spyNames = new HashSet<>();
+                        new JavaIsoVisitor<Set<String>>() {
+                            @Override
+                            public J.Assignment visitAssignment(J.Assignment assignment, Set<String> acc) {
+                                if (SPY_MATCHER.matches(assignment.getAssignment()) &&
+                                        assignment.getVariable() instanceof J.Identifier) {
+                                    acc.add(((J.Identifier) assignment.getVariable()).getSimpleName());
+                                }
+                                return super.visitAssignment(assignment, acc);
+                            }
+
+                            @Override
+                            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<String> acc) {
+                                if (SPY_MATCHER.matches(variable.getInitializer())) {
+                                    acc.add(variable.getSimpleName());
+                                }
+                                return super.visitVariable(variable, acc);
+                            }
+                        }.visit(classDecl.getBody(), spyNames);
+                        return spyNames;
                     }
 
                     @Override
@@ -106,9 +167,13 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                         if (whenCall.getArguments().isEmpty() || !(whenCall.getArguments().get(0) instanceof J.Identifier)) {
                             return false;
                         }
-                        String mockName = ((J.Identifier) whenCall.getArguments().get(0)).getSimpleName();
+                        J.Identifier mock = (J.Identifier) whenCall.getArguments().get(0);
+                        // A local variable or parameter shadowing a `@Mock` field may well hold a spy instead
+                        if (mock.getFieldType() != null && !(mock.getFieldType().getOwner() instanceof JavaType.FullyQualified)) {
+                            return false;
+                        }
                         Set<String> mockFieldNames = getCursor().getNearestMessage("mockFieldNames");
-                        if (mockFieldNames == null || !mockFieldNames.contains(mockName)) {
+                        if (mockFieldNames == null || !mockFieldNames.contains(mock.getSimpleName())) {
                             return false;
                         }
                         // Preserve stubbings whose arguments include ArgumentCaptor.capture(),
@@ -116,7 +181,7 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                         return !containsCapture(mi.getArguments());
                     }
 
-                    private boolean containsCapture(java.util.List<Expression> arguments) {
+                    private boolean containsCapture(List<Expression> arguments) {
                         AtomicBoolean found = new AtomicBoolean();
                         JavaIsoVisitor<AtomicBoolean> visitor = new JavaIsoVisitor<AtomicBoolean>() {
                             @Override

--- a/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
+++ b/src/main/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocks.java
@@ -70,7 +70,9 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                                 }
                             }
                         }
-                        mockFieldNames.removeAll(namesAssignedFromSpy(classDecl));
+                        if (!mockFieldNames.isEmpty()) {
+                            mockFieldNames.removeAll(namesAssignedFromSpy(classDecl));
+                        }
                         getCursor().putMessage("mockFieldNames", mockFieldNames);
                         return super.visitClassDeclaration(classDecl, ctx);
                     }
@@ -112,9 +114,11 @@ public class RemoveDoNothingForDefaultMocks extends Recipe {
                         return new JavaIsoVisitor<Set<String>>() {
                             @Override
                             public J.Assignment visitAssignment(J.Assignment assignment, Set<String> acc) {
-                                if (SPY_MATCHER.matches(assignment.getAssignment()) &&
-                                        assignment.getVariable() instanceof J.Identifier) {
-                                    acc.add(((J.Identifier) assignment.getVariable()).getSimpleName());
+                                if (SPY_MATCHER.matches(assignment.getAssignment())) {
+                                    String name = simpleName(assignment.getVariable());
+                                    if (name != null) {
+                                        acc.add(name);
+                                    }
                                 }
                                 return super.visitAssignment(assignment, acc);
                             }

--- a/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
@@ -163,6 +163,150 @@ class RemoveDoNothingForDefaultMocksTest implements RewriteTest {
     }
 
     @Test
+    void retainsDoNothingOnMockCallingRealMethods() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Answers;
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Mockito.doNothing;
+
+              class MyTest {
+                  @Mock(answer = Answers.CALLS_REAL_METHODS)
+                  private ArrayList<String> partialMock;
+
+                  void test() {
+                      doNothing().when(partialMock).clear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainsDoNothingOnMockCallingRealMethodsWithStaticImport() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Answers.CALLS_REAL_METHODS;
+              import static org.mockito.Mockito.doNothing;
+
+              class MyTest {
+                  @Mock(answer = CALLS_REAL_METHODS)
+                  private ArrayList<String> partialMock;
+
+                  void test() {
+                      doNothing().when(partialMock).clear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removesDoNothingOnMockWithDeepStubs() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Answers;
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Mockito.doNothing;
+
+              class MyTest {
+                  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+                  private ArrayList<String> list;
+
+                  void test() {
+                      doNothing().when(list).clear();
+                  }
+              }
+              """,
+            """
+              import org.mockito.Answers;
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              class MyTest {
+                  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+                  private ArrayList<String> list;
+
+                  void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainsDoNothingOnMockFieldReassignedToSpy() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Mockito.doNothing;
+              import static org.mockito.Mockito.spy;
+
+              class MyTest {
+                  @Mock
+                  private ArrayList<String> list;
+
+                  void setUp() {
+                      list = spy(new ArrayList<>());
+                  }
+
+                  void test() {
+                      doNothing().when(list).clear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void retainsDoNothingOnLocalSpyShadowingMockField() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+              import java.util.List;
+
+              import static org.mockito.Mockito.doNothing;
+              import static org.mockito.Mockito.spy;
+
+              class MyTest {
+                  @Mock
+                  private List<String> list;
+
+                  void test() {
+                      List<String> list = spy(new ArrayList<>());
+                      doNothing().when(list).clear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainsChainedDoNothing() {
         rewriteRun(
           //language=Java

--- a/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
@@ -280,6 +280,35 @@ class RemoveDoNothingForDefaultMocksTest implements RewriteTest {
     }
 
     @Test
+    void retainsDoNothingOnMockFieldReassignedToSpyThroughThis() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Mockito.doNothing;
+              import static org.mockito.Mockito.spy;
+
+              class MyTest {
+                  @Mock
+                  private ArrayList<String> list;
+
+                  void setUp() {
+                      this.list = spy(new ArrayList<>());
+                  }
+
+                  void test() {
+                      doNothing().when(list).clear();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainsDoNothingOnLocalSpyShadowingMockField() {
         rewriteRun(
           //language=Java

--- a/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
+++ b/src/test/java/org/openrewrite/java/testing/mockito/RemoveDoNothingForDefaultMocksTest.java
@@ -280,6 +280,42 @@ class RemoveDoNothingForDefaultMocksTest implements RewriteTest {
     }
 
     @Test
+    void removesDoNothingOnMockFieldAccessedThroughThis() {
+        rewriteRun(
+          //language=Java
+          java(
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              import static org.mockito.Mockito.doNothing;
+
+              class MyTest {
+                  @Mock
+                  private ArrayList<String> list;
+
+                  void test() {
+                      doNothing().when(this.list).clear();
+                  }
+              }
+              """,
+            """
+              import org.mockito.Mock;
+              import java.util.ArrayList;
+
+              class MyTest {
+                  @Mock
+                  private ArrayList<String> list;
+
+                  void test() {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainsDoNothingOnMockFieldReassignedToSpyThroughThis() {
         rewriteRun(
           //language=Java


### PR DESCRIPTION
- `RemoveDoNothingForDefaultMocks` treated every `@Mock` field as a plain mock, whose void methods do nothing by default. But a `@Mock` field can still run real code for void methods, in which case removing the stubbing changes behaviour — the real method now executes, as reported in #1099.

Three cases are now retained:

- `@Mock(answer = Answers.CALLS_REAL_METHODS)` — a partial mock, both qualified and statically imported
- a `@Mock` field reassigned from `Mockito.spy(..)` before the stubbing runs
- a local variable or parameter holding a spy that shadows a `@Mock` field

Other answers (`RETURNS_DEEP_STUBS` and friends) still do nothing for void methods, so those stubbings are still removed; there's a test pinning that.

- Fixes #1099