### PR TITLE
fix: comments must not break rewritten assertions

### DIFF
--- a/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AssertToAssertionsTest.java
@@ -164,6 +164,40 @@ class AssertToAssertionsTest implements RewriteTest {
     }
 
     @Test
+    void commentWithMessage() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.junit.Test;
+              import static org.junit.Assert.assertTrue;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertTrue("a message", true//a weird comment
+                      );
+                  }
+              }
+              """,
+            """
+              import org.junit.Test;
+
+              import static org.junit.jupiter.api.Assertions.assertTrue;
+
+              public class MyTest {
+                  @Test
+                  public void test() {
+                      assertTrue(true, "a message"//a weird comment
+                      );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void assertWithoutMessage() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.

This template is defined once for the whole organization in openrewrite/.github, so you
won't find it in the repository you're contributing to. The same is true of our issue
templates and contributing guide: https://github.com/openrewrite/.github
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The `AssertToAssertions` recipe currently does not handle comments correctly when reordering arguments, which can lead to compilation errors after applying the recipe.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 
## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
