### PR TITLE
Add junit-jupiter when only junit.framework.TestCase is used

### DIFF
--- a/src/main/java/org/openrewrite/java/testing/junit5/AddJupiterDependencies.java
+++ b/src/main/java/org/openrewrite/java/testing/junit5/AddJupiterDependencies.java
@@ -47,7 +47,18 @@ public class AddJupiterDependencies extends ScanningRecipe<AddDependency.Accumul
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(AddDependency.Accumulator acc) {
-        return addJupiterDependency().getScanner(acc);
+        // The scanner sees the sources before `MigrateJUnitTestCase` rewrites them, so a
+        // codebase of `junit.framework.TestCase` subclasses uses no `org.junit` type yet.
+        TreeVisitor<?, ExecutionContext> usesJUnit4 = addJupiterDependency("org.junit..*").getScanner(acc);
+        TreeVisitor<?, ExecutionContext> usesJUnit3 = addJupiterDependency("junit.framework..*").getScanner(acc);
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                usesJUnit4.visit(tree, ctx);
+                usesJUnit3.visit(tree, ctx);
+                return tree;
+            }
+        };
     }
 
     @Override
@@ -73,8 +84,12 @@ public class AddJupiterDependencies extends ScanningRecipe<AddDependency.Accumul
     }
 
     private static AddDependency addJupiterDependency() {
+        return addJupiterDependency("org.junit..*");
+    }
+
+    private static AddDependency addJupiterDependency(String onlyIfUsing) {
         return new AddDependency("org.junit.jupiter", "junit-jupiter", "5.x", null,
-                "org.junit..*", null, null, null, null, null,
+                onlyIfUsing, null, null, null, null, null,
                 null, null, null, null);
     }
 

--- a/src/test/java/org/openrewrite/java/testing/junit5/AddJupiterDependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/AddJupiterDependenciesTest.java
@@ -99,4 +99,75 @@ class AddJupiterDependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotAddWithoutJUnit() {
+        rewriteRun(
+          mavenProject("project",
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  public class NotATest {
+                      public void addition() {
+                          assert 4 == 2 + 2;
+                      }
+                  }
+                  """
+              )
+            ),
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>0.0.1</version>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1113")
+    @Test
+    void addWhenOnlyJUnit3TestCaseIsUsed() {
+        rewriteRun(
+          spec -> spec.parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(), "junit-4")),
+          mavenProject("project",
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import junit.framework.TestCase;
+
+                  public class LegacyTest extends TestCase {
+                      public void testAddition() {
+                          assertEquals(4, 2 + 2);
+                      }
+                  }
+                  """
+              )
+            ),
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>0.0.1</version>
+                </project>
+                """,
+              spec -> spec.after(pom -> {
+                  return assertThat(pom)
+                          .contains("junit-jupiter")
+                          .contains("<scope>test</scope>").actual();
+              })
+            )
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
+++ b/src/test/java/org/openrewrite/java/testing/junit5/JUnit5MigrationTest.java
@@ -228,6 +228,58 @@ class JUnit5MigrationTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1113")
+    @Test
+    void addJupiterWhenOnlyTestCaseIsUsed() {
+        rewriteRun(
+          mavenProject("project",
+            srcTestJava(
+              //language=java
+              java(
+                """
+                  import junit.framework.TestCase;
+
+                  public class LegacyTest extends TestCase {
+                      public void testAddition() {
+                          assertEquals(4, 2 + 2);
+                      }
+                  }
+                  """,
+                spec -> spec.after(src -> {
+                    return assertThat(src)
+                            .contains("import org.junit.jupiter.api.Test;")
+                            .doesNotContain("junit.framework").actual();
+                })
+              )
+            ),
+            pomXml(
+              //language=xml
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>project</artifactId>
+                    <version>0.0.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>junit</groupId>
+                            <artifactId>junit</artifactId>
+                            <version>4.13.2</version>
+                            <scope>test</scope>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> {
+                  return assertThat(pom)
+                          .contains("<artifactId>junit-jupiter</artifactId>")
+                          .doesNotContain("<artifactId>junit</artifactId>").actual();
+              })
+            )
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/429")
     @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/850")
     @Test


### PR DESCRIPTION
## What's changed?
`AddJupiterDependencies` now also scans for uses of `junit.framework..*`, next to `org.junit..*`, when deciding whether to add `junit-jupiter`. The two scanners share the accumulator, so either one marks the project as using JUnit and the scope logic is unchanged.

## What's your motivation?
Fixes #1113. In a project whose tests only extend `junit.framework.TestCase`, `JUnit4to5Migration` removed `junit:junit` but never added Jupiter, because the scanner runs on the sources before `MigrateJUnitTestCase` rewrites them and no `org.junit` type is in use at that point. The migrated project didn't compile.

## Anything in particular you'd like reviewers to focus on?
Whether broadening the guard here is the shape you want, versus making the `RemoveDependency` in the composite conditional. This one keeps `AddJupiterDependencies` correct on its own, which also covers running it standalone on a JUnit 3 codebase.

## Have you considered any alternatives or workarounds?
A single glob covering both packages doesn't exist (`org.junit` and `junit.framework` share no prefix), and `AddDependency` takes one `onlyIfUsing` pattern, hence the two scanners.

## Any additional context
Three tests: one on `AddJupiterDependencies` with a `TestCase` subclass in the test source set, a negative one with no JUnit at all (nothing is added), and one on the `JUnit4to5Migration` composite reproducing the issue (pom with `junit:junit` only), asserting `junit-jupiter` is added and `junit` removed. The two positive ones fail on `main` and pass with the change.

On building locally: since #1116 the build plugins resolve from the Code Genome repository, which asks for credentials I don't have, and `latest.release` (2.23.4) depends on rewrite 8.91.4, which isn't on Maven Central. With the plugins pinned to 2.23.1 locally (not part of this PR) `./gradlew build` passes: 1859 tests, 0 failures, `recipes.csv` validated.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv` (with the plugin pin described above; `recipes.csv` unchanged)
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch