### PR TITLE
test: add for final TestName Rule

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfo.java
@@ -83,9 +83,24 @@ public class TestRuleToTestInfo extends Recipe {
                     }
                     return anno;
                 }));
+                varDecls = removeFinalModifier(varDecls);
                 getCursor().dropParentUntil(J.ClassDeclaration.class::isInstance).putMessage("has-testName-rule", varDecls);
             }
             return varDecls;
+        }
+
+        private static J.VariableDeclarations removeFinalModifier(J.VariableDeclarations varDecls) {
+            List<J.Modifier> modifiers = varDecls.getModifiers();
+            List<J.Modifier> retained = ListUtils.filter(modifiers, mod -> mod.getType() != J.Modifier.Type.Final);
+            if (retained == modifiers) {
+                return varDecls;
+            }
+            Space prefix = modifiers.get(0).getPrefix();
+            if (retained.isEmpty()) {
+                return varDecls.withModifiers(retained).withTypeExpression(
+                        varDecls.getTypeExpression() == null ? null : varDecls.getTypeExpression().withPrefix(prefix));
+            }
+            return varDecls.withModifiers(ListUtils.mapFirst(retained, mod -> mod.withPrefix(prefix)));
         }
 
         @Override

--- a/src/test/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfoTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/TestRuleToTestInfoTest.java
@@ -144,4 +144,48 @@ class TestRuleToTestInfoTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void ruleIsFinal() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Rule;
+              import org.junit.rules.TestName;
+
+              public class SomeTest {
+                  @Rule
+                  public final TestName name = new TestName();
+                  protected String randomName() {
+                      return name.getMethodName();
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.BeforeEach;
+              import org.junit.jupiter.api.TestInfo;
+
+              import java.lang.reflect.Method;
+              import java.util.Optional;
+
+              public class SomeTest {
+                 \s
+                  public String name;
+                  protected String randomName() {
+                      return name;
+                  }
+
+                  @BeforeEach
+                  public void setup(TestInfo testInfo) {
+                      Optional<Method> testMethod = testInfo.getTestMethod();
+                      if (testMethod.isPresent()) {
+                          this.name = testMethod.get().getName();
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.

This template is defined once for the whole organization in openrewrite/.github, so you
won't find it in the repository you're contributing to. The same is true of our issue
templates and contributing guide: https://github.com/openrewrite/.github
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

Fix a bug where if the `TestName` rule is final, after the rewrite the String is still final (which leads to a compilation error). 

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 
## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
